### PR TITLE
[Bug Fix] Fix guild member list refresh

### DIFF
--- a/zone/guild.cpp
+++ b/zone/guild.cpp
@@ -357,7 +357,7 @@ void EntityList::SendGuildMembers(uint32 guild_id)
 	while (it != client_list.end()) {
 		Client *client = it->second;
 		if (client->GuildID() == guild_id) {
-			client->SendGuildMembersList();
+			client->SendGuildMembers();
 		}
 		++it;
 	}

--- a/zone/guild.cpp
+++ b/zone/guild.cpp
@@ -209,7 +209,7 @@ void Client::SendGuildList()
 
 void Client::SendGuildMembers()
 {
-	SendGuildMembersList(GetCleanName());
+	SendGuildMembersList();
 
 	auto pack =
 	    new ServerPacket(ServerOP_RequestOnlineGuildMembers, sizeof(ServerRequestOnlineGuildMembers_Struct));

--- a/zone/guild.cpp
+++ b/zone/guild.cpp
@@ -209,7 +209,7 @@ void Client::SendGuildList()
 
 void Client::SendGuildMembers()
 {
-	SendGuildMembersList();
+	SendGuildMembersList(GetCleanName());
 
 	auto pack =
 	    new ServerPacket(ServerOP_RequestOnlineGuildMembers, sizeof(ServerRequestOnlineGuildMembers_Struct));

--- a/zone/guild.cpp
+++ b/zone/guild.cpp
@@ -207,20 +207,9 @@ void Client::SendGuildList()
 }
 
 
-void Client::SendGuildMembers() {
-	uint32 len;
-	uint8 *data = guild_mgr.MakeGuildMembers(GuildID(), GetName(), len);
-	if(data == nullptr)
-		return;	//invalid guild, shouldent happen.
-
-	auto outapp = new EQApplicationPacket(OP_GuildMemberList);
-	outapp->size = len;
-	outapp->pBuffer = data;
-	data = nullptr;
-
-	LogGuilds("Sending OP_GuildMemberList of length [{}]", outapp->size);
-
-	FastQueuePacket(&outapp);
+void Client::SendGuildMembers()
+{
+	SendGuildMembersList();
 
 	auto pack =
 	    new ServerPacket(ServerOP_RequestOnlineGuildMembers, sizeof(ServerRequestOnlineGuildMembers_Struct));
@@ -233,10 +222,6 @@ void Client::SendGuildMembers() {
 	worldserver.SendPacket(pack);
 
 	safe_delete(pack);
-
-	// We need to send the Guild URL and Channel name again, as sending OP_GuildMemberList appears to clear this information out.
-	SendGuildURL();
-	SendGuildChannel();
 }
 
 void Client::RefreshGuildInfo()
@@ -372,7 +357,7 @@ void EntityList::SendGuildMembers(uint32 guild_id)
 	while (it != client_list.end()) {
 		Client *client = it->second;
 		if (client->GuildID() == guild_id) {
-			//client->SendGuildMembers();
+			client->SendGuildMembersList();
 		}
 		++it;
 	}


### PR DESCRIPTION
This pull request refactors how the guild member list is sent to clients by introducing the use of a new `SendGuildMembersList()` method, replacing the previous inline implementation in `SendGuildMembers()`. The change also removes redundant code that re-sent guild URL and channel information after sending the member list.

### Refactoring of guild member list sending:

* Replaced the inline logic in `Client::SendGuildMembers()` with a call to the new `SendGuildMembersList()` method, simplifying the function and centralizing the member list sending logic.
* Updated `EntityList::SendGuildMembers()` to call `SendGuildMembersList()` on each client in the guild, ensuring consistency with the new approach.

### Removal of redundant operations:

* Removed the repeated sending of guild URL and channel information after sending the guild member list, as this is no longer necessary with the refactored logic.

### Testing
<img width="634" height="435" alt="image" src="https://github.com/user-attachments/assets/e6df1e22-5bdf-4cfb-9b87-2bae2941736d" />

Guild members are now appearing reliably in the guild list UI. 