### PR TITLE
[Bug Fix] Evolving Items SayLink

### DIFF
--- a/common/eq_packet_structs.h
+++ b/common/eq_packet_structs.h
@@ -6499,7 +6499,7 @@ struct PickZone_Struct {
 
 struct EvolveItemToggle {
 	uint32 action;
-	uint32 unknown_004;
+	uint32 item_id;
 	uint64 unique_id;
 	uint32 percentage;
 	uint32 activated;

--- a/common/patches/rof2.cpp
+++ b/common/patches/rof2.cpp
@@ -6499,10 +6499,9 @@ namespace RoF2
 		ob.write((const char*)&hdr, sizeof(RoF2::structs::ItemSerializationHeader));
 
 		if (item->EvolvingItem > 0) {
-			RoF2::structs::EvolvingItem_Struct evotop;
+			RoF2::structs::EvolvingItem_Struct evotop{};
 			inst->CalculateEvolveProgression();
 
-			evotop.final_item_id    = inst->GetEvolveFinalItemID();
 			evotop.evolve_level     = item->EvolvingLevel;
 			evotop.progress         = inst->GetEvolveProgression();
 			evotop.activated        = inst->GetEvolveActivated();

--- a/zone/client_evolving_items.cpp
+++ b/zone/client_evolving_items.cpp
@@ -286,9 +286,9 @@ void Client::DoEvolveItemDisplayFinalResult(const EQApplicationPacket *app)
 {
 	const auto in        = reinterpret_cast<EvolveItemToggle *>(app->pBuffer);
 
-	const uint32 item_id = static_cast<uint32>(in->unique_id & 0xFFFFFFFF);
+	const uint32 item_id = in->item_id;
 	if (item_id == 0) {
-		LogEvolveItem("Error - Item ID of final evolve item is blank.");
+		LogEvolveItem("Error - Item ID of evolve item display final request is blank.");
 		return;
 	}
 
@@ -297,19 +297,23 @@ void Client::DoEvolveItemDisplayFinalResult(const EQApplicationPacket *app)
 		return;
 	}
 
+	auto final_id = EvolvingItemsManager::Instance()->GetFinalItemID(*inst);
+	std::unique_ptr<EQ::ItemInstance> const final_inst(database.CreateItem(final_id));
+	if (!final_inst) {
+		return;
+	}
+
 	LogEvolveItemDetail(
 		"Character ID <green>[{}] requested to view final evolve item id <yellow>[{}] for evolve item id <yellow>[{}]",
 		CharacterID(),
-		item_id,
-		EvolvingItemsManager::Instance()->GetFirstItemInLoreGroupByItemID(item_id)
+		final_id,
+		item_id
 	);
-
-	inst->SetEvolveProgression(100);
 
 	LogEvolveItemDetail(
 		"Sending final result for item id <yellow>[{}] to Character ID <green>[{}]", item_id, CharacterID()
 	);
-	SendItemPacket(0, inst.get(), ItemPacketViewLink);
+	SendItemPacket(0, final_inst.get(), ItemPacketViewLink);
 }
 
 bool Client::DoEvolveCheckProgression(EQ::ItemInstance &inst)

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -14404,6 +14404,8 @@ void Client::Handle_OP_ShopPlayerSell(const EQApplicationPacket *app)
 
 				inst2->SetPrice(price);
 				inst2->SetMerchantSlot(freeslot);
+				inst2->SetEvolveCurrentAmount(0);
+				inst2->CalculateEvolveProgression();
 
 				uint32 merchant_quantity = zone->GetTempMerchantQuantity(vendor->GetNPCTypeID(), freeslot);
 

--- a/zone/parcels.cpp
+++ b/zone/parcels.cpp
@@ -134,20 +134,21 @@ void Client::SendParcel(Parcel_Struct &parcel_in)
 
 	CharacterParcelsRepository::CharacterParcels p{};
 
-	p.from_name  = r.from_name;
-	p.id         = r.id;
-	p.note       = r.note;
-	p.quantity   = r.quantity;
-	p.sent_date  = r.sent_date;
-	p.item_id    = r.item_id;
-	p.aug_slot_1 = r.aug_slot_1;
-	p.aug_slot_2 = r.aug_slot_2;
-	p.aug_slot_3 = r.aug_slot_3;
-	p.aug_slot_4 = r.aug_slot_4;
-	p.aug_slot_5 = r.aug_slot_5;
-	p.aug_slot_6 = r.aug_slot_6;
-	p.slot_id    = r.slot_id;
-	p.char_id    = r.char_id;
+	p.from_name     = r.from_name;
+	p.id            = r.id;
+	p.note          = r.note;
+	p.quantity      = r.quantity;
+	p.sent_date     = r.sent_date;
+	p.item_id       = r.item_id;
+	p.aug_slot_1    = r.aug_slot_1;
+	p.aug_slot_2    = r.aug_slot_2;
+	p.aug_slot_3    = r.aug_slot_3;
+	p.aug_slot_4    = r.aug_slot_4;
+	p.aug_slot_5    = r.aug_slot_5;
+	p.aug_slot_6    = r.aug_slot_6;
+	p.slot_id       = r.slot_id;
+	p.char_id       = r.char_id;
+	p.evolve_amount = r.evolve_amount;
 
 	auto item = database.GetItem(p.item_id);
 	if (item) {


### PR DESCRIPTION
Backports EQEmu/Server#5017 into this fork.
Credit to Nekkola

Description
-------------------------------------------
An outstanding item from PR4992 was item https://github.com/EQEmu/Server/pull/4. An issue where creating a saylink from an evolving item would inject a random character as character https://github.com/EQEmu/Server/pull/1.

Fixes the above noted item from PR4992. Saylinks should work correctly for evolving items.
In testing, noticed that when selling an evolving item with progression, if the player had the merchant window open and clicked inspect, the progression would show incorrectly. This has been fixed to show progression at 0. This was not present if the merchant window was opened after selling the item.
Similar issue with parceling an evolving item with progression. If the player receiving the item had the parcel window open, the inspect would show the incorrect progression. This was not present if the player opens the parcel window after receiving the item.

<img width="466" height="645" alt="image" src="https://github.com/user-attachments/assets/63a755e0-5da7-4239-a3d4-203382c3f6c3" />
<img width="488" height="598" alt="image" src="https://github.com/user-attachments/assets/14087a43-afc4-4328-9266-c9f7729a3a03" />
Clients tested:
RoF2