### PR TITLE
Add hybrid release workflow for automated binary builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -136,7 +136,7 @@ jobs:
           $minZipSize = 100KB
 
           # Verify that critical binaries exist
-          $requiredBinaries = @("world.exe", "zone.exe", "ucs.exe", "queryserv.exe", "eqlaunch.exe", "shared_memory.exe")
+          $requiredBinaries = @("world.exe", "zone.exe", "ucs.exe", "queryserv.exe", "eqlaunch.exe", "shared_memory.exe", "loginserver.exe", "import_client_files.exe", "export_client_files.exe")
           $missingBinaries = @()
           
           foreach ($binary in $requiredBinaries) {
@@ -240,6 +240,12 @@ jobs:
       - name: List artifacts
         run: ls -la artifacts/
 
+      - name: Generate checksums
+        run: |
+          cd artifacts
+          sha256sum *.zip > SHA256SUMS.txt
+          cat SHA256SUMS.txt
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
@@ -250,3 +256,4 @@ jobs:
           files: |
             artifacts/eqemu-server-linux-x64.zip
             artifacts/eqemu-server-windows-x64.zip
+            artifacts/SHA256SUMS.txt


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for automated building and releasing of project binaries for both Linux and Windows platforms. The workflow handles building, packaging, artifact uploading, and release creation upon pushes to the `master` branch or when a version tag is pushed.

Build and release automation:

* Adds a `.github/workflows/release.yaml` workflow that triggers on pushes to `master` or tags matching `v*`, automating the build and release process.

Linux build and packaging:

* Implements a `build-linux` job that checks out the code, sets up build dependencies and ccache, builds the project using CMake and Ninja, packages relevant binaries into a zip file, and uploads the resulting artifact.

Windows build and packaging:

* Implements a `build-windows` job that sets up the MSVC environment, builds the project with Visual Studio generator, collects executables and DLLs (including zlib if present), packages them into a zip file, and uploads the artifact.

Release creation:

* Adds a `release` job that depends on successful Linux and Windows builds, downloads their artifacts, and creates a GitHub release with the packaged binaries attached when a version tag is pushed.

## Usage documentation

**Accessing artifacts from commits:**
- Navigate via commit status checkmark → Release workflow → Artifacts section
- Alternative: Actions tab → Release workflow → Select run → Download artifacts
- Artifacts retained 90 days

**Triggering releases:**
```bash
git tag v1.0.0
git push origin v1.0.0
```
- Tags starting with `v` trigger automatic release creation
- Builds both platforms, packages binaries, creates GitHub release with auto-generated notes
- Assets appear in repository Releases section
