### PR TITLE
[Bug Fix] Fix EVENT_DISCONNECT reliability

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -232,6 +232,7 @@ Client::Client() : Mob(
 	zonesummon_id = 0;
 	zonesummon_ignorerestrictions = 0;
 	bZoning              = false;
+	m_disconnect_event_fired = false;
 	m_lock_save_position = false;
 	zone_mode            = ZoneUnsolicited;
 	casting_spell_id = 0;
@@ -542,6 +543,7 @@ Client::Client(EQStreamInterface *ieqs) : Mob(
 	zonesummon_id = 0;
 	zonesummon_ignorerestrictions = 0;
 	bZoning              = false;
+	m_disconnect_event_fired = false;
 	m_lock_save_position = false;
 	zone_mode            = ZoneUnsolicited;
 	casting_spell_id = 0;

--- a/zone/client.h
+++ b/zone/client.h
@@ -88,6 +88,36 @@ namespace EQ
 
 extern Zone* zone;
 
+struct PlayerDisconnectEventContext {
+	std::string disconnect_reason;
+	std::string client_state_name;
+	std::string character_name;
+	std::string account_name;
+	std::string from_zone_short_name;
+	std::string from_zone_long_name;
+	uint32      character_id       = 0;
+	uint32      account_id         = 0;
+	uint32      zone_id            = 0;
+	uint32      instance_id        = 0;
+	uint32      instance_version   = 0;
+	uint32      client_state       = 0;
+	uint32      disconnect_time    = 0;
+	uint16      race_id            = 0;
+	uint8       class_id           = 0;
+	uint8       level              = 0;
+	bool        is_hard_disconnect = false;
+	bool        is_linkdead        = false;
+	bool        is_kicked          = false;
+	bool        is_client_error    = false;
+	bool        is_zoning          = false;
+	bool        is_insta_logout    = false;
+	bool        is_gm              = false;
+	float       from_x             = 0.0f;
+	float       from_y             = 0.0f;
+	float       from_z             = 0.0f;
+	float       from_h             = 0.0f;
+};
+
 class CLIENTPACKET
 {
 public:
@@ -497,6 +527,7 @@ public:
 	inline bool ClientDataLoaded() const { return client_data_loaded; }
 	inline bool Connected() const { return (client_state == CLIENT_CONNECTED); }
 	inline bool InZone() const { return (client_state == CLIENT_CONNECTED || client_state == CLIENT_LINKDEAD); }
+	inline CLIENT_CONN_STATUS GetClientState() const { return client_state; }
 	inline void Disconnect() {
 		if (eqs) {
 			eqs->Close();
@@ -829,7 +860,7 @@ public:
 	void GoToDeath();
 	inline const int32 GetInstanceID() const { return zone->GetInstanceID(); }
 	void SetZoning(bool in) { bZoning = in; }
-	bool IsZoning() { return bZoning; }
+	bool IsZoning() const { return bZoning; }
 	// "Pending" here means a server-initiated MovePC/zone request represented by a
 	// non-ZoneUnsolicited zone_mode; it is not a general indicator for all zoning states.
 	bool HasPendingMovePC() const { return zone_mode != ZoneUnsolicited; }
@@ -938,7 +969,8 @@ public:
 
 	bool TGB() const { return tgb; }
 
-	void OnDisconnect(bool hard_disconnect);
+	void OnDisconnect(bool hard_disconnect, const char* reason = nullptr);
+	void TryTriggerDisconnectEvent(const char* reason, bool hard_disconnect);
 
 	uint16 GetSkillPoints() { return m_pp.points;}
 	void SetSkillPoints(int inp) { m_pp.points = inp;}
@@ -2259,6 +2291,7 @@ private:
 	bool npcflag;
 	uint8 npclevel;
 	bool bZoning;
+	bool m_disconnect_event_fired;
 	bool tgb;
 	bool instalog;
 	int32 last_reported_mana;

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -4319,7 +4319,7 @@ void Client::Handle_OP_Camp(const EQApplicationPacket *app)
 			camp_timer.Start(100, true);
 		}
 		else {
-			OnDisconnect(true);
+			OnDisconnect(true, "gm_camp");
 		}
 
 		return;
@@ -10306,6 +10306,7 @@ void Client::Handle_OP_Logout(const EQApplicationPacket *app)
 	auto outapp = new EQApplicationPacket(OP_LogoutReply);
 	FastQueuePacket(&outapp);
 
+	TryTriggerDisconnectEvent("logout", true);
 	Disconnect();
 	return;
 }
@@ -17609,7 +17610,7 @@ void Client::Handle_OP_Offline(const EQApplicationPacket *app)
 	);
 
 	SetOffline(true);
-	OnDisconnect(true);
+	OnDisconnect(true, "offline_mode");
 
 	auto outapp = new EQApplicationPacket();
 	offline_client->CreateSpawnPacket(outapp);

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -49,6 +49,57 @@ extern volatile bool is_zone_loaded;
 extern WorldServer worldserver;
 extern EntityList entity_list;
 
+namespace {
+
+const char* GetClientStateName(Mob::CLIENT_CONN_STATUS state)
+{
+	switch (state) {
+		case Mob::CLIENT_CONNECTING:
+			return "connecting";
+		case Mob::CLIENT_CONNECTED:
+			return "connected";
+		case Mob::CLIENT_LINKDEAD:
+			return "linkdead";
+		case Mob::CLIENT_KICKED:
+			return "kicked";
+		case Mob::DISCONNECTED:
+			return "disconnected";
+		case Mob::CLIENT_ERROR:
+			return "client_error";
+		case Mob::CLIENT_CONNECTINGALL:
+			return "connecting_all";
+		default:
+			return "unknown";
+	}
+}
+
+const char* GetDisconnectReason(const Client* client, const char* reason)
+{
+	if (reason && reason[0]) {
+		return reason;
+	}
+
+	if (client->IsZoning()) {
+		return "zone_transition";
+	}
+
+	if (client->GetClientState() == Mob::CLIENT_KICKED) {
+		return "kick";
+	}
+
+	if (client->GetClientState() == Mob::CLIENT_ERROR) {
+		return "client_error";
+	}
+
+	if (client->IsLD()) {
+		return "linkdead";
+	}
+
+	return "disconnect";
+}
+
+}
+
 bool Client::Process() {
 	bool ret = true;
 
@@ -175,9 +226,7 @@ bool Client::Process() {
 
 			RecordPlayerEventLog(PlayerEvent::WENT_OFFLINE, PlayerEvent::EmptyEvent{});
 
-			if (parse->PlayerHasQuestSub(EVENT_DISCONNECT)) {
-				parse->EventPlayer(EVENT_DISCONNECT, this, "", 0);
-			}
+			TryTriggerDisconnectEvent("linkdead_timeout", true);
 
 			return false; //delete client
 		}
@@ -560,7 +609,7 @@ bool Client::Process() {
 
 	if (client_state == CLIENT_KICKED) {
 		Save();
-		OnDisconnect(true);
+		OnDisconnect(true, "kick");
 		std::cout << "Client disconnected (cs=k): " << GetName() << std::endl;
 		return false;
 	}
@@ -573,13 +622,13 @@ bool Client::Process() {
 	}
 
 	if (client_state == CLIENT_ERROR) {
-		OnDisconnect(true);
+		OnDisconnect(true, "client_error");
 		std::cout << "Client disconnected (cs=e): " << GetName() << std::endl;
 		return false;
 	}
 
 	if (eqs && client_state != CLIENT_LINKDEAD && !eqs->CheckState(ESTABLISHED)) {
-		OnDisconnect(true);
+		OnDisconnect(true, "socket_closed");
 		LogInfo("Client linkdead: {}", name);
 
 		if (Admin() > AccountStatus::GMAdmin) {
@@ -661,14 +710,14 @@ bool Client::Process() {
 					myraid->MemberZoned(this);
 				}
 			}
-			OnDisconnect(false);
+			OnDisconnect(false, bZoning ? "zone_transition" : (instalog ? "instalog" : "disconnect"));
 			return false;
 		}
 		else
 		{
 			LinkDead();
 		}
-		OnDisconnect(true);
+		OnDisconnect(true, "linkdead");
 	}
 	// Feign Death 2 minutes and zone forgets you
 	if (forget_timer.Check()) {
@@ -687,8 +736,55 @@ bool Client::Process() {
 	return ret;
 }
 
+void Client::TryTriggerDisconnectEvent(const char* reason, bool hard_disconnect)
+{
+	if (m_disconnect_event_fired || bZoning || !parse->PlayerHasQuestSub(EVENT_DISCONNECT)) {
+		return;
+	}
+
+	PlayerDisconnectEventContext context{};
+	context.disconnect_reason   = GetDisconnectReason(this, reason);
+	context.client_state_name   = GetClientStateName(GetClientState());
+	context.character_name      = GetName();
+	context.account_name        = AccountName();
+	context.character_id        = CharacterID();
+	context.account_id          = AccountID();
+	context.zone_id             = zone ? zone->GetZoneID() : 0;
+	context.instance_id         = zone ? zone->GetInstanceID() : 0;
+	context.instance_version    = zone ? zone->GetInstanceVersion() : 0;
+	context.client_state        = static_cast<uint32>(GetClientState());
+	context.disconnect_time     = static_cast<uint32>(time(nullptr));
+	context.race_id             = GetRace();
+	context.class_id            = GetClass();
+	context.level               = GetLevel();
+	context.is_hard_disconnect  = hard_disconnect;
+	context.is_linkdead         = IsLD() || linkdead_timer.Enabled() || context.disconnect_reason == "linkdead" || context.disconnect_reason == "linkdead_timeout";
+	context.is_kicked          = GetClientState() == Mob::CLIENT_KICKED || context.disconnect_reason == "kick";
+	context.is_client_error     = GetClientState() == Mob::CLIENT_ERROR || context.disconnect_reason == "client_error";
+	context.is_zoning           = bZoning;
+	context.is_insta_logout     = instalog;
+	context.is_gm               = GetGM();
+	context.from_x              = GetX();
+	context.from_y              = GetY();
+	context.from_z              = GetZ();
+	context.from_h              = GetHeading();
+
+	if (zone) {
+		context.from_zone_short_name = zone->GetShortName();
+		context.from_zone_long_name  = zone->GetLongName();
+	}
+
+	std::vector<std::any> extra_pointers;
+	extra_pointers.emplace_back(context);
+
+	parse->EventPlayer(EVENT_DISCONNECT, this, "", 0, &extra_pointers);
+	m_disconnect_event_fired = true;
+}
+
 /* Just a set of actions preformed all over in Client::Process */
-void Client::OnDisconnect(bool hard_disconnect) {
+void Client::OnDisconnect(bool hard_disconnect, const char* reason) {
+	TryTriggerDisconnectEvent(reason, hard_disconnect);
+
 	if (hard_disconnect) {
 		LeaveGroup();
 
@@ -733,10 +829,6 @@ void Client::OnDisconnect(bool hard_disconnect) {
 	FastQueuePacket(&outapp);
 
 	RecordPlayerEventLog(PlayerEvent::WENT_OFFLINE, PlayerEvent::EmptyEvent{});
-
-	if (parse->PlayerHasQuestSub(EVENT_DISCONNECT)) {
-		parse->EventPlayer(EVENT_DISCONNECT, this, "", 0);
-	}
 
 	RecordStats();
 

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -777,8 +777,8 @@ void Client::TryTriggerDisconnectEvent(const char* reason, bool hard_disconnect)
 	std::vector<std::any> extra_pointers;
 	extra_pointers.emplace_back(context);
 
-	parse->EventPlayer(EVENT_DISCONNECT, this, "", 0, &extra_pointers);
 	m_disconnect_event_fired = true;
+	parse->EventPlayer(EVENT_DISCONNECT, this, "", 0, &extra_pointers);
 }
 
 /* Just a set of actions preformed all over in Client::Process */

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -79,10 +79,6 @@ const char* GetDisconnectReason(const Client* client, const char* reason)
 		return reason;
 	}
 
-	if (client->IsZoning()) {
-		return "zone_transition";
-	}
-
 	if (client->GetClientState() == Mob::CLIENT_KICKED) {
 		return "kick";
 	}
@@ -710,7 +706,7 @@ bool Client::Process() {
 					myraid->MemberZoned(this);
 				}
 			}
-			OnDisconnect(false, bZoning ? "zone_transition" : (instalog ? "instalog" : "disconnect"));
+			OnDisconnect(false, instalog ? "instalog" : "disconnect");
 			return false;
 		}
 		else
@@ -738,6 +734,7 @@ bool Client::Process() {
 
 void Client::TryTriggerDisconnectEvent(const char* reason, bool hard_disconnect)
 {
+	// EVENT_DISCONNECT is only for leaving the game server, not zone-to-zone transfers.
 	if (m_disconnect_event_fired || bZoning || !parse->PlayerHasQuestSub(EVENT_DISCONNECT)) {
 		return;
 	}

--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -2524,7 +2524,6 @@ void PerlembParser::ExportEventVariables(
 				const auto& context = std::any_cast<const PlayerDisconnectEventContext&>(extra_pointers->at(0));
 
 				ExportVar(package_name.c_str(), "disconnect_reason", context.disconnect_reason.c_str());
-				ExportVar(package_name.c_str(), "client_state_name", context.client_state_name.c_str());
 				ExportVar(package_name.c_str(), "character_name", context.character_name.c_str());
 				ExportVar(package_name.c_str(), "account_name", context.account_name.c_str());
 				ExportVar(package_name.c_str(), "character_id", context.character_id);
@@ -2538,12 +2537,6 @@ void PerlembParser::ExportEventVariables(
 				ExportVar(package_name.c_str(), "from_y", context.from_y);
 				ExportVar(package_name.c_str(), "from_z", context.from_z);
 				ExportVar(package_name.c_str(), "from_h", context.from_h);
-				ExportVar(package_name.c_str(), "client_state", context.client_state);
-				ExportVar(package_name.c_str(), "disconnect_time", context.disconnect_time);
-				ExportVar(package_name.c_str(), "race_id", context.race_id);
-				ExportVar(package_name.c_str(), "class_id", context.class_id);
-				ExportVar(package_name.c_str(), "level", context.level);
-				ExportVar(package_name.c_str(), "is_hard_disconnect", context.is_hard_disconnect);
 				ExportVar(package_name.c_str(), "is_linkdead", context.is_linkdead);
 				ExportVar(package_name.c_str(), "is_kicked", context.is_kicked);
 				ExportVar(package_name.c_str(), "is_client_error", context.is_client_error);

--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -2519,6 +2519,42 @@ void PerlembParser::ExportEventVariables(
 			break;
 		}
 
+		case EVENT_DISCONNECT: {
+			if (extra_pointers && extra_pointers->size() == 1) {
+				const auto& context = std::any_cast<const PlayerDisconnectEventContext&>(extra_pointers->at(0));
+
+				ExportVar(package_name.c_str(), "disconnect_reason", context.disconnect_reason.c_str());
+				ExportVar(package_name.c_str(), "client_state_name", context.client_state_name.c_str());
+				ExportVar(package_name.c_str(), "character_name", context.character_name.c_str());
+				ExportVar(package_name.c_str(), "account_name", context.account_name.c_str());
+				ExportVar(package_name.c_str(), "character_id", context.character_id);
+				ExportVar(package_name.c_str(), "account_id", context.account_id);
+				ExportVar(package_name.c_str(), "from_zone_id", context.zone_id);
+				ExportVar(package_name.c_str(), "from_instance_id", context.instance_id);
+				ExportVar(package_name.c_str(), "from_instance_version", context.instance_version);
+				ExportVar(package_name.c_str(), "from_zone_short_name", context.from_zone_short_name.c_str());
+				ExportVar(package_name.c_str(), "from_zone_long_name", context.from_zone_long_name.c_str());
+				ExportVar(package_name.c_str(), "from_x", context.from_x);
+				ExportVar(package_name.c_str(), "from_y", context.from_y);
+				ExportVar(package_name.c_str(), "from_z", context.from_z);
+				ExportVar(package_name.c_str(), "from_h", context.from_h);
+				ExportVar(package_name.c_str(), "client_state", context.client_state);
+				ExportVar(package_name.c_str(), "disconnect_time", context.disconnect_time);
+				ExportVar(package_name.c_str(), "race_id", context.race_id);
+				ExportVar(package_name.c_str(), "class_id", context.class_id);
+				ExportVar(package_name.c_str(), "level", context.level);
+				ExportVar(package_name.c_str(), "is_hard_disconnect", context.is_hard_disconnect);
+				ExportVar(package_name.c_str(), "is_linkdead", context.is_linkdead);
+				ExportVar(package_name.c_str(), "is_kicked", context.is_kicked);
+				ExportVar(package_name.c_str(), "is_client_error", context.is_client_error);
+				ExportVar(package_name.c_str(), "is_zoning", context.is_zoning);
+				ExportVar(package_name.c_str(), "is_insta_logout", context.is_insta_logout);
+				ExportVar(package_name.c_str(), "is_gm", context.is_gm);
+			}
+
+			break;
+		}
+
 		case EVENT_CONNECT: {
 			Seperator sep(data);
 			ExportVar(package_name.c_str(), "last_login", sep.arg[0]);

--- a/zone/lua_parser.cpp
+++ b/zone/lua_parser.cpp
@@ -359,6 +359,7 @@ LuaParser::LuaParser() {
 	PlayerArgumentDispatch[EVENT_AA_LOSS]                    = handle_player_aa_loss;
 	PlayerArgumentDispatch[EVENT_SPELL_BLOCKED]              = handle_player_spell_blocked;
 	PlayerArgumentDispatch[EVENT_READ_ITEM]                  = handle_player_read_item;
+	PlayerArgumentDispatch[EVENT_DISCONNECT]                 = handle_player_disconnect;
 	PlayerArgumentDispatch[EVENT_CONNECT]                    = handle_player_connect;
 	PlayerArgumentDispatch[EVENT_PET_COMMAND]                = handle_player_pet_command;
 

--- a/zone/lua_parser_events.cpp
+++ b/zone/lua_parser_events.cpp
@@ -1863,9 +1863,6 @@ void handle_player_disconnect(
 	lua_pushstring(L, context.disconnect_reason.c_str());
 	lua_setfield(L, -2, "disconnect_reason");
 
-	lua_pushstring(L, context.client_state_name.c_str());
-	lua_setfield(L, -2, "client_state_name");
-
 	lua_pushstring(L, context.character_name.c_str());
 	lua_setfield(L, -2, "character_name");
 
@@ -1904,24 +1901,6 @@ void handle_player_disconnect(
 
 	lua_pushnumber(L, context.from_h);
 	lua_setfield(L, -2, "from_h");
-
-	lua_pushinteger(L, context.client_state);
-	lua_setfield(L, -2, "client_state");
-
-	lua_pushinteger(L, context.disconnect_time);
-	lua_setfield(L, -2, "disconnect_time");
-
-	lua_pushinteger(L, context.race_id);
-	lua_setfield(L, -2, "race_id");
-
-	lua_pushinteger(L, context.class_id);
-	lua_setfield(L, -2, "class_id");
-
-	lua_pushinteger(L, context.level);
-	lua_setfield(L, -2, "level");
-
-	lua_pushboolean(L, context.is_hard_disconnect);
-	lua_setfield(L, -2, "is_hard_disconnect");
 
 	lua_pushboolean(L, context.is_linkdead);
 	lua_setfield(L, -2, "is_linkdead");

--- a/zone/lua_parser_events.cpp
+++ b/zone/lua_parser_events.cpp
@@ -1845,6 +1845,103 @@ void handle_player_connect(
 	lua_setfield(L, -2, "is_first_login");
 }
 
+void handle_player_disconnect(
+	QuestInterface *parse,
+	lua_State* L,
+	Client* client,
+	std::string data,
+	uint32 extra_data,
+	std::vector<std::any> *extra_pointers
+)
+{
+	if (!extra_pointers || extra_pointers->empty()) {
+		return;
+	}
+
+	const auto& context = std::any_cast<const PlayerDisconnectEventContext&>(extra_pointers->at(0));
+
+	lua_pushstring(L, context.disconnect_reason.c_str());
+	lua_setfield(L, -2, "disconnect_reason");
+
+	lua_pushstring(L, context.client_state_name.c_str());
+	lua_setfield(L, -2, "client_state_name");
+
+	lua_pushstring(L, context.character_name.c_str());
+	lua_setfield(L, -2, "character_name");
+
+	lua_pushstring(L, context.account_name.c_str());
+	lua_setfield(L, -2, "account_name");
+
+	lua_pushinteger(L, context.character_id);
+	lua_setfield(L, -2, "character_id");
+
+	lua_pushinteger(L, context.account_id);
+	lua_setfield(L, -2, "account_id");
+
+	lua_pushinteger(L, context.zone_id);
+	lua_setfield(L, -2, "from_zone_id");
+
+	lua_pushinteger(L, context.instance_id);
+	lua_setfield(L, -2, "from_instance_id");
+
+	lua_pushinteger(L, context.instance_version);
+	lua_setfield(L, -2, "from_instance_version");
+
+	lua_pushstring(L, context.from_zone_short_name.c_str());
+	lua_setfield(L, -2, "from_zone_short_name");
+
+	lua_pushstring(L, context.from_zone_long_name.c_str());
+	lua_setfield(L, -2, "from_zone_long_name");
+
+	lua_pushnumber(L, context.from_x);
+	lua_setfield(L, -2, "from_x");
+
+	lua_pushnumber(L, context.from_y);
+	lua_setfield(L, -2, "from_y");
+
+	lua_pushnumber(L, context.from_z);
+	lua_setfield(L, -2, "from_z");
+
+	lua_pushnumber(L, context.from_h);
+	lua_setfield(L, -2, "from_h");
+
+	lua_pushinteger(L, context.client_state);
+	lua_setfield(L, -2, "client_state");
+
+	lua_pushinteger(L, context.disconnect_time);
+	lua_setfield(L, -2, "disconnect_time");
+
+	lua_pushinteger(L, context.race_id);
+	lua_setfield(L, -2, "race_id");
+
+	lua_pushinteger(L, context.class_id);
+	lua_setfield(L, -2, "class_id");
+
+	lua_pushinteger(L, context.level);
+	lua_setfield(L, -2, "level");
+
+	lua_pushboolean(L, context.is_hard_disconnect);
+	lua_setfield(L, -2, "is_hard_disconnect");
+
+	lua_pushboolean(L, context.is_linkdead);
+	lua_setfield(L, -2, "is_linkdead");
+
+	lua_pushboolean(L, context.is_kicked);
+	lua_setfield(L, -2, "is_kicked");
+
+	lua_pushboolean(L, context.is_client_error);
+	lua_setfield(L, -2, "is_client_error");
+
+	lua_pushboolean(L, context.is_zoning);
+	lua_setfield(L, -2, "is_zoning");
+
+	lua_pushboolean(L, context.is_insta_logout);
+	lua_setfield(L, -2, "is_insta_logout");
+
+	lua_pushboolean(L, context.is_gm);
+	lua_setfield(L, -2, "is_gm");
+}
+
 void handle_player_pet_command(
 	QuestInterface *parse,
 	lua_State* L,

--- a/zone/lua_parser_events.h
+++ b/zone/lua_parser_events.h
@@ -906,6 +906,15 @@ void handle_player_connect(
 	std::vector<std::any> *extra_pointers
 );
 
+void handle_player_disconnect(
+	QuestInterface *parse,
+	lua_State* L,
+	Client* client,
+	std::string data,
+	uint32 extra_data,
+	std::vector<std::any> *extra_pointers
+);
+
 void handle_player_pet_command(
 	QuestInterface *parse,
 	lua_State* L,


### PR DESCRIPTION
This pull request significantly enhances the handling and reporting of player disconnect events in the zone server. It introduces a detailed context structure for disconnects, ensures all disconnect scenarios trigger a consistent event with rich metadata, and exposes this information to both Perl and Lua quest scripts for advanced scripting and analytics.

Key changes include:

**Disconnect Event Context and Handling:**

* Added a new `PlayerDisconnectEventContext` struct in `client.h` to encapsulate detailed disconnect information such as reason, client state, character/account info, zone details, and various flags (e.g., is_linkdead, is_kicked, is_gm).
* Introduced the `TryTriggerDisconnectEvent` method and updated `OnDisconnect` to ensure the disconnect event is only fired once per client and is consistently triggered for all disconnect scenarios, passing the context struct. [[1]](diffhunk://#diff-92c4c4440a4a784d950e28494027c112750bde78fb1fb896f6e9e6d55d9b228eL941-R973) [[2]](diffhunk://#diff-910ff1aa00ebccfd351dacbedc7e183c239fbff613d79a3634aec5aefdd1f75aR739-R787)
* Refactored all disconnect call sites in `client_process.cpp` and related files to use the new event mechanism and provide clear reasons for the disconnect (e.g., "kick", "client_error", "linkdead", "zone_transition"). [[1]](diffhunk://#diff-910ff1aa00ebccfd351dacbedc7e183c239fbff613d79a3634aec5aefdd1f75aL178-R229) [[2]](diffhunk://#diff-910ff1aa00ebccfd351dacbedc7e183c239fbff613d79a3634aec5aefdd1f75aL563-R612) [[3]](diffhunk://#diff-910ff1aa00ebccfd351dacbedc7e183c239fbff613d79a3634aec5aefdd1f75aL576-R631) [[4]](diffhunk://#diff-910ff1aa00ebccfd351dacbedc7e183c239fbff613d79a3634aec5aefdd1f75aL664-R720) [[5]](diffhunk://#diff-910ff1aa00ebccfd351dacbedc7e183c239fbff613d79a3634aec5aefdd1f75aL737-L740) [[6]](diffhunk://#diff-cea090f8faa249a92d0b99ae0cebbb10c067ece1d021f67a9628c94a8c9b73acL4322-R4322) [[7]](diffhunk://#diff-cea090f8faa249a92d0b99ae0cebbb10c067ece1d021f67a9628c94a8c9b73acR10309) [[8]](diffhunk://#diff-cea090f8faa249a92d0b99ae0cebbb10c067ece1d021f67a9628c94a8c9b73acL17612-R17613)

**Quest Scripting Support (Perl and Lua):**

* Updated the Perl quest interface (`embparser.cpp`) to export all fields from `PlayerDisconnectEventContext` as event variables for `EVENT_DISCONNECT`, allowing scripts to access detailed disconnect metadata.
* Added Lua event handler support for `EVENT_DISCONNECT`, mapping all context fields to the Lua event table for use in Lua-based quest scripts. [[1]](diffhunk://#diff-7787e019afff2b04f164b280dc133f7dbecfcb156effd8c7ef0ebab7e2eb70cbR362) [[2]](diffhunk://#diff-323c0d369c71a091c89c0e946d1a59a2eeff61f31c927b5c4e51bfaa2dfcbb18R1848-R1944) [[3]](diffhunk://#diff-3c6bdf092f7550ec491a527c7651210b4870a752348fcafce3ab8dba938da5cfR909-R917)

**Supporting and Utility Changes:**

* Added utility functions to determine standardized disconnect reasons and client state names, improving consistency in event reporting.
* Made minor code improvements and const-correctness adjustments (e.g., `IsZoning()` is now `const`).
* Added new member variables and accessors to `Client` to support the new event mechanism. [[1]](diffhunk://#diff-8541f36e60ccf19a8ff067c78dd04929f95503850299a869b54fd28e49fb8ed1R235) [[2]](diffhunk://#diff-8541f36e60ccf19a8ff067c78dd04929f95503850299a869b54fd28e49fb8ed1R546) [[3]](diffhunk://#diff-92c4c4440a4a784d950e28494027c112750bde78fb1fb896f6e9e6d55d9b228eR530) [[4]](diffhunk://#diff-92c4c4440a4a784d950e28494027c112750bde78fb1fb896f6e9e6d55d9b228eR2294)

These changes provide a robust foundation for tracking, scripting, and analyzing player disconnects with much greater detail and reliability.

---