### PR TITLE
Skip redundant builds on merge when PR already passed

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,7 +6,23 @@ on:
   pull_request:
 
 jobs:
+  # Check if we should skip this workflow run (e.g., if the same code already built successfully)
+  pre_job:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          # Skip if a successful run exists for the same tree hash (same file content)
+          skip_after_successful_duplicate: 'true'
+          # Never skip PR builds - we always want to see status before merge
+          do_not_skip: '["pull_request"]'
+
   linux:
+    needs: pre_job
+    if: needs.pre_job.outputs.should_skip != 'true'
     name: Linux
     runs-on: ubuntu-latest
     container:
@@ -57,6 +73,8 @@ jobs:
         run: ./bin/tests
 
   windows:
+    needs: pre_job
+    if: needs.pre_job.outputs.should_skip != 'true'
     name: Windows
     runs-on: windows-latest
     steps:


### PR DESCRIPTION
Add skip-duplicate-actions to avoid rebuilding on push to master when the same code already built successfully on the PR. This saves CI time and resources by detecting when file content (tree hash) matches a previous successful run.

- Add pre_job that checks for duplicate runs using fkirc/skip-duplicate-actions
- PR builds always run (never skipped) to ensure status before merge
- Push builds to master skip if identical code already built successfully
- Both linux and windows jobs depend on pre_job skip check


