### PR TITLE
Fix inventory overflow bug overwriting equipment slot 0

### DIFF
--- a/common/inventory_profile.cpp
+++ b/common/inventory_profile.cpp
@@ -1847,7 +1847,7 @@ int16 EQ::InventoryProfile::FindFirstFreeSlotThatFitsItem(const EQ::ItemData *it
 			}
 		}
 	}
-	return 0;
+	return INVALID_INDEX;
 }
 
 //This function has the same flaw as noted above

--- a/zone/inventory.cpp
+++ b/zone/inventory.cpp
@@ -4679,7 +4679,8 @@ bool Client::PutItemInInventoryWithStacking(EQ::ItemInstance *inst)
 			return true;
 		}
 	}
-	if (free_id != INVALID_INDEX) {
+	// Protect equipment slots (0-22) from being overwritten
+	if (free_id != INVALID_INDEX && !EQ::ValueWithin(free_id, EQ::invslot::EQUIPMENT_BEGIN, EQ::invslot::EQUIPMENT_END)) {
 		if (PutItemInInventory(free_id, *inst, true)) {
 			return true;
 		}


### PR DESCRIPTION
FindFirstFreeSlotThatFitsItem was returning 0 instead of INVALID_INDEX when no free slot was found. This caused items to be placed in slot 0 (charm equipment slot) when inventory was full, overwriting equipped items.

Changes:
- Fix FindFirstFreeSlotThatFitsItem to return INVALID_INDEX when no slot found
- Add defensive check in PutItemInInventoryWithStacking to protect equipment slots 0-22 from being targeted for item placement


