### PR TITLE
[Feature] Rule to replace dispel spell effects with suppression effect.

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -546,6 +546,9 @@ RULE_INT(Spells, PointBlankAOEMaxTargets, 0, "Max number of targets a Point-Blan
 RULE_INT(Spells, DefaultAOEMaxTargets, 0, "Max number of targets that an AOE spell which does not meet other descriptions can cast on. Set to 0 for no limit.")
 RULE_BOOL(Spells, AllowFocusOnSkillDamageSpells, false, "Allow focus effects 185, 459, and 482 to enhance SkillAttack spell effect 193")
 RULE_STRING(Spells, AlwaysStackSpells, "", "Comma-Seperated list of spell IDs to always stack with every other spell, except themselves.")
+RULE_BOOL(Spells, SuppressDispels, false, "Swaps 'cancel magic' SPA logic with SuppressBuff SPA (527).")
+RULE_INT(Spells, SuppressDispelsTime, 6, "Number of tics that dispelled buffs will be suppressed for")
+RULE_INT(Spells, SuppressDebuffSpellID, 21840, "Spell ID to send to client when a spell is supprssed.  21840 = 'Suppression Field'")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Combat)

--- a/common/spdat.cpp
+++ b/common/spdat.cpp
@@ -966,6 +966,19 @@ bool IsValidSpell(uint32 spell_id)
 	return false;
 }
 
+bool IsValidOrSuppressedSpell(uint32 spell_id)
+{
+	if (IsValidSpell(spell_id)) {
+		return true;
+	}
+
+	if (spell_id == SPELL_SUPPRESSED) {
+		return true;
+	}
+
+	return false;
+}
+
 bool IsHarmTouchSpell(uint16 spell_id)
 {
 	return spell_id == SPELL_HARM_TOUCH ||

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -24,6 +24,7 @@
 
 #define SPELL_UNKNOWN 0xFFFF
 #define POISON_PROC 0xFFFE
+#define SPELL_SUPPRESSED 0xFFFD
 #define SPELLBOOK_UNKNOWN 0xFFFFFFFF		//player profile spells are 32 bit
 
 //some spell IDs which will prolly change, but are needed
@@ -1816,6 +1817,7 @@ bool IsEffectInSpell(uint16 spell_id, int effect_id);
 uint16 GetSpellTriggerSpellID(uint16 spell_id, int effect_id);
 bool IsBlankSpellEffect(uint16 spell_id, int effect_index);
 bool IsValidSpell(uint32 spell_id);
+bool IsValidOrSuppressedSpell(uint32 spell_id);
 bool IsSummonSpell(uint16 spell_id);
 bool IsDamageSpell(uint16 spell_id);
 bool IsAnyDamageSpell(uint16 spell_id);

--- a/zone/client.h
+++ b/zone/client.h
@@ -344,6 +344,7 @@ public:
 	bool IsClient() const override { return true; }
 	bool IsOfClientBot() const override { return true; }
 	bool IsOfClientBotMerc() const override { return true; }
+	void ReapplyBuff(uint32 index, bool from_suppress = false);
 	void CompleteConnect();
 	bool TryStacking(EQ::ItemInstance* item, uint8 type = ItemPacketTrade, bool try_worn = true, bool try_cursor = true);
 	void SendTraderPacket(Client* trader, uint32 Unknown72 = 51);

--- a/zone/common.h
+++ b/zone/common.h
@@ -274,6 +274,8 @@ struct Buffs_Struct {
 	bool	persistant_buff;
 	bool	client; //True if the caster is a client
 	bool	UpdateClient;
+	uint16  suppressedid;
+	uint32  suppressedticsremaining;
 
 	// cereal
 	template<class Archive>

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -2167,6 +2167,11 @@ void Lua_Mob::BuffFadeBySlot(int slot, bool recalc_bonuses) {
 	self->BuffFadeBySlot(slot, recalc_bonuses);
 }
 
+void Lua_Mob::BuffFadeBySlot(int slot, bool recalc_bonuses, bool suppress, int suppress_tics) {
+	Lua_Safe_Call_Void();
+	self->BuffFadeBySlot(slot, recalc_bonuses, suppress, suppress_tics);
+}
+
 int Lua_Mob::CanBuffStack(int spell_id, int caster_level) {
 	Lua_Safe_Call_Int();
 	return self->CanBuffStack(spell_id, caster_level);
@@ -3524,6 +3529,7 @@ luabind::scope lua_register_mob() {
 	.def("BuffFadeByEffect", (void(Lua_Mob::*)(int,int))&Lua_Mob::BuffFadeByEffect)
 	.def("BuffFadeBySlot", (void(Lua_Mob::*)(int))&Lua_Mob::BuffFadeBySlot)
 	.def("BuffFadeBySlot", (void(Lua_Mob::*)(int,bool))&Lua_Mob::BuffFadeBySlot)
+	.def("BuffFadeBySlot", (void(Lua_Mob::*)(int,bool,bool,int))&Lua_Mob::BuffFadeBySlot)
 	.def("BuffFadeBySpellID", (void(Lua_Mob::*)(int))&Lua_Mob::BuffFadeBySpellID)
 	.def("BuffFadeDetrimental", (void(Lua_Mob::*)(void))&Lua_Mob::BuffFadeDetrimental)
 	.def("BuffFadeDetrimentalByCaster", (void(Lua_Mob::*)(Lua_Mob))&Lua_Mob::BuffFadeDetrimentalByCaster)

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -434,6 +434,7 @@ public:
 	void BuffFadeAll();
 	void BuffFadeBySlot(int slot);
 	void BuffFadeBySlot(int slot, bool recalc_bonuses);
+	void BuffFadeBySlot(int slot, bool recalc_bonuses, bool suppress, int suppress_tics);
 	int CanBuffStack(int spell_id, int caster_level);
 	int CanBuffStack(int spell_id, int caster_level, bool fail_if_overwrite);
 	void SetPseudoRoot(bool in);

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -453,7 +453,7 @@ public:
 	void BuffFadeBeneficial();
 	void BuffFadeNonPersistDeath();
 	void BuffFadeDetrimental();
-	void BuffFadeBySlot(int slot, bool iRecalcBonuses = true);
+	void BuffFadeBySlot(int slot, bool iRecalcBonuses = true, bool suppress = false, uint32 suppresstics = 0);
 	void BuffFadeDetrimentalByCaster(Mob *caster);
 	void BuffFadeBySitModifier();
 	void BuffFadeSongs();
@@ -967,7 +967,9 @@ public:
 	void TrySympatheticProc(Mob *target, uint32 spell_id);
 	uint16 GetSympatheticFocusEffect(focusType type, uint16 spell_id);
 	bool TryFadeEffect(int slot);
-	void DispelMagic(Mob* casterm, uint16 spell_id, int effect_value);
+	void DispelMagic(Mob* casterm, uint16 spell_id, int effect_value, int chance = 1000, bool detrimental_only = false, bool benficial_only = false);
+	bool IsSuppressableBuff(int slot) const;
+	void SuppressBuff(Mob* caster, uint16 spell_id, int tic_count);
 	bool TrySpellEffectResist(uint16 spell_id);
 	int32 GetVulnerability(Mob *caster, uint32 spell_id, uint32 ticsremaining, bool from_buff_tic = false);
 	int64 GetFcDamageAmtIncoming(Mob *caster, int32 spell_id, bool from_buff_tic = false);

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -1044,6 +1044,11 @@ void Perl_Mob_BuffFadeBySlot(Mob* self, int slot, bool recalc_bonuses) // @categ
 	self->BuffFadeBySlot(slot, recalc_bonuses);
 }
 
+void Perl_Mob_BuffFadeBySlot(Mob* self, int slot, bool recalc_bonuses, bool suppress, int suppress_tics) // @categories Script Utility, Spells and Disciplines
+{
+	self->BuffFadeBySlot(slot, recalc_bonuses, suppress, suppress_tics);
+}
+
 bool Perl_Mob_CanBuffStack(Mob* self, uint16 spell_id, uint8 caster_level) // @categories Script Utility, Spells and Disciplines
 {
 	return self->CanBuffStack(spell_id, caster_level);
@@ -3613,6 +3618,7 @@ void perl_register_mob()
 	package.add("BuffFadeByEffect", (void(*)(Mob*, int, int))&Perl_Mob_BuffFadeByEffect);
 	package.add("BuffFadeBySlot", (void(*)(Mob*, int))&Perl_Mob_BuffFadeBySlot);
 	package.add("BuffFadeBySlot", (void(*)(Mob*, int, bool))&Perl_Mob_BuffFadeBySlot);
+	package.add("BuffFadeBySlot", (void(*)(Mob*, int, bool, bool, int))&Perl_Mob_BuffFadeBySlot);
 	package.add("BuffFadeBySpellID", &Perl_Mob_BuffFadeBySpellID);
 	package.add("BuffFadeDetrimental", &Perl_Mob_BuffFadeDetrimental);
 	package.add("BuffFadeDetrimentalByCaster", &Perl_Mob_BuffFadeDetrimentalByCaster);

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -2897,7 +2897,7 @@ void ZoneDatabase::SaveBuffs(Client *client)
 	uint32 character_buff_count = 0;
 
 	for (int slot_id = 0; slot_id < max_buff_slots; slot_id++) {
-		if (!IsValidSpell(buffs[slot_id].spellid)) {
+		if (!IsValidOrSuppressedSpell(buffs[slot_id].spellid)) {
 			continue;
 		}
 
@@ -2907,16 +2907,18 @@ void ZoneDatabase::SaveBuffs(Client *client)
 	v.reserve(character_buff_count);
 
 	for (int slot_id = 0; slot_id < max_buff_slots; slot_id++) {
-		if (!IsValidSpell(buffs[slot_id].spellid)) {
+		if (!IsValidOrSuppressedSpell(buffs[slot_id].spellid)) {
 			continue;
 		}
 
+		bool suppressed = buffs[slot_id].spellid == SPELL_SUPPRESSED;
+
 		e.character_id   = client->CharacterID();
 		e.slot_id        = slot_id;
-		e.spell_id       = buffs[slot_id].spellid;
+		e.spell_id       = suppressed ? buffs[slot_id].suppressedid : buffs[slot_id].spellid;
 		e.caster_level   = buffs[slot_id].casterlevel;
 		e.caster_name    = buffs[slot_id].caster_name;
-		e.ticsremaining  = buffs[slot_id].ticsremaining;
+		e.ticsremaining  = suppressed ? buffs[slot_id].suppressedticsremaining : buffs[slot_id].ticsremaining;
 		e.counters       = buffs[slot_id].counters;
 		e.numhits        = buffs[slot_id].hit_number;
 		e.melee_rune     = buffs[slot_id].melee_rune;
@@ -2999,6 +3001,8 @@ void ZoneDatabase::LoadBuffs(Client *client)
 		buffs[e.slot_id].virus_spread_time = 0;
 		buffs[e.slot_id].UpdateClient      = false;
 		buffs[e.slot_id].instrument_mod    = e.instrument_mod;
+		buffs[e.slot_id].suppressedid            = 0;
+		buffs[e.slot_id].suppressedticsremaining = -1;
 	}
 
 	// We load up to the most our client supports


### PR DESCRIPTION
# Description
This is a feature created by @zimp-wow here: https://github.com/EQEmu/Server/pull/4964
I am working on bring into CW

1. Enable the 'SuppressDispels' rule
 
![image](https://private-user-images.githubusercontent.com/66187107/464424323-9404f956-5667-4711-861b-683db744166c.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NTkwNzg2NDcsIm5iZiI6MTc1OTA3ODM0NywicGF0aCI6Ii82NjE4NzEwNy80NjQ0MjQzMjMtOTQwNGY5NTYtNTY2Ny00NzExLTg2MWItNjgzZGI3NDQxNjZjLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTA5MjglMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwOTI4VDE2NTIyN1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTEzMGIwNzRkNzUzZWE2ODY3ZjlmYzA2NmY4ZjVjOWI4YTc4N2JhMTAxYTA4ZTU0NzQ2MDM0NjU1MmZmYTc4ODkmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.XracW9XGMK7mo54ZCV4jcGGfS6PJA9F7cxeM2XtO4Ks)

 This will cause CancelMagic, DispelDetrimental and DispelBeneficial SPAs to automatically use the suppression effect instead when the target is a player/player's pet and the caster is an NPC.

Players will still be able to dispel themselves and enemies normally.

When this rule is disabled (default) dispels should behave the same as always.

2. New overloaded API method for 'BuffFadeBySlot'

Scripts can now pass two optional parameters to this API to force a suppression effect on a specific buff slot. The third parameter is true/false to enable the suppression with the fourth being the number of tics the effect should last.

Downstream users will likely want to customizes these behaviors somewhat depending on what they desire.


# Testing
<img width="200" height="300" alt="image" src="https://github.com/user-attachments/assets/000af9d3-8bcd-42d1-8147-6ef505b868dc" />

Tested with base RoF client and latest eqemu/master branch.

Test Cases:

* Suppressed buffs lose their effects and restore when suppression end
* Levitate effect properly restores after suppression
* Lua buff fade by slot works
* Perl buff fade by slot works
* Suppress on charm breaks charm
* Suppress on pet works
* Dispel on self clears buffs (with rule on or off)
* Dispel on npc clears buffs
* Custom spell with SPA 527 works
* DispelBeneficial works
* DispelDetrimental works



