### PR TITLE
[Bug Fix] Fix multi-buff overwrite stacking

### DIFF
--- a/zone/cli/tests/cli_zone_state.cpp
+++ b/zone/cli/tests/cli_zone_state.cpp
@@ -1014,6 +1014,36 @@ inline void TestBuffOverwriteStacking()
 	RunTest("Buff stacking > Fire-only buff overwritten", false, test_npc->FindBuff(fire_resist_spell_id));
 	RunTest("Buff stacking > Cold-only buff overwritten", false, test_npc->FindBuff(cold_resist_spell_id));
 	RunTest("Buff stacking > Combined resist buff remains", true, test_npc->FindBuff(fire_and_cold_resist_spell_id));
+
+	constexpr uint16 shield_of_words_spell_id   = 20;   // AC-only cleric buff
+	constexpr uint16 resolution_spell_id        = 314;  // HP/AC cleric buff
+	constexpr uint16 gift_of_aegolism_spell_id  = 2122; // Ancient: Gift of Aegolism
+
+	test_npc->BuffFadeAll();
+
+	RunTest(
+		"Buff stacking > Shield of Words lands",
+		true,
+		test_npc->AddBuff(test_npc, shield_of_words_spell_id, 10) >= 0
+	);
+	RunTest(
+		"Buff stacking > Resolution lands",
+		true,
+		test_npc->AddBuff(test_npc, resolution_spell_id, 10) >= 0
+	);
+	RunTest(
+		"Buff stacking > Resolution and Shield of Words coexist before Gift",
+		true,
+		test_npc->FindBuff(shield_of_words_spell_id) && test_npc->FindBuff(resolution_spell_id)
+	);
+	RunTest(
+		"Buff stacking > Gift of Aegolism lands",
+		true,
+		test_npc->AddBuff(test_npc, gift_of_aegolism_spell_id, 10) >= 0
+	);
+	RunTest("Buff stacking > Shield of Words overwritten by Gift", false, test_npc->FindBuff(shield_of_words_spell_id));
+	RunTest("Buff stacking > Resolution overwritten by Gift", false, test_npc->FindBuff(resolution_spell_id));
+	RunTest("Buff stacking > Gift of Aegolism remains", true, test_npc->FindBuff(gift_of_aegolism_spell_id));
 }
 
 inline void TestZLocationDrift()

--- a/zone/cli/tests/cli_zone_state.cpp
+++ b/zone/cli/tests/cli_zone_state.cpp
@@ -968,6 +968,54 @@ inline void TestBuffs()
 	RunTest("Buffs > Persist after shutdown/bootup", false, missing_buffs);
 }
 
+inline void TestBuffOverwriteStacking()
+{
+	constexpr uint16 fire_resist_spell_id          = 60;   // Resist Fire: FR on slot 1
+	constexpr uint16 cold_resist_spell_id          = 1276; // Aura of White Petals: CR on slot 2
+	constexpr uint16 fire_and_cold_resist_spell_id = 2681; // Beta Seasons: FR on slot 1, CR on slot 2
+
+	NPC *test_npc = nullptr;
+	for (auto &e: entity_list.GetNPCList()) {
+		if (e.second->GetNPCTypeID() == 0) {
+			continue;
+		}
+
+		test_npc = e.second;
+		break;
+	}
+
+	if (!test_npc) {
+		RunTest("Buff stacking > Test NPC exists", true, false);
+		return;
+	}
+
+	test_npc->BuffFadeAll();
+
+	RunTest(
+		"Buff stacking > Fire-only buff lands",
+		true,
+		test_npc->AddBuff(test_npc, fire_resist_spell_id, 10) >= 0
+	);
+	RunTest(
+		"Buff stacking > Cold-only buff lands",
+		true,
+		test_npc->AddBuff(test_npc, cold_resist_spell_id, 10) >= 0
+	);
+	RunTest(
+		"Buff stacking > Fire and cold buffs coexist before overwrite",
+		true,
+		test_npc->FindBuff(fire_resist_spell_id) && test_npc->FindBuff(cold_resist_spell_id)
+	);
+	RunTest(
+		"Buff stacking > Combined resist buff lands",
+		true,
+		test_npc->AddBuff(test_npc, fire_and_cold_resist_spell_id, 10) >= 0
+	);
+	RunTest("Buff stacking > Fire-only buff overwritten", false, test_npc->FindBuff(fire_resist_spell_id));
+	RunTest("Buff stacking > Cold-only buff overwritten", false, test_npc->FindBuff(cold_resist_spell_id));
+	RunTest("Buff stacking > Combined resist buff remains", true, test_npc->FindBuff(fire_and_cold_resist_spell_id));
+}
+
 inline void TestZLocationDrift()
 {
 	zone->Shutdown();
@@ -1244,6 +1292,7 @@ void ZoneCLI::TestZoneState(int argc, char **argv, argh::parser &cmd, std::strin
 	TestHpManaEnd();
 	TestClientBuffPersistence();
 	TestBuffs();
+	TestBuffOverwriteStacking();
 	TestLocationChange();
 	TestEntityVariables();
 	TestLoot();

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3638,13 +3638,14 @@ int Mob::AddBuff(Mob *caster, uint16 spell_id, int duration, int32 level_overrid
 				}
 
 				return -1;
-			} else if (ret == 1 && !will_overwrite) {
+			} else if (ret == 1) {
 				// Reject buffing a superior buff while an inferior one is suppressed or else they end up with both
 				if (curbuf.spellid == SPELL_SUPPRESSED) {
 					return -1;
 				}
 
-				// set a flag to indicate that there will be overwriting
+				// Keep collecting every slot this buff should replace so composite buffs
+				// can evict multiple single-effect buffs in one landing.
 				LogSpells(
 					"Adding buff [{}] will overwrite spell [{}] in slot [{}] with caster level [{}]",
 					spell_id,


### PR DESCRIPTION
### **Description**

This pull request adds a new test to verify correct buff stacking and overwrite behavior, and updates the buff application logic to allow composite buffs to overwrite multiple single-effect buffs at once. The changes improve test coverage and enhance the buff system's correctness.

**Buff stacking and overwrite improvements:**

* Added a new test function `TestBuffOverwriteStacking` in `cli_zone_state.cpp` to verify that composite resist buffs correctly overwrite single-effect buffs, and integrated this test into the main test suite. [[1]](diffhunk://#diff-d4390184a3c0c341b69f85872ba435b34c3e594ad366c3c564a017d0743c82f8R971-R1018) [[2]](diffhunk://#diff-d4390184a3c0c341b69f85872ba435b34c3e594ad366c3c564a017d0743c82f8R1295)
* Updated the `AddBuff` method in `zone/spells.cpp` to remove the `will_overwrite` check, allowing composite buffs to evict multiple single-effect buffs in one application, improving the accuracy of buff stacking logic.

### Testing
<img width="775" height="168" alt="image" src="https://github.com/user-attachments/assets/aa8851a3-8016-45d0-a80d-d82f66f779b3" />
<img width="256" height="184" alt="image" src="https://github.com/user-attachments/assets/7a0cfa3f-50cb-49bc-91ca-b630f29c719c" />


*Prior to this PR*

- if you have Resolution in buff slot 1, Shield of Words in buff slot 2 and then cast Aego:
-- Both get overridden. 

Before Aego
<img width="172" height="61" alt="image" src="https://github.com/user-attachments/assets/13aee8c5-37a8-4f9e-9363-e01b53d97e33" />

After Aego
<img width="174" height="63" alt="image" src="https://github.com/user-attachments/assets/94ea470d-8093-484f-8eba-29655941a5d4" />

----------------------------------------
- If you have Shield of Words in buff slot 1 and Resolution in buff slot 2 and then cast Aego: 
-- Only Shield of Words gets overridden.

Before Aego
<img width="177" height="62" alt="image" src="https://github.com/user-attachments/assets/c1e6f902-4243-4c5a-b839-86412b3b5c38" />

After Aego
<img width="176" height="65" alt="image" src="https://github.com/user-attachments/assets/661e6135-9923-4303-a8f8-c6f021da2339" />

----------------------------------------

- If you have Shield of Words in buff slot 1 and Resolution in buff slot 2 and and Symbol of Marzin in buff slot 3 then cast Aego:
-- Shield of Words and Symbol of Marzin get overridden, but not Resolution.

Before Aego
<img width="176" height="64" alt="image" src="https://github.com/user-attachments/assets/4743289a-9e2f-4f8d-af93-d710561080bf" />

After Aego
<img width="180" height="61" alt="image" src="https://github.com/user-attachments/assets/7f8da66a-c4e3-4712-a412-a997039cf92a" />

----------------------------------------

### Test Results

Aegolism reliably overrides Shield of Words, Resolution and Symbol of Marzin.
<img width="164" height="57" alt="image" src="https://github.com/user-attachments/assets/b009660f-a246-43d1-a86a-58e93e7d9400" />


Local unit tests with this PR pass and indicate that this stacking issue should be resolved with this bug fix.