### PR TITLE
[Feature] Add #discover & #undiscover commands for manual item discovery

### DIFF
--- a/common/repositories/discovered_items_repository.h
+++ b/common/repositories/discovered_items_repository.h
@@ -44,5 +44,25 @@ public:
      */
 
 	// Custom extended repository methods here
+	static bool InsertIgnore(Database& db, const DiscoveredItems &e)
+	{
+		std::vector<std::string> v;
+
+		v.push_back(std::to_string(e.item_id));
+		v.push_back("'" + Strings::Escape(e.char_name) + "'");
+		v.push_back(std::to_string(e.discovered_date));
+		v.push_back(std::to_string(e.account_status));
+
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"INSERT IGNORE INTO {} ({}) VALUES ({})",
+				TableName(),
+				ColumnsRaw(),
+				Strings::Implode(",", v)
+			)
+		);
+
+		return results.Success() && results.RowsAffected() > 0;
+	}
 
 };

--- a/zone/CMakeLists.txt
+++ b/zone/CMakeLists.txt
@@ -394,6 +394,7 @@ set(gm_command_sources
     gm_commands/depop.cpp
     gm_commands/depopzone.cpp
     gm_commands/devtools.cpp
+    gm_commands/discover.cpp
     gm_commands/disablerecipe.cpp
     gm_commands/disarmtrap.cpp
     gm_commands/doanim.cpp

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -4992,7 +4992,8 @@ bool Client::IsDiscovered(uint32 item_id)
 	return true;
 }
 
-void Client::DiscoverItem(uint32 item_id) {
+bool Client::DiscoverItem(uint32 item_id)
+{
 	auto e = DiscoveredItemsRepository::NewEntity();
 
 	e.account_status = Admin();
@@ -5000,14 +5001,18 @@ void Client::DiscoverItem(uint32 item_id) {
 	e.discovered_date = std::time(nullptr);
 	e.item_id = item_id;
 
-	auto d = DiscoveredItemsRepository::InsertOne(database, e);
+	if (!DiscoveredItemsRepository::InsertIgnore(database, e)) {
+		return false;
+	}
+
+	zone->discovered_items.emplace_back(item_id);
 
 	if (PlayerEventLogs::Instance()->IsEventEnabled(PlayerEvent::DISCOVER_ITEM)) {
 		const auto* item = database.GetItem(item_id);
 
 		auto e = PlayerEvent::DiscoverItemEvent{
 			.item_id = item_id,
-			.item_name = item->Name,
+			.item_name = item ? item->Name : "",
 		};
 		RecordPlayerEventLog(PlayerEvent::DISCOVER_ITEM, e);
 
@@ -5019,6 +5024,8 @@ void Client::DiscoverItem(uint32 item_id) {
 
 		parse->EventPlayer(EVENT_DISCOVER_ITEM, this, "", item_id, &args);
 	}
+
+	return true;
 }
 
 void Client::CheckItemDiscoverability(EQ::ItemInstance* inst)

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -5028,6 +5028,25 @@ bool Client::DiscoverItem(uint32 item_id)
 	return true;
 }
 
+bool Client::UndiscoverItem(uint32 item_id)
+{
+	const bool deleted = DiscoveredItemsRepository::DeleteOne(database, item_id) > 0;
+	if (!deleted) {
+		return false;
+	}
+
+	zone->discovered_items.erase(
+		std::remove(
+			zone->discovered_items.begin(),
+			zone->discovered_items.end(),
+			item_id
+		),
+		zone->discovered_items.end()
+	);
+
+	return true;
+}
+
 void Client::CheckItemDiscoverability(EQ::ItemInstance* inst)
 {
 	if (!RuleB(Character, EnableDiscoveredItems) || !inst || !inst->GetItem()) {

--- a/zone/client.h
+++ b/zone/client.h
@@ -964,7 +964,7 @@ public:
 	void SendPath(Mob* target);
 
 	bool IsDiscovered(uint32 itemid);
-	void DiscoverItem(uint32 itemid);
+	bool DiscoverItem(uint32 itemid);
 	void CheckItemDiscoverability(EQ::ItemInstance* inst);
 
 	bool TGB() const { return tgb; }

--- a/zone/client.h
+++ b/zone/client.h
@@ -965,6 +965,7 @@ public:
 
 	bool IsDiscovered(uint32 itemid);
 	bool DiscoverItem(uint32 itemid);
+	bool UndiscoverItem(uint32 itemid);
 	void CheckItemDiscoverability(EQ::ItemInstance* inst);
 
 	bool TGB() const { return tgb; }

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -106,7 +106,7 @@ int command_init(void)
 		command_add("depop", "[Start Spawn Timer] - Depop your NPC target and optionally start their spawn timer (false by default)", AccountStatus::Guide, command_depop) ||
 		command_add("depopzone", "[Start Spawn Timers] - Depop the zone and optionally start spawn timers (false by default)", AccountStatus::GMAdmin, command_depopzone) ||
 		command_add("devtools", "[menu|window] [enable|disable] - Manages Developer Tools (send no parameter for menu)", AccountStatus::GMMgmt, command_devtools) ||
-		command_add("discover", "Discovers the item on your cursor.", AccountStatus::GMMgmt, command_discover) ||
+		command_add("discover", "[Item ID] - Discovers the item on your cursor or the specified item ID.", AccountStatus::GMMgmt, command_discover) ||
 		command_add("disablerecipe", "[Recipe ID] - Disables a Recipe", AccountStatus::QuestTroupe, command_disablerecipe) ||
 		command_add("disarmtrap", "Analog for ldon disarm trap for the newer clients since we still don't have it working.", AccountStatus::QuestTroupe, command_disarmtrap) ||
 		command_add("door", "Door editing command", AccountStatus::QuestTroupe, command_door) ||
@@ -225,6 +225,7 @@ int command_init(void)
 		command_add("traindisc", "[level] - Trains all the disciplines usable by the target, up to level specified. (may freeze client for a few seconds)", AccountStatus::GMLeadAdmin, command_traindisc) ||
 		command_add("tune", "Calculate statistical values related to combat.", AccountStatus::GMAdmin, command_tune) ||
 		command_add("undye", "Remove dye from all of your or your target's armor slots", AccountStatus::GMAdmin, command_undye) ||
+		command_add("undiscover", "[Item ID] - Removes the item on your cursor or the specified item ID from discovered items.", AccountStatus::GMMgmt, command_undiscover) ||
 		command_add("unmemspell", "[Spell ID] - Unmemorize a Spell by ID for you or your target", AccountStatus::Guide, command_unmemspell) ||
 		command_add("unmemspells", " Unmemorize all spells for you or your target", AccountStatus::Guide, command_unmemspells) ||
 		command_add("unscribespell", "[Spell ID] - Unscribe a spell from your or your target's spell book by Spell ID", AccountStatus::GMCoder, command_unscribespell) ||

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -106,6 +106,7 @@ int command_init(void)
 		command_add("depop", "[Start Spawn Timer] - Depop your NPC target and optionally start their spawn timer (false by default)", AccountStatus::Guide, command_depop) ||
 		command_add("depopzone", "[Start Spawn Timers] - Depop the zone and optionally start spawn timers (false by default)", AccountStatus::GMAdmin, command_depopzone) ||
 		command_add("devtools", "[menu|window] [enable|disable] - Manages Developer Tools (send no parameter for menu)", AccountStatus::GMMgmt, command_devtools) ||
+		command_add("discover", "Discovers the item on your cursor.", AccountStatus::GMMgmt, command_discover) ||
 		command_add("disablerecipe", "[Recipe ID] - Disables a Recipe", AccountStatus::QuestTroupe, command_disablerecipe) ||
 		command_add("disarmtrap", "Analog for ldon disarm trap for the newer clients since we still don't have it working.", AccountStatus::QuestTroupe, command_disarmtrap) ||
 		command_add("door", "Door editing command", AccountStatus::QuestTroupe, command_door) ||

--- a/zone/command.h
+++ b/zone/command.h
@@ -183,6 +183,7 @@ void command_petname(Client *c, const Seperator *sep);
 void command_traindisc(Client *c, const Seperator *sep);
 void command_tune(Client *c, const Seperator *sep);
 void command_undye(Client *c, const Seperator *sep);
+void command_undiscover(Client *c, const Seperator *sep);
 void command_unmemspell(Client *c, const Seperator *sep);
 void command_unmemspells(Client *c, const Seperator *sep);
 void command_unscribespell(Client *c, const Seperator *sep);

--- a/zone/command.h
+++ b/zone/command.h
@@ -68,6 +68,7 @@ void command_delpetition(Client *c, const Seperator *sep);
 void command_depop(Client *c, const Seperator *sep);
 void command_depopzone(Client *c, const Seperator *sep);
 void command_devtools(Client *c, const Seperator *sep);
+void command_discover(Client *c, const Seperator *sep);
 void command_disablerecipe(Client *c, const Seperator *sep);
 void command_disarmtrap(Client *c, const Seperator *sep);
 void command_door(Client *c, const Seperator *sep);

--- a/zone/gm_commands/discover.cpp
+++ b/zone/gm_commands/discover.cpp
@@ -188,11 +188,8 @@ void command_discover(Client *c, const Seperator *sep)
 		c->Message(
 			Chat::Red,
 			fmt::format(
-				"#discover partially failed for {}: {} new, {} already discovered, {} failed.",
-				item_ref.item_link,
-				counts.changed,
-				counts.unchanged,
-				counts.failed
+				"#discover failed for {}. Some item discoveries could not be completed.",
+				item_ref.item_link
 			).c_str()
 		);
 		return;
@@ -202,10 +199,8 @@ void command_discover(Client *c, const Seperator *sep)
 		c->Message(
 			Chat::Red,
 			fmt::format(
-				"#discover found no new discoveries for {}: {} item{} already discovered.",
-				item_ref.item_link,
-				counts.unchanged,
-				counts.unchanged == 1 ? " was" : "s were"
+				"#discover failed for {}. It was already marked discovered.",
+				item_ref.item_link
 			).c_str()
 		);
 		return;
@@ -214,11 +209,8 @@ void command_discover(Client *c, const Seperator *sep)
 	c->Message(
 		Chat::Green,
 		fmt::format(
-			"#discover succeeded for {}: {} new item{} discovered, {} already discovered.",
-			item_ref.item_link,
-			counts.changed,
-			counts.changed == 1 ? "" : "s",
-			counts.unchanged
+			"#discover succeeded for {}. It has now been marked discovered by you.",
+			item_ref.item_link
 		).c_str()
 	);
 }
@@ -236,11 +228,8 @@ void command_undiscover(Client *c, const Seperator *sep)
 		c->Message(
 			Chat::Red,
 			fmt::format(
-				"#undiscover partially failed for {}: {} removed, {} not discovered, {} failed.",
-				item_ref.item_link,
-				counts.changed,
-				counts.unchanged,
-				counts.failed
+				"#undiscover failed for {}. Some item discoveries could not be removed.",
+				item_ref.item_link
 			).c_str()
 		);
 		return;
@@ -250,10 +239,8 @@ void command_undiscover(Client *c, const Seperator *sep)
 		c->Message(
 			Chat::Red,
 			fmt::format(
-				"#undiscover found no discoveries to remove for {}: {} item{} not discovered.",
-				item_ref.item_link,
-				counts.unchanged,
-				counts.unchanged == 1 ? " was" : "s were"
+				"#undiscover failed for {}. It was not marked discovered.",
+				item_ref.item_link
 			).c_str()
 		);
 		return;
@@ -262,11 +249,8 @@ void command_undiscover(Client *c, const Seperator *sep)
 	c->Message(
 		Chat::Green,
 		fmt::format(
-			"#undiscover succeeded for {}: {} item{} removed from discovered items, {} not discovered.",
-			item_ref.item_link,
-			counts.changed,
-			counts.changed == 1 ? "" : "s",
-			counts.unchanged
+			"#undiscover succeeded for {}. It is no longer marked discovered.",
+			item_ref.item_link
 		).c_str()
 	);
 }

--- a/zone/gm_commands/discover.cpp
+++ b/zone/gm_commands/discover.cpp
@@ -5,10 +5,17 @@
 #include <unordered_set>
 
 namespace {
-	struct DiscoveryCounts {
-		uint32 discovered = 0;
-		uint32 already_discovered = 0;
+	struct OperationCounts {
+		uint32 changed = 0;
+		uint32 unchanged = 0;
 		uint32 failed = 0;
+	};
+
+	struct ItemReference {
+		uint32 item_id = 0;
+		EQ::ItemInstance *instance = nullptr;
+		std::string item_link;
+		bool from_argument = false;
 	};
 
 	std::string GetItemLink(EQ::ItemInstance *inst)
@@ -20,11 +27,75 @@ namespace {
 		return linker.GenerateLink();
 	}
 
+	bool ResolveItemReference(Client *c, const Seperator *sep, const char *command_name, ItemReference &item_ref)
+	{
+		if (sep->argnum >= 1 && sep->arg[1][0]) {
+			if (!sep->IsNumber(1)) {
+				c->Message(
+					Chat::Red,
+					fmt::format(
+						"#{} failed: item ID argument [{}] is not numeric.",
+						command_name,
+						sep->arg[1]
+					).c_str()
+				);
+				return false;
+			}
+
+			item_ref.item_id = Strings::ToUnsignedInt(sep->arg[1]);
+			item_ref.from_argument = true;
+
+			const auto *item = database.GetItem(item_ref.item_id);
+			if (!item) {
+				c->Message(
+					Chat::Red,
+					fmt::format(
+						"#{} failed: item ID {} does not exist.",
+						command_name,
+						item_ref.item_id
+					).c_str()
+				);
+				return false;
+			}
+
+			item_ref.item_link = database.CreateItemLink(item_ref.item_id);
+			return true;
+		}
+
+		item_ref.instance = c->GetInv().GetItem(EQ::invslot::slotCursor);
+		if (!item_ref.instance) {
+			c->Message(
+				Chat::Red,
+				fmt::format(
+					"#{} failed: no item found on your cursor.",
+					command_name
+				).c_str()
+			);
+			return false;
+		}
+
+		if (!item_ref.instance->GetItem()) {
+			c->Message(
+				Chat::Red,
+				fmt::format(
+					"#{} failed: cursor item ID {} has no item data.",
+					command_name,
+					item_ref.instance->GetID()
+				).c_str()
+			);
+			return false;
+		}
+
+		item_ref.item_id = item_ref.instance->GetID();
+		item_ref.item_link = GetItemLink(item_ref.instance);
+		return true;
+	}
+
 	void DiscoverSingleItem(
 		Client *c,
 		uint32 item_id,
 		std::unordered_set<uint32> &seen_items,
-		DiscoveryCounts &counts
+		OperationCounts &counts
 	)
 	{
 		if (!item_id || !seen_items.emplace(item_id).second) {
@@ -32,86 +103,109 @@ namespace {
 		}
 
 		if (c->IsDiscovered(item_id)) {
-			counts.already_discovered++;
+			counts.unchanged++;
 		} else if (c->DiscoverItem(item_id)) {
-			counts.discovered++;
+			counts.changed++;
 		} else if (c->IsDiscovered(item_id)) {
-			counts.already_discovered++;
+			counts.unchanged++;
 		} else {
 			counts.failed++;
 		}
 	}
 
-	void DiscoverItemTree(
+	void UndiscoverSingleItem(
+		Client *c,
+		uint32 item_id,
+		std::unordered_set<uint32> &seen_items,
+		OperationCounts &counts
+	)
+	{
+		if (!item_id || !seen_items.emplace(item_id).second) {
+			return;
+		}
+
+		if (!c->IsDiscovered(item_id)) {
+			counts.unchanged++;
+		} else if (c->UndiscoverItem(item_id)) {
+			counts.changed++;
+		} else if (!c->IsDiscovered(item_id)) {
+			counts.changed++;
+		} else {
+			counts.failed++;
+		}
+	}
+
+	template <typename Operation>
+	void ProcessItemTree(
 		Client *c,
 		EQ::ItemInstance *inst,
 		std::unordered_set<uint32> &seen_items,
-		DiscoveryCounts &counts
+		OperationCounts &counts,
+		Operation operation
 	)
 	{
 		if (!inst || !inst->GetItem()) {
 			return;
 		}
 
-		DiscoverSingleItem(c, inst->GetID(), seen_items, counts);
+		operation(c, inst->GetID(), seen_items, counts);
 
 		for (const auto item_id : inst->GetAugmentIDs()) {
-			DiscoverSingleItem(c, item_id, seen_items, counts);
+			operation(c, item_id, seen_items, counts);
 		}
 
 		for (const auto &[_, content_inst] : *inst->GetContents()) {
-			DiscoverItemTree(c, content_inst, seen_items, counts);
+			ProcessItemTree(c, content_inst, seen_items, counts, operation);
 		}
+	}
+
+	template <typename Operation>
+	OperationCounts ProcessItemReference(Client *c, const ItemReference &item_ref, Operation operation)
+	{
+		std::unordered_set<uint32> seen_items;
+		OperationCounts counts;
+
+		if (item_ref.from_argument) {
+			operation(c, item_ref.item_id, seen_items, counts);
+			return counts;
+		}
+
+		ProcessItemTree(c, item_ref.instance, seen_items, counts, operation);
+		return counts;
 	}
 }
 
 void command_discover(Client *c, const Seperator *sep)
 {
-	auto *cursor_item = c->GetInv().GetItem(EQ::invslot::slotCursor);
-	if (!cursor_item) {
-		c->Message(Chat::Red, "#discover failed: no item found on your cursor.");
+	ItemReference item_ref;
+	if (!ResolveItemReference(c, sep, "discover", item_ref)) {
 		return;
 	}
 
-	if (!cursor_item->GetItem()) {
-		c->Message(
-			Chat::Red,
-			fmt::format(
-				"#discover failed: cursor item ID {} has no item data.",
-				cursor_item->GetID()
-			).c_str()
-		);
-		return;
-	}
-
-	const std::string item_link = GetItemLink(cursor_item);
-
-	std::unordered_set<uint32> seen_items;
-	DiscoveryCounts counts;
-	DiscoverItemTree(c, cursor_item, seen_items, counts);
+	const OperationCounts counts = ProcessItemReference(c, item_ref, DiscoverSingleItem);
 
 	if (counts.failed) {
 		c->Message(
 			Chat::Red,
 			fmt::format(
 				"#discover partially failed for {}: {} new, {} already discovered, {} failed.",
-				item_link,
-				counts.discovered,
-				counts.already_discovered,
+				item_ref.item_link,
+				counts.changed,
+				counts.unchanged,
 				counts.failed
 			).c_str()
 		);
 		return;
 	}
 
-	if (!counts.discovered) {
+	if (!counts.changed) {
 		c->Message(
 			Chat::Red,
 			fmt::format(
 				"#discover found no new discoveries for {}: {} item{} already discovered.",
-				item_link,
-				counts.already_discovered,
-				counts.already_discovered == 1 ? " was" : "s were"
+				item_ref.item_link,
+				counts.unchanged,
+				counts.unchanged == 1 ? " was" : "s were"
 			).c_str()
 		);
 		return;
@@ -121,10 +215,58 @@ void command_discover(Client *c, const Seperator *sep)
 		Chat::Green,
 		fmt::format(
 			"#discover succeeded for {}: {} new item{} discovered, {} already discovered.",
-			item_link,
-			counts.discovered,
-			counts.discovered == 1 ? "" : "s",
-			counts.already_discovered
+			item_ref.item_link,
+			counts.changed,
+			counts.changed == 1 ? "" : "s",
+			counts.unchanged
+		).c_str()
+	);
+}
+
+void command_undiscover(Client *c, const Seperator *sep)
+{
+	ItemReference item_ref;
+	if (!ResolveItemReference(c, sep, "undiscover", item_ref)) {
+		return;
+	}
+
+	const OperationCounts counts = ProcessItemReference(c, item_ref, UndiscoverSingleItem);
+
+	if (counts.failed) {
+		c->Message(
+			Chat::Red,
+			fmt::format(
+				"#undiscover partially failed for {}: {} removed, {} not discovered, {} failed.",
+				item_ref.item_link,
+				counts.changed,
+				counts.unchanged,
+				counts.failed
+			).c_str()
+		);
+		return;
+	}
+
+	if (!counts.changed) {
+		c->Message(
+			Chat::Red,
+			fmt::format(
+				"#undiscover found no discoveries to remove for {}: {} item{} not discovered.",
+				item_ref.item_link,
+				counts.unchanged,
+				counts.unchanged == 1 ? " was" : "s were"
+			).c_str()
+		);
+		return;
+	}
+
+	c->Message(
+		Chat::Green,
+		fmt::format(
+			"#undiscover succeeded for {}: {} item{} removed from discovered items, {} not discovered.",
+			item_ref.item_link,
+			counts.changed,
+			counts.changed == 1 ? "" : "s",
+			counts.unchanged
 		).c_str()
 	);
 }

--- a/zone/gm_commands/discover.cpp
+++ b/zone/gm_commands/discover.cpp
@@ -1,0 +1,130 @@
+#include "zone/client.h"
+
+#include "fmt/format.h"
+
+#include <unordered_set>
+
+namespace {
+	struct DiscoveryCounts {
+		uint32 discovered = 0;
+		uint32 already_discovered = 0;
+		uint32 failed = 0;
+	};
+
+	std::string GetItemLink(EQ::ItemInstance *inst)
+	{
+		EQ::SayLinkEngine linker;
+		linker.SetLinkType(EQ::saylink::SayLinkItemInst);
+		linker.SetItemInst(inst);
+
+		return linker.GenerateLink();
+	}
+
+	void DiscoverSingleItem(
+		Client *c,
+		uint32 item_id,
+		std::unordered_set<uint32> &seen_items,
+		DiscoveryCounts &counts
+	)
+	{
+		if (!item_id || !seen_items.emplace(item_id).second) {
+			return;
+		}
+
+		if (c->IsDiscovered(item_id)) {
+			counts.already_discovered++;
+		} else if (c->DiscoverItem(item_id)) {
+			counts.discovered++;
+		} else if (c->IsDiscovered(item_id)) {
+			counts.already_discovered++;
+		} else {
+			counts.failed++;
+		}
+	}
+
+	void DiscoverItemTree(
+		Client *c,
+		EQ::ItemInstance *inst,
+		std::unordered_set<uint32> &seen_items,
+		DiscoveryCounts &counts
+	)
+	{
+		if (!inst || !inst->GetItem()) {
+			return;
+		}
+
+		DiscoverSingleItem(c, inst->GetID(), seen_items, counts);
+
+		for (const auto item_id : inst->GetAugmentIDs()) {
+			DiscoverSingleItem(c, item_id, seen_items, counts);
+		}
+
+		for (const auto &[_, content_inst] : *inst->GetContents()) {
+			DiscoverItemTree(c, content_inst, seen_items, counts);
+		}
+	}
+}
+
+void command_discover(Client *c, const Seperator *sep)
+{
+	auto *cursor_item = c->GetInv().GetItem(EQ::invslot::slotCursor);
+	if (!cursor_item) {
+		c->Message(Chat::Red, "#discover failed: no item found on your cursor.");
+		return;
+	}
+
+	if (!cursor_item->GetItem()) {
+		c->Message(
+			Chat::Red,
+			fmt::format(
+				"#discover failed: cursor item ID {} has no item data.",
+				cursor_item->GetID()
+			).c_str()
+		);
+		return;
+	}
+
+	const std::string item_link = GetItemLink(cursor_item);
+
+	std::unordered_set<uint32> seen_items;
+	DiscoveryCounts counts;
+	DiscoverItemTree(c, cursor_item, seen_items, counts);
+
+	if (counts.failed) {
+		c->Message(
+			Chat::Red,
+			fmt::format(
+				"#discover partially failed for {}: {} new, {} already discovered, {} failed.",
+				item_link,
+				counts.discovered,
+				counts.already_discovered,
+				counts.failed
+			).c_str()
+		);
+		return;
+	}
+
+	if (!counts.discovered) {
+		c->Message(
+			Chat::Red,
+			fmt::format(
+				"#discover found no new discoveries for {}: {} item{} already discovered.",
+				item_link,
+				counts.already_discovered,
+				counts.already_discovered == 1 ? " was" : "s were"
+			).c_str()
+		);
+		return;
+	}
+
+	c->Message(
+		Chat::Green,
+		fmt::format(
+			"#discover succeeded for {}: {} new item{} discovered, {} already discovered.",
+			item_link,
+			counts.discovered,
+			counts.discovered == 1 ? "" : "s",
+			counts.already_discovered
+		).c_str()
+	);
+}


### PR DESCRIPTION
## Summary
- Adds a new `#discover [item_id]` GM command for manually adding discovered item entries.
- Adds a matching `#undiscover [item_id]` GM command for removing discovered item entries.
- Both commands support either an explicit item ID argument or the item on the user's cursor; when both are present, the item ID argument takes priority.
- Cursor-based usage processes the full cursor item tree, including augments and bag contents; item ID usage affects only the specified item.
- Keeps normal automatic discovery rules unchanged while making these commands explicit GM actions.
- Uses concise green success feedback and red failure/no-op feedback with item links, without count-heavy confirmation text.

## Tests

Success
<img width="437" height="43" alt="image" src="https://github.com/user-attachments/assets/778b87aa-9ba1-4302-9b35-dd4f04951370" />

Failure
<img width="446" height="30" alt="image" src="https://github.com/user-attachments/assets/c5e9775d-00d7-4b6a-a62a-2c95da3848b1" />

## Validation
- `git diff --check`
- `cmake --build build-codex --target zone --config Debug`
- `cmake --build build-codex --target tests --config Debug`
- `./build-codex/bin/Debug/tests.exe` (90 tests, 100% correct)
- `cmake --build build-codex --target zone --config Release`
- `$emu-compile` linux-test build and deploy to `C:\AkkStack\server\bin`