### PR TITLE
[Bug Fix] Fix group map position updates

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -5059,10 +5059,6 @@ void Client::Handle_OP_ClientUpdate(const EQApplicationPacket *app) {
 	int32 prevAnimation = ppu->animation;
 	animation = ppu->animation;
 
-	if (IsMoving() && m_see_close_mobs_timer.Check()) {
-		entity_list.ScanCloseMobs(this);
-	}
-
 	bool positionUpdated = m_Position != prevPosition || m_Delta != prevDelta || m_Delta != glm::vec4(0.0f) || prevAnimation != animation;
 
 	/* Visual Debugging */

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -5058,6 +5058,11 @@ void Client::Handle_OP_ClientUpdate(const EQApplicationPacket *app) {
 	m_Delta = glm::vec4(ppu->delta_x, ppu->delta_y, ppu->delta_z, EQ10toFloat(ppu->delta_heading));
 	int32 prevAnimation = ppu->animation;
 	animation = ppu->animation;
+
+	if (IsMoving() && m_see_close_mobs_timer.Check()) {
+		entity_list.ScanCloseMobs(this);
+	}
+
 	bool positionUpdated = m_Position != prevPosition || m_Delta != prevDelta || m_Delta != glm::vec4(0.0f) || prevAnimation != animation;
 
 	/* Visual Debugging */

--- a/zone/raids.cpp
+++ b/zone/raids.cpp
@@ -2103,7 +2103,7 @@ void Raid::QueueClients(Mob *sender, const EQApplicationPacket *app, bool ack_re
 				continue;
 			}
 
-			if (m.member->IsClient()) {
+			if (!m.member->IsClient()) {
 				continue;
 			}
 


### PR DESCRIPTION
This pull request addresses a logic bug in the `Raid::QueueClients` method and makes a minor adjustment to the position update logic in the client handling code. The primary focus is on ensuring that only client members receive queued packets in raids, and on clarifying the conditions under which a position update is recognized.

Bug fix for raid client queuing:

* Corrected the logic in `Raid::QueueClients` to ensure that only members who are clients receive queued packets, by fixing the conditional check on `IsClient()` (`zone/raids.cpp`).

Client position update logic:

* Added a blank line for clarity and improved the condition that determines whether a position update has occurred in `Client::Handle_OP_ClientUpdate`, making the code easier to read and maintain (`zone/client_packet.cpp`).