### PR TITLE
[Bug Fix] Prevent NPC summon during pending zone transfer

### DIFF
--- a/zone/client.h
+++ b/zone/client.h
@@ -814,6 +814,7 @@ public:
 	inline const int32 GetInstanceID() const { return zone->GetInstanceID(); }
 	void SetZoning(bool in) { bZoning = in; }
 	bool IsZoning() { return bZoning; }
+	bool HasPendingMovePC() const { return zone_mode != ZoneUnsolicited; }
 
 	void ShowSpells(Client* c, ShowSpellType show_spell_type);
 

--- a/zone/client.h
+++ b/zone/client.h
@@ -814,6 +814,8 @@ public:
 	inline const int32 GetInstanceID() const { return zone->GetInstanceID(); }
 	void SetZoning(bool in) { bZoning = in; }
 	bool IsZoning() { return bZoning; }
+	// "Pending" here means a server-initiated MovePC/zone request represented by a
+	// non-ZoneUnsolicited zone_mode; it is not a general indicator for all zoning states.
 	bool HasPendingMovePC() const { return zone_mode != ZoneUnsolicited; }
 
 	void ShowSpells(Client* c, ShowSpellType show_spell_type);

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -4875,7 +4875,12 @@ bool Mob::HateSummon() {
 			new_pos = target->TryMoveAlong(new_pos, 5.0f, angle);
 
 			if (target->IsClient()) {
-				target->CastToClient()->MovePC(
+				auto* client = target->CastToClient();
+				if (client->IsZoning() || client->HasPendingMovePC()) {
+					return false;
+				}
+
+				client->MovePC(
 					zone->GetZoneID(),
 					zone->GetInstanceID(),
 					new_pos.x,

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -4862,6 +4862,13 @@ bool Mob::HateSummon() {
 	if(target)
 	{
 		if(summon_level == 1) {
+			if (target->IsClient()) {
+				auto* client = target->CastToClient();
+				if (client->IsZoning() || client->HasPendingMovePC()) {
+					return false;
+				}
+			}
+
 			entity_list.MessageClose(this, true, 500, Chat::Say, "%s says 'You will not evade me, %s!' ", GetCleanName(), target->GetCleanName() );
 
 			float summoner_zoff = GetZOffset();
@@ -4875,12 +4882,7 @@ bool Mob::HateSummon() {
 			new_pos = target->TryMoveAlong(new_pos, 5.0f, angle);
 
 			if (target->IsClient()) {
-				auto* client = target->CastToClient();
-				if (client->IsZoning() || client->HasPendingMovePC()) {
-					return false;
-				}
-
-				client->MovePC(
+				target->CastToClient()->MovePC(
 					zone->GetZoneID(),
 					zone->GetInstanceID(),
 					new_pos.x,


### PR DESCRIPTION
NPC hate-summon would emit the "You will not evade me" taunt even when `MovePC` was subsequently skipped due to the client already zoning or having an in-flight server-initiated move request.

## Changes

- **`zone/mob.cpp` — `Mob::HateSummon()`**: Moved the `IsZoning() || HasPendingMovePC()` guard check to before the `MessageClose` taunt. The message is now only broadcast when the summon will actually execute.
- **`zone/client.h`**: Added `HasPendingMovePC()` helper — returns `true` when `zone_mode` indicates a server-initiated move/zone request is pending (i.e., non-`ZoneUnsolicited` state).

```cpp
// Guard runs before taunt — no message if summon is skipped
if (target->IsClient()) {
    auto* client = target->CastToClient();
    if (client->IsZoning() || client->HasPendingMovePC()) {
        return false;
    }
}
entity_list.MessageClose(this, true, 500, Chat::Say,
    "%s says 'You will not evade me, %s!' ", GetCleanName(), target->GetCleanName());
// ... MovePC follows
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Verified logic change is isolated to summon-level-1 client path. Non-client targets (pets, NPCs) and summon-level-2 behavior are unaffected.

Clients tested: 

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur