### PR TITLE
[Feature] Add Perl encounter support

### DIFF
--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -1017,11 +1017,15 @@ void PerlembParser::UnregisterEncounterEvent(
 		encounter_name = quest_manager.GetEncounter();
 	}
 
+	if (encounter_name.empty()) {
+		return;
+	}
+
 	auto remove_from_list = [&](auto& events) {
 		auto iter = events.begin();
 		while (iter != events.end()) {
 			if (
-				(iter->encounter_name == encounter_name || encounter_name.empty()) &&
+				iter->encounter_name == encounter_name &&
 				(event_id < 0 || iter->event_id == static_cast<QuestEventID>(event_id))
 			) {
 				iter = events.erase(iter);

--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -920,9 +920,18 @@ int PerlembParser::EventEncounter(
 	ExportVar(package_name.c_str(), "encounter_name", encounter_name.c_str());
 	ExportVar(package_name.c_str(), "data", "");
 	ExportVar(package_name.c_str(), "timer", "");
+	ExportVar(package_name.c_str(), "duration", "");
 
-	if (event_id == EVENT_TIMER) {
+	if (event_id == EVENT_TIMER || event_id == EVENT_TIMER_STOP) {
 		ExportVar(package_name.c_str(), "timer", data.c_str());
+	} else if (
+		event_id == EVENT_TIMER_PAUSE ||
+		event_id == EVENT_TIMER_RESUME ||
+		event_id == EVENT_TIMER_START
+	) {
+		Seperator sep(data.c_str());
+		ExportVar(package_name.c_str(), "timer", sep.arg[0]);
+		ExportVar(package_name.c_str(), "duration", sep.arg[1]);
 	} else if (
 		(event_id == EVENT_ENCOUNTER_LOAD || event_id == EVENT_ENCOUNTER_UNLOAD) &&
 		extra_pointers &&

--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -1069,6 +1069,7 @@ void PerlembParser::UnregisterEncounterEvent(
 void PerlembParser::RemoveEncounter(const std::string& name)
 {
 	UnregisterEncounterEvent("", name, -1);
+	encounter_quest_status_.erase(name);
 }
 
 int PerlembParser::DispatchEncounterRegisteredEvents(

--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -23,12 +23,15 @@
 #include "common/seperator.h"
 #include "common/strings.h"
 #include "zone/embparser.h"
+#include "zone/encounter.h"
 #include "zone/masterentity.h"
 #include "zone/qglobals.h"
 #include "zone/questmgr.h"
 #include "zone/zone.h"
 
 #include <algorithm>
+#include <cctype>
+#include <functional>
 #include <sstream>
 
 extern Zone* zone;
@@ -216,8 +219,12 @@ const char* QuestEventSubroutines[_LargestEventID] = {
 	"EVENT_SPELL_EFFECT_BUFF_TIC_BOT"
 };
 
+PerlembParser* PerlembParser::instance_ = nullptr;
+
 PerlembParser::PerlembParser() : perl(nullptr)
 {
+	instance_ = this;
+
 	global_npc_quest_status_    = questUnloaded;
 	player_quest_status_        = questUnloaded;
 	global_player_quest_status_ = questUnloaded;
@@ -231,6 +238,10 @@ PerlembParser::PerlembParser() : perl(nullptr)
 
 PerlembParser::~PerlembParser()
 {
+	if (instance_ == this) {
+		instance_ = nullptr;
+	}
+
 	safe_delete(perl);
 }
 
@@ -275,6 +286,8 @@ void PerlembParser::ReloadQuests()
 
 	item_quest_status_.clear();
 	spell_quest_status_.clear();
+	encounter_quest_status_.clear();
+	perl_encounter_events_registered_.clear();
 }
 
 int PerlembParser::EventCommon(
@@ -822,6 +835,651 @@ void PerlembParser::LoadSpellScript(std::string filename, uint32 spell_id)
 	spell_quest_status_[spell_id] = questLoaded;
 }
 
+void PerlembParser::LoadEncounterScript(std::string filename, std::string encounter_name)
+{
+	if (!perl) {
+		return;
+	}
+
+	auto iter = encounter_quest_status_.find(encounter_name);
+	if (iter != encounter_quest_status_.end()) {
+		return;
+	}
+
+	std::string package_name = GetEncounterPackageName(encounter_name);
+
+	try {
+		perl->eval_file(package_name.c_str(), filename.c_str());
+	} catch (std::string e) {
+		AddError(
+			fmt::format(
+				"Error Compiling Encounter Quest File [{}] Encounter [{}] Error [{}]",
+				filename,
+				encounter_name,
+				e
+			)
+		);
+
+		encounter_quest_status_[encounter_name] = questFailedToLoad;
+		return;
+	}
+
+	encounter_quest_status_[encounter_name] = questLoaded;
+}
+
+bool PerlembParser::EncounterHasQuestSub(std::string encounter_name, QuestEventID event_id)
+{
+	if (!perl || event_id >= _LargestEventID) {
+		return false;
+	}
+
+	auto iter = encounter_quest_status_.find(encounter_name);
+	if (iter == encounter_quest_status_.end() || iter->second != questLoaded) {
+		return false;
+	}
+
+	std::string package_name = GetEncounterPackageName(encounter_name);
+	return perl->SubExists(package_name.c_str(), QuestEventSubroutines[event_id]);
+}
+
+bool PerlembParser::HasEncounterSub(const std::string& package_name, QuestEventID event_id)
+{
+	auto iter = perl_encounter_events_registered_.find(package_name);
+	if (iter == perl_encounter_events_registered_.end()) {
+		return false;
+	}
+
+	for (const auto& registered_event : iter->second) {
+		if (
+			registered_event.event_id == event_id &&
+			parse->IsEncounterLoaded(registered_event.encounter_name) &&
+			!parse->IsEncounterUnloading(registered_event.encounter_name)
+		) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+int PerlembParser::EventEncounter(
+	QuestEventID event_id,
+	std::string encounter_name,
+	std::string data,
+	uint32 extra_data,
+	std::vector<std::any>* extra_pointers
+)
+{
+	if (!perl || event_id >= _LargestEventID || !EncounterHasQuestSub(encounter_name, event_id)) {
+		return 0;
+	}
+
+	std::string package_name = GetEncounterPackageName(encounter_name);
+
+	ExportVar(package_name.c_str(), "name", encounter_name.c_str());
+	ExportVar(package_name.c_str(), "encounter_name", encounter_name.c_str());
+	ExportVar(package_name.c_str(), "data", "");
+	ExportVar(package_name.c_str(), "timer", "");
+
+	if (event_id == EVENT_TIMER) {
+		ExportVar(package_name.c_str(), "timer", data.c_str());
+	} else if (
+		(event_id == EVENT_ENCOUNTER_LOAD || event_id == EVENT_ENCOUNTER_UNLOAD) &&
+		extra_pointers &&
+		!extra_pointers->empty()
+	) {
+		auto* str = std::any_cast<std::string*>(extra_pointers->at(0));
+		ExportVar(package_name.c_str(), "data", str ? str->c_str() : "");
+	}
+
+	if (parse->perl_event_export_settings[event_id].zone) {
+		ExportZoneVariables(package_name);
+	}
+
+	auto* encounter = GetLoadedEncounter(encounter_name);
+	if (encounter) {
+		ExportVar(package_name.c_str(), "encounter", "Mob", encounter);
+	}
+
+	return SendCommands(
+		package_name.c_str(),
+		QuestEventSubroutines[event_id],
+		0,
+		encounter,
+		nullptr,
+		nullptr,
+		nullptr,
+		nullptr,
+		encounter_name
+	);
+}
+
+void PerlembParser::LoadEncounter(std::string encounter_name)
+{
+	parse->LoadEncounter(encounter_name);
+}
+
+void PerlembParser::LoadEncounterWithData(std::string encounter_name, std::string data)
+{
+	parse->LoadEncounterWithData(encounter_name, data);
+}
+
+void PerlembParser::UnloadEncounter(std::string encounter_name)
+{
+	parse->UnloadEncounter(encounter_name);
+}
+
+void PerlembParser::UnloadEncounterWithData(std::string encounter_name, std::string data)
+{
+	parse->UnloadEncounterWithData(encounter_name, data);
+}
+
+void PerlembParser::RegisterEncounterEvent(
+	std::string package_name,
+	std::string encounter_name,
+	int event_id,
+	std::string sub_name
+)
+{
+	if (event_id < 0 || event_id >= _LargestEventID || sub_name.empty()) {
+		return;
+	}
+
+	if (encounter_name.empty()) {
+		encounter_name = quest_manager.GetEncounter();
+	}
+
+	if (
+		encounter_name.empty() ||
+		!parse->IsEncounterLoaded(encounter_name) ||
+		parse->IsEncounterUnloading(encounter_name)
+	) {
+		return;
+	}
+
+	UnregisterEncounterEvent(package_name, encounter_name, event_id);
+
+	PerlRegisteredEvent registered_event;
+	registered_event.encounter_name = encounter_name;
+	registered_event.sub_name       = sub_name;
+	registered_event.event_id       = static_cast<QuestEventID>(event_id);
+
+	perl_encounter_events_registered_[package_name].push_back(registered_event);
+}
+
+void PerlembParser::UnregisterEncounterEvent(
+	std::string package_name,
+	std::string encounter_name,
+	int event_id
+)
+{
+	if (encounter_name.empty()) {
+		encounter_name = quest_manager.GetEncounter();
+	}
+
+	auto remove_from_list = [&](auto& events) {
+		auto iter = events.begin();
+		while (iter != events.end()) {
+			if (
+				(iter->encounter_name == encounter_name || encounter_name.empty()) &&
+				(event_id < 0 || iter->event_id == static_cast<QuestEventID>(event_id))
+			) {
+				iter = events.erase(iter);
+			} else {
+				++iter;
+			}
+		}
+	};
+
+	if (!package_name.empty()) {
+		auto iter = perl_encounter_events_registered_.find(package_name);
+		if (iter != perl_encounter_events_registered_.end()) {
+			remove_from_list(iter->second);
+			if (iter->second.empty()) {
+				perl_encounter_events_registered_.erase(iter);
+			}
+		}
+		return;
+	}
+
+	auto iter = perl_encounter_events_registered_.begin();
+	while (iter != perl_encounter_events_registered_.end()) {
+		remove_from_list(iter->second);
+		if (iter->second.empty()) {
+			iter = perl_encounter_events_registered_.erase(iter);
+		} else {
+			++iter;
+		}
+	}
+}
+
+void PerlembParser::RemoveEncounter(const std::string& name)
+{
+	UnregisterEncounterEvent("", name, -1);
+}
+
+int PerlembParser::DispatchEncounterRegisteredEvents(
+	const std::string& package_name,
+	QuestEventID event_id,
+	uint32 object_id,
+	const char* data,
+	Mob* npc_mob,
+	EQ::ItemInstance* inst,
+	const SPDat_Spell_Struct* spell,
+	Mob* mob,
+	Zone* zone,
+	uint32 extra_data,
+	std::vector<std::any>* extra_pointers
+)
+{
+	if (!perl || event_id >= _LargestEventID) {
+		return 0;
+	}
+
+	auto iter = perl_encounter_events_registered_.find(package_name);
+	if (iter == perl_encounter_events_registered_.end()) {
+		return 0;
+	}
+
+	const auto registered_events = iter->second;
+	int ret = 0;
+
+	for (const auto& registered_event : registered_events) {
+		if (registered_event.event_id != event_id) {
+			continue;
+		}
+
+		if (
+			!parse->IsEncounterLoaded(registered_event.encounter_name) ||
+			parse->IsEncounterUnloading(registered_event.encounter_name)
+		) {
+			continue;
+		}
+
+		auto status_iter = encounter_quest_status_.find(registered_event.encounter_name);
+		if (status_iter == encounter_quest_status_.end() || status_iter->second != questLoaded) {
+			continue;
+		}
+
+		std::string encounter_package_name = GetEncounterPackageName(registered_event.encounter_name);
+		if (!perl->SubExists(encounter_package_name.c_str(), registered_event.sub_name.c_str())) {
+			continue;
+		}
+
+		QuestType quest_type = GetQuestTypes(
+			event_id,
+			npc_mob,
+			inst,
+			mob,
+			zone,
+			false
+		);
+
+		int char_id = 0;
+		ExportCharID(encounter_package_name, char_id, npc_mob, mob);
+
+		if (parse->perl_event_export_settings[event_id].qglobals) {
+			ExportQGlobals(
+				quest_type,
+				encounter_package_name,
+				npc_mob,
+				mob,
+				char_id
+			);
+		}
+
+		if (parse->perl_event_export_settings[event_id].mob) {
+			ExportMobVariables(
+				quest_type,
+				encounter_package_name,
+				mob,
+				npc_mob
+			);
+		}
+
+		if (parse->perl_event_export_settings[event_id].zone) {
+			ExportZoneVariables(encounter_package_name);
+		}
+
+		if (parse->perl_event_export_settings[event_id].item) {
+			ExportItemVariables(encounter_package_name, mob);
+		}
+
+		if (parse->perl_event_export_settings[event_id].event_variables) {
+			ExportEventVariables(
+				encounter_package_name,
+				event_id,
+				object_id,
+				data,
+				npc_mob,
+				inst,
+				mob,
+				extra_data,
+				extra_pointers
+			);
+		}
+
+		ExportVar(encounter_package_name.c_str(), "name", registered_event.encounter_name.c_str());
+		ExportVar(encounter_package_name.c_str(), "encounter_name", registered_event.encounter_name.c_str());
+
+		auto* encounter = GetLoadedEncounter(registered_event.encounter_name);
+		if (encounter) {
+			ExportVar(encounter_package_name.c_str(), "encounter", "Mob", encounter);
+		}
+
+		int event_return = 0;
+		if (quest_type == QuestType::Player || quest_type == QuestType::PlayerGlobal) {
+			event_return = SendCommands(
+				encounter_package_name.c_str(),
+				registered_event.sub_name.c_str(),
+				0,
+				mob,
+				mob,
+				nullptr,
+				nullptr,
+				nullptr,
+				registered_event.encounter_name
+			);
+		} else if (
+			quest_type == QuestType::Bot ||
+			quest_type == QuestType::BotGlobal ||
+			quest_type == QuestType::Merc ||
+			quest_type == QuestType::MercGlobal
+		) {
+			event_return = SendCommands(
+				encounter_package_name.c_str(),
+				registered_event.sub_name.c_str(),
+				0,
+				npc_mob,
+				mob,
+				nullptr,
+				nullptr,
+				nullptr,
+				registered_event.encounter_name
+			);
+		} else if (quest_type == QuestType::Item || quest_type == QuestType::ItemGlobal) {
+			event_return = SendCommands(
+				encounter_package_name.c_str(),
+				registered_event.sub_name.c_str(),
+				0,
+				mob,
+				mob,
+				inst,
+				nullptr,
+				nullptr,
+				registered_event.encounter_name
+			);
+		} else if (quest_type == QuestType::Spell || quest_type == QuestType::SpellGlobal) {
+			event_return = SendCommands(
+				encounter_package_name.c_str(),
+				registered_event.sub_name.c_str(),
+				0,
+				mob ? mob : npc_mob,
+				mob,
+				nullptr,
+				spell,
+				nullptr,
+				registered_event.encounter_name
+			);
+		} else if (quest_type == QuestType::NPC || quest_type == QuestType::NPCGlobal) {
+			event_return = SendCommands(
+				encounter_package_name.c_str(),
+				registered_event.sub_name.c_str(),
+				object_id,
+				npc_mob,
+				mob,
+				nullptr,
+				nullptr,
+				nullptr,
+				registered_event.encounter_name
+			);
+		} else if (quest_type == QuestType::Zone || quest_type == QuestType::ZoneGlobal) {
+			event_return = SendCommands(
+				encounter_package_name.c_str(),
+				registered_event.sub_name.c_str(),
+				0,
+				nullptr,
+				nullptr,
+				nullptr,
+				nullptr,
+				zone,
+				registered_event.encounter_name
+			);
+		}
+
+		if (event_return != 0) {
+			ret = event_return;
+		}
+	}
+
+	return ret;
+}
+
+int PerlembParser::DispatchEventNPC(
+	QuestEventID event_id,
+	NPC* npc,
+	Mob* init,
+	std::string data,
+	uint32 extra_data,
+	std::vector<std::any>* extra_pointers
+)
+{
+	if (!npc) {
+		return 0;
+	}
+
+	int ret = DispatchEncounterRegisteredEvents(
+		fmt::format("npc_{}", npc->GetNPCTypeID()),
+		event_id,
+		npc->GetNPCTypeID(),
+		data.c_str(),
+		npc,
+		nullptr,
+		nullptr,
+		init,
+		nullptr,
+		extra_data,
+		extra_pointers
+	);
+
+	const int wildcard_return = DispatchEncounterRegisteredEvents(
+		"npc_-1",
+		event_id,
+		npc->GetNPCTypeID(),
+		data.c_str(),
+		npc,
+		nullptr,
+		nullptr,
+		init,
+		nullptr,
+		extra_data,
+		extra_pointers
+	);
+
+	return wildcard_return != 0 ? wildcard_return : ret;
+}
+
+int PerlembParser::DispatchEventPlayer(
+	QuestEventID event_id,
+	Client* client,
+	std::string data,
+	uint32 extra_data,
+	std::vector<std::any>* extra_pointers
+)
+{
+	return DispatchEncounterRegisteredEvents(
+		"player",
+		event_id,
+		0,
+		data.c_str(),
+		nullptr,
+		nullptr,
+		nullptr,
+		client,
+		nullptr,
+		extra_data,
+		extra_pointers
+	);
+}
+
+int PerlembParser::DispatchEventItem(
+	QuestEventID event_id,
+	Client* client,
+	EQ::ItemInstance* inst,
+	Mob* mob,
+	std::string data,
+	uint32 extra_data,
+	std::vector<std::any>* extra_pointers
+)
+{
+	if (!inst) {
+		return 0;
+	}
+
+	int ret = DispatchEncounterRegisteredEvents(
+		fmt::format("item_{}", inst->GetID()),
+		event_id,
+		inst->GetID(),
+		data.c_str(),
+		nullptr,
+		inst,
+		nullptr,
+		client ? client : mob,
+		nullptr,
+		extra_data,
+		extra_pointers
+	);
+
+	const int wildcard_return = DispatchEncounterRegisteredEvents(
+		"item_-1",
+		event_id,
+		inst->GetID(),
+		data.c_str(),
+		nullptr,
+		inst,
+		nullptr,
+		client ? client : mob,
+		nullptr,
+		extra_data,
+		extra_pointers
+	);
+
+	return wildcard_return != 0 ? wildcard_return : ret;
+}
+
+int PerlembParser::DispatchEventSpell(
+	QuestEventID event_id,
+	Mob* mob,
+	Client* client,
+	uint32 spell_id,
+	std::string data,
+	uint32 extra_data,
+	std::vector<std::any>* extra_pointers
+)
+{
+	auto* spell = IsValidSpell(spell_id) ? &spells[spell_id] : nullptr;
+	int ret = DispatchEncounterRegisteredEvents(
+		fmt::format("spell_{}", spell_id),
+		event_id,
+		spell_id,
+		data.c_str(),
+		mob,
+		nullptr,
+		spell,
+		client,
+		nullptr,
+		extra_data,
+		extra_pointers
+	);
+
+	const int wildcard_return = DispatchEncounterRegisteredEvents(
+		"spell_-1",
+		event_id,
+		spell_id,
+		data.c_str(),
+		mob,
+		nullptr,
+		spell,
+		client,
+		nullptr,
+		extra_data,
+		extra_pointers
+	);
+
+	return wildcard_return != 0 ? wildcard_return : ret;
+}
+
+int PerlembParser::DispatchEventBot(
+	QuestEventID event_id,
+	Bot* bot,
+	Mob* init,
+	std::string data,
+	uint32 extra_data,
+	std::vector<std::any>* extra_pointers
+)
+{
+	return DispatchEncounterRegisteredEvents(
+		"bot",
+		event_id,
+		0,
+		data.c_str(),
+		bot,
+		nullptr,
+		nullptr,
+		init,
+		nullptr,
+		extra_data,
+		extra_pointers
+	);
+}
+
+int PerlembParser::DispatchEventMerc(
+	QuestEventID event_id,
+	Merc* merc,
+	Mob* init,
+	std::string data,
+	uint32 extra_data,
+	std::vector<std::any>* extra_pointers
+)
+{
+	return DispatchEncounterRegisteredEvents(
+		"merc",
+		event_id,
+		0,
+		data.c_str(),
+		merc,
+		nullptr,
+		nullptr,
+		init,
+		nullptr,
+		extra_data,
+		extra_pointers
+	);
+}
+
+int PerlembParser::DispatchEventZone(
+	QuestEventID event_id,
+	Zone* zone,
+	std::string data,
+	uint32 extra_data,
+	std::vector<std::any>* extra_pointers
+)
+{
+	return DispatchEncounterRegisteredEvents(
+		"zone",
+		event_id,
+		0,
+		data.c_str(),
+		nullptr,
+		nullptr,
+		nullptr,
+		nullptr,
+		zone,
+		extra_data,
+		extra_pointers
+	);
+}
+
 void PerlembParser::AddVar(std::string name, std::string val)
 {
 	vars_[name] = val;
@@ -995,6 +1653,21 @@ int PerlembParser::SendCommands(
 	Zone* zone
 )
 {
+	return SendCommands(prefix, event_id, object_id, other, mob, inst, spell, zone, "");
+}
+
+int PerlembParser::SendCommands(
+	const char* prefix,
+	const char* event_id,
+	uint32 object_id,
+	Mob* other,
+	Mob* mob,
+	EQ::ItemInstance* inst,
+	const SPDat_Spell_Struct* spell,
+	Zone* zone,
+	const std::string& encounter_name
+)
+{
 	if (!perl) {
 		return 0;
 	}
@@ -1005,6 +1678,11 @@ int PerlembParser::SendCommands(
 	q.owner      = other;
 	q.questitem  = inst;
 	q.questspell = spell;
+	q.encounter  = encounter_name;
+
+	if (q.encounter.empty() && other && other->IsEncounter()) {
+		q.encounter = other->CastToEncounter()->GetEncounterName();
+	}
 
 	if (mob && mob->IsClient()) {
 		q.initiator  = mob->CastToClient();
@@ -1030,7 +1708,8 @@ int PerlembParser::SendCommands(
 				"npc",
 				"questitem",
 				"spell",
-				"zone"
+				"zone",
+				"encounter"
 			};
 
 			for (const auto& suffix : suffixes) {
@@ -1071,6 +1750,10 @@ int PerlembParser::SendCommands(
 				buf = fmt::format("{}::npc", prefix);
 				SV* npc = get_sv(buf.c_str(), true);
 				sv_setref_pv(npc, "NPC", n);
+			} else if (other->IsEncounter()) {
+				buf = fmt::format("{}::encounter", prefix);
+				SV* encounter = get_sv(buf.c_str(), true);
+				sv_setref_pv(encounter, "Mob", other);
 			}
 		}
 
@@ -1110,7 +1793,8 @@ int PerlembParser::SendCommands(
 				"npc",
 				"questitem",
 				"spell",
-				"zone"
+				"zone",
+				"encounter"
 			};
 
 			for (const auto& suffix : suffixes) {
@@ -1279,6 +1963,31 @@ std::string PerlembParser::GetQuestPackageName(
 	}
 
 	return "";
+}
+
+std::string PerlembParser::GetEncounterPackageName(const std::string& encounter_name)
+{
+	std::string package_name = "qst_encounter_";
+
+	for (const auto c : encounter_name) {
+		const auto uc = static_cast<unsigned char>(c);
+		if (std::isalnum(uc) || c == '_') {
+			package_name += c;
+		} else {
+			package_name += '_';
+		}
+	}
+
+	if (package_name == "qst_encounter_") {
+		package_name += "unnamed";
+	}
+
+	return fmt::format("{}_{:x}", package_name, std::hash<std::string>{}(encounter_name));
+}
+
+Encounter* PerlembParser::GetLoadedEncounter(const std::string& encounter_name)
+{
+	return parse->GetLoadedEncounter(encounter_name);
 }
 
 void PerlembParser::ExportCharID(const std::string& package_name, int& char_id, Mob* npc_mob, Mob* mob)

--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -1718,7 +1718,7 @@ int PerlembParser::SendCommands(
 
 			for (const auto& suffix : suffixes) {
 				const std::string& key = fmt::format("${}::{}", prefix, suffix);
-				if (clear_vars_.find(suffix) != clear_vars_.end()) {
+				if (clear_vars_.find(key) != clear_vars_.end()) {
 					auto e = fmt::format("{} = undef;", key);
 					perl->eval(e.c_str());
 				}

--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -1771,6 +1771,15 @@ int PerlembParser::SendCommands(
 			}
 		}
 
+		if (!encounter_name.empty() && (!other || !other->IsEncounter())) {
+			auto* loaded_encounter = GetLoadedEncounter(encounter_name);
+			if (loaded_encounter) {
+				buf = fmt::format("{}::encounter", prefix);
+				SV* encounter = get_sv(buf.c_str(), true);
+				sv_setref_pv(encounter, "Mob", loaded_encounter);
+			}
+		}
+
 		//only export QuestItem if it's an inst quest
 		if (inst) {
 			auto i = quest_manager.GetQuestItem();

--- a/zone/embparser.h
+++ b/zone/embparser.h
@@ -24,6 +24,7 @@
 #include "zone/quest_interface.h"
 #include "zone/quest_parser_collection.h"
 
+#include <list>
 #include <map>
 #include <queue>
 #include <string>
@@ -31,6 +32,7 @@
 class Mob;
 class Client;
 class NPC;
+class Encounter;
 
 namespace EQ {
 	class ItemInstance;
@@ -63,6 +65,8 @@ class PerlembParser : public QuestInterface {
 public:
 	PerlembParser();
 	~PerlembParser();
+
+	static PerlembParser* Instance() { return instance_; }
 
 	virtual int EventNPC(
 		QuestEventID event_id,
@@ -113,6 +117,14 @@ public:
 		Mob* mob,
 		Client* client,
 		uint32 spell_id,
+		std::string data,
+		uint32 extra_data,
+		std::vector<std::any>* extra_pointers
+	);
+
+	virtual int EventEncounter(
+		QuestEventID event_id,
+		std::string encounter_name,
 		std::string data,
 		uint32 extra_data,
 		std::vector<std::any>* extra_pointers
@@ -176,6 +188,8 @@ public:
 	virtual bool GlobalPlayerHasQuestSub(QuestEventID event_id);
 	virtual bool SpellHasQuestSub(uint32 spell_id, QuestEventID event_id);
 	virtual bool ItemHasQuestSub(EQ::ItemInstance* inst, QuestEventID event_id);
+	virtual bool EncounterHasQuestSub(std::string encounter_name, QuestEventID event_id);
+	virtual bool HasEncounterSub(const std::string& package_name, QuestEventID event_id);
 	virtual bool BotHasQuestSub(QuestEventID event_id);
 	virtual bool GlobalBotHasQuestSub(QuestEventID event_id);
 	virtual bool MercHasQuestSub(QuestEventID event_id);
@@ -189,6 +203,7 @@ public:
 	virtual void LoadGlobalPlayerScript(std::string filename);
 	virtual void LoadItemScript(std::string filename, EQ::ItemInstance* inst);
 	virtual void LoadSpellScript(std::string filename, uint32 spell_id);
+	virtual void LoadEncounterScript(std::string filename, std::string encounter_name);
 	virtual void LoadBotScript(std::string filename);
 	virtual void LoadGlobalBotScript(std::string filename);
 	virtual void LoadMercScript(std::string filename);
@@ -201,8 +216,87 @@ public:
 	virtual void Init() override;
 	virtual void ReloadQuests();
 	virtual uint32 GetIdentifier() { return 0xf8b05c11; }
+	virtual void RemoveEncounter(const std::string& name);
+
+	virtual int DispatchEventNPC(
+		QuestEventID event_id,
+		NPC* npc,
+		Mob* init,
+		std::string data,
+		uint32 extra_data,
+		std::vector<std::any>* extra_pointers
+	);
+
+	virtual int DispatchEventPlayer(
+		QuestEventID event_id,
+		Client* client,
+		std::string data,
+		uint32 extra_data,
+		std::vector<std::any>* extra_pointers
+	);
+
+	virtual int DispatchEventItem(
+		QuestEventID event_id,
+		Client* client,
+		EQ::ItemInstance* inst,
+		Mob* mob,
+		std::string data,
+		uint32 extra_data,
+		std::vector<std::any>* extra_pointers
+	);
+
+	virtual int DispatchEventSpell(
+		QuestEventID event_id,
+		Mob* mob,
+		Client* client,
+		uint32 spell_id,
+		std::string data,
+		uint32 extra_data,
+		std::vector<std::any>* extra_pointers
+	);
+
+	virtual int DispatchEventBot(
+		QuestEventID event_id,
+		Bot* bot,
+		Mob* init,
+		std::string data,
+		uint32 extra_data,
+		std::vector<std::any>* extra_pointers
+	);
+
+	virtual int DispatchEventMerc(
+		QuestEventID event_id,
+		Merc* merc,
+		Mob* init,
+		std::string data,
+		uint32 extra_data,
+		std::vector<std::any>* extra_pointers
+	);
+
+	virtual int DispatchEventZone(
+		QuestEventID event_id,
+		Zone* zone,
+		std::string data,
+		uint32 extra_data,
+		std::vector<std::any>* extra_pointers
+	);
+
+	void LoadEncounter(std::string encounter_name);
+	void LoadEncounterWithData(std::string encounter_name, std::string data);
+	void UnloadEncounter(std::string encounter_name);
+	void UnloadEncounterWithData(std::string encounter_name, std::string data);
+	void RegisterEncounterEvent(std::string package_name, std::string encounter_name, int event_id, std::string sub_name);
+	void UnregisterEncounterEvent(std::string package_name, std::string encounter_name, int event_id);
 
 private:
+	struct PerlRegisteredEvent {
+		std::string encounter_name;
+		std::string sub_name;
+		QuestEventID event_id;
+	};
+
+	static PerlembParser* instance_;
+
 	Embperl* perl;
 
 	void ExportHash(const char* prefix, const char* hash_name, std::map<std::string, std::string>& vals);
@@ -237,6 +331,18 @@ private:
 		Zone* zone
 	);
 
+	int SendCommands(
+		const char* prefix,
+		const char* event,
+		uint32 spell_id,
+		Mob* other,
+		Mob* mob,
+		EQ::ItemInstance* inst,
+		const SPDat_Spell_Struct* spell,
+		Zone* zone,
+		const std::string& encounter_name
+	);
+
 	void MapFunctions();
 
 	QuestType GetQuestTypes(
@@ -255,6 +361,23 @@ private:
 		const char* data,
 		Mob* npc_mob,
 		EQ::ItemInstance* inst
+	);
+
+	std::string GetEncounterPackageName(const std::string& encounter_name);
+	Encounter* GetLoadedEncounter(const std::string& encounter_name);
+
+	int DispatchEncounterRegisteredEvents(
+		const std::string& package_name,
+		QuestEventID event_id,
+		uint32 object_id,
+		const char* data,
+		Mob* npc_mob,
+		EQ::ItemInstance* inst,
+		const SPDat_Spell_Struct* spell,
+		Mob* mob,
+		Zone* zone,
+		uint32 extra_data,
+		std::vector<std::any>* extra_pointers
 	);
 
 	void ExportCharID(const std::string& package_name, int& char_id, Mob* npc_mob, Mob* mob);
@@ -293,6 +416,8 @@ private:
 	std::map<uint32, PerlQuestStatus> npc_quest_status_;
 	std::map<uint32, PerlQuestStatus> item_quest_status_;
 	std::map<uint32, PerlQuestStatus> spell_quest_status_;
+	std::map<std::string, PerlQuestStatus> encounter_quest_status_;
+	std::map<std::string, std::list<PerlRegisteredEvent>> perl_encounter_events_registered_;
 
 	PerlQuestStatus global_npc_quest_status_;
 	PerlQuestStatus player_quest_status_;

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -27,6 +27,7 @@
 #include "common/zone_store.h"
 #include "zone/dialogue_window.h"
 #include "zone/dynamic_zone.h"
+#include "zone/embparser.h"
 #include "zone/embperl.h"
 #include "zone/entity.h"
 #include "zone/queryserv.h"
@@ -403,6 +404,147 @@ void Perl__settimerMS(std::string timer_name, uint32 milliseconds, EQ::ItemInsta
 	quest_manager.settimerMS(timer_name, milliseconds, inst);
 }
 
+void Perl__load_encounter(std::string encounter_name)
+{
+	auto* perl_parser = PerlembParser::Instance();
+	if (perl_parser) {
+		perl_parser->LoadEncounter(encounter_name);
+	}
+}
+
+void Perl__load_encounter_with_data(std::string encounter_name, std::string data)
+{
+	auto* perl_parser = PerlembParser::Instance();
+	if (perl_parser) {
+		perl_parser->LoadEncounterWithData(encounter_name, data);
+	}
+}
+
+void Perl__unload_encounter(std::string encounter_name)
+{
+	auto* perl_parser = PerlembParser::Instance();
+	if (perl_parser) {
+		perl_parser->UnloadEncounter(encounter_name);
+	}
+}
+
+void Perl__unload_encounter_with_data(std::string encounter_name, std::string data)
+{
+	auto* perl_parser = PerlembParser::Instance();
+	if (perl_parser) {
+		perl_parser->UnloadEncounterWithData(encounter_name, data);
+	}
+}
+
+std::string Perl__get_encounter()
+{
+	return quest_manager.GetEncounter();
+}
+
+void Perl__register_npc_event(std::string encounter_name, int event_id, int npc_id, std::string sub_name)
+{
+	auto* perl_parser = PerlembParser::Instance();
+	if (perl_parser) {
+		perl_parser->RegisterEncounterEvent(fmt::format("npc_{}", npc_id), encounter_name, event_id, sub_name);
+	}
+}
+
+void Perl__register_npc_event(int event_id, int npc_id, std::string sub_name)
+{
+	Perl__register_npc_event(quest_manager.GetEncounter(), event_id, npc_id, sub_name);
+}
+
+void Perl__unregister_npc_event(std::string encounter_name, int event_id, int npc_id)
+{
+	auto* perl_parser = PerlembParser::Instance();
+	if (perl_parser) {
+		perl_parser->UnregisterEncounterEvent(fmt::format("npc_{}", npc_id), encounter_name, event_id);
+	}
+}
+
+void Perl__unregister_npc_event(int event_id, int npc_id)
+{
+	Perl__unregister_npc_event(quest_manager.GetEncounter(), event_id, npc_id);
+}
+
+void Perl__register_player_event(std::string encounter_name, int event_id, std::string sub_name)
+{
+	auto* perl_parser = PerlembParser::Instance();
+	if (perl_parser) {
+		perl_parser->RegisterEncounterEvent("player", encounter_name, event_id, sub_name);
+	}
+}
+
+void Perl__register_player_event(int event_id, std::string sub_name)
+{
+	Perl__register_player_event(quest_manager.GetEncounter(), event_id, sub_name);
+}
+
+void Perl__unregister_player_event(std::string encounter_name, int event_id)
+{
+	auto* perl_parser = PerlembParser::Instance();
+	if (perl_parser) {
+		perl_parser->UnregisterEncounterEvent("player", encounter_name, event_id);
+	}
+}
+
+void Perl__unregister_player_event(int event_id)
+{
+	Perl__unregister_player_event(quest_manager.GetEncounter(), event_id);
+}
+
+void Perl__register_item_event(std::string encounter_name, int event_id, int item_id, std::string sub_name)
+{
+	auto* perl_parser = PerlembParser::Instance();
+	if (perl_parser) {
+		perl_parser->RegisterEncounterEvent(fmt::format("item_{}", item_id), encounter_name, event_id, sub_name);
+	}
+}
+
+void Perl__register_item_event(int event_id, int item_id, std::string sub_name)
+{
+	Perl__register_item_event(quest_manager.GetEncounter(), event_id, item_id, sub_name);
+}
+
+void Perl__unregister_item_event(std::string encounter_name, int event_id, int item_id)
+{
+	auto* perl_parser = PerlembParser::Instance();
+	if (perl_parser) {
+		perl_parser->UnregisterEncounterEvent(fmt::format("item_{}", item_id), encounter_name, event_id);
+	}
+}
+
+void Perl__unregister_item_event(int event_id, int item_id)
+{
+	Perl__unregister_item_event(quest_manager.GetEncounter(), event_id, item_id);
+}
+
+void Perl__register_spell_event(std::string encounter_name, int event_id, int spell_id, std::string sub_name)
+{
+	auto* perl_parser = PerlembParser::Instance();
+	if (perl_parser) {
+		perl_parser->RegisterEncounterEvent(fmt::format("spell_{}", spell_id), encounter_name, event_id, sub_name);
+	}
+}
+
+void Perl__register_spell_event(int event_id, int spell_id, std::string sub_name)
+{
+	Perl__register_spell_event(quest_manager.GetEncounter(), event_id, spell_id, sub_name);
+}
+
+void Perl__unregister_spell_event(std::string encounter_name, int event_id, int spell_id)
+{
+	auto* perl_parser = PerlembParser::Instance();
+	if (perl_parser) {
+		perl_parser->UnregisterEncounterEvent(fmt::format("spell_{}", spell_id), encounter_name, event_id);
+	}
+}
+
+void Perl__unregister_spell_event(int event_id, int spell_id)
+{
+	Perl__unregister_spell_event(quest_manager.GetEncounter(), event_id, spell_id);
+}
+
 void Perl__pausetimer(std::string timer_name)
 {
 	quest_manager.pausetimer(timer_name);
@@ -418,9 +560,29 @@ void Perl__stoptimer(std::string timer_name)
 	quest_manager.stoptimer(timer_name);
 }
 
+void Perl__stoptimer(std::string timer_name, Mob* m)
+{
+	quest_manager.stoptimer(timer_name, m);
+}
+
+void Perl__stoptimer(std::string timer_name, EQ::ItemInstance* inst)
+{
+	quest_manager.stoptimer(timer_name, inst);
+}
+
 void Perl__stopalltimers()
 {
 	quest_manager.stopalltimers();
+}
+
+void Perl__stopalltimers(Mob* m)
+{
+	quest_manager.stopalltimers(m);
+}
+
+void Perl__stopalltimers(EQ::ItemInstance* inst)
+{
+	quest_manager.stopalltimers(inst);
 }
 
 void Perl__emote(const char* message)
@@ -6918,6 +7080,27 @@ void perl_register_quest()
 	package.add("settimerMS", (void(*)(std::string, uint32))&Perl__settimerMS);
 	package.add("settimerMS", (void(*)(std::string, uint32, EQ::ItemInstance*))&Perl__settimerMS);
 	package.add("settimerMS", (void(*)(std::string, uint32, Mob*))&Perl__settimerMS);
+	package.add("load_encounter", &Perl__load_encounter);
+	package.add("unload_encounter", &Perl__unload_encounter);
+	package.add("load_encounter_with_data", &Perl__load_encounter_with_data);
+	package.add("unload_encounter_with_data", &Perl__unload_encounter_with_data);
+	package.add("get_encounter", &Perl__get_encounter);
+	package.add("register_npc_event", (void(*)(std::string, int, int, std::string))&Perl__register_npc_event);
+	package.add("register_npc_event", (void(*)(int, int, std::string))&Perl__register_npc_event);
+	package.add("unregister_npc_event", (void(*)(std::string, int, int))&Perl__unregister_npc_event);
+	package.add("unregister_npc_event", (void(*)(int, int))&Perl__unregister_npc_event);
+	package.add("register_player_event", (void(*)(std::string, int, std::string))&Perl__register_player_event);
+	package.add("register_player_event", (void(*)(int, std::string))&Perl__register_player_event);
+	package.add("unregister_player_event", (void(*)(std::string, int))&Perl__unregister_player_event);
+	package.add("unregister_player_event", (void(*)(int))&Perl__unregister_player_event);
+	package.add("register_item_event", (void(*)(std::string, int, int, std::string))&Perl__register_item_event);
+	package.add("register_item_event", (void(*)(int, int, std::string))&Perl__register_item_event);
+	package.add("unregister_item_event", (void(*)(std::string, int, int))&Perl__unregister_item_event);
+	package.add("unregister_item_event", (void(*)(int, int))&Perl__unregister_item_event);
+	package.add("register_spell_event", (void(*)(std::string, int, int, std::string))&Perl__register_spell_event);
+	package.add("register_spell_event", (void(*)(int, int, std::string))&Perl__register_spell_event);
+	package.add("unregister_spell_event", (void(*)(std::string, int, int))&Perl__unregister_spell_event);
+	package.add("unregister_spell_event", (void(*)(int, int))&Perl__unregister_spell_event);
 	package.add("sfollow", &Perl__sfollow);
 	package.add("shout", &Perl__shout);
 	package.add("shout2", &Perl__shout2);
@@ -6936,8 +7119,12 @@ void perl_register_quest()
 	package.add("spawn_from_spawn2", &Perl__spawn_from_spawn2);
 	package.add("start", &Perl__start);
 	package.add("stop", &Perl__stop);
-	package.add("stopalltimers", &Perl__stopalltimers);
-	package.add("stoptimer", &Perl__stoptimer);
+	package.add("stopalltimers", (void(*)())&Perl__stopalltimers);
+	package.add("stopalltimers", (void(*)(EQ::ItemInstance*))&Perl__stopalltimers);
+	package.add("stopalltimers", (void(*)(Mob*))&Perl__stopalltimers);
+	package.add("stoptimer", (void(*)(std::string))&Perl__stoptimer);
+	package.add("stoptimer", (void(*)(std::string, EQ::ItemInstance*))&Perl__stoptimer);
+	package.add("stoptimer", (void(*)(std::string, Mob*))&Perl__stoptimer);
 	package.add("summonallplayercorpses", &Perl__summonallplayercorpses);
 	package.add("summonburiedplayercorpse", &Perl__summonburiedplayercorpse);
 	package.add("summonitem", (void(*)(int))&Perl__summonitem);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -105,7 +105,7 @@ void register_event(std::string package_name, std::string name, int evt, luabind
 void unregister_event(std::string package_name, std::string name, int evt) {
 	auto liter = lua_encounter_events_registered.find(package_name);
 	if(liter != lua_encounter_events_registered.end()) {
-		std::list<lua_registered_event> elist = liter->second;
+		std::list<lua_registered_event> &elist = liter->second;
 		auto iter = elist.begin();
 		while(iter != elist.end()) {
 			if(iter->event_id == evt && iter->encounter_name.compare(name) == 0) {
@@ -114,7 +114,10 @@ void unregister_event(std::string package_name, std::string name, int evt) {
 			}
 			++iter;
 		}
-		lua_encounter_events_registered[package_name] = elist;
+
+		if(elist.empty()) {
+			lua_encounter_events_registered.erase(liter);
+		}
 	}
 }
 

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -56,8 +56,6 @@ struct lua_registered_event {
 };
 
 extern std::map<std::string, std::list<lua_registered_event>> lua_encounter_events_registered;
-extern std::map<std::string, bool> lua_encounters_loaded;
-extern std::map<std::string, Encounter *> lua_encounters;
 
 extern void MapOpcodes();
 extern void ClearMappedOpcode(EmuOpcode op);
@@ -67,91 +65,23 @@ extern WorldServer worldserver;
 void unregister_event(std::string package_name, std::string name, int evt);
 
 void load_encounter(std::string name) {
-	if(lua_encounters_loaded.count(name) > 0)
-		return;
-	auto enc = new Encounter(name.c_str());
-	entity_list.AddEncounter(enc);
-	lua_encounters[name] = enc;
-	lua_encounters_loaded[name] = true;
-	parse->EventEncounter(EVENT_ENCOUNTER_LOAD, name, "", 0);
+	parse->LoadEncounter(name);
 }
 
 void load_encounter_with_data(std::string name, std::string info_str) {
-	if(lua_encounters_loaded.count(name) > 0)
-		return;
-	auto enc = new Encounter(name.c_str());
-	entity_list.AddEncounter(enc);
-	lua_encounters[name] = enc;
-	lua_encounters_loaded[name] = true;
-	std::vector<std::any> info_ptrs;
-	info_ptrs.push_back(&info_str);
-	parse->EventEncounter(EVENT_ENCOUNTER_LOAD, name, "", 0, &info_ptrs);
+	parse->LoadEncounterWithData(name, info_str);
 }
 
 void unload_encounter(std::string name) {
-	if(lua_encounters_loaded.count(name) == 0)
-		return;
-
-	auto liter = lua_encounter_events_registered.begin();
-	while(liter != lua_encounter_events_registered.end()) {
-		std::list<lua_registered_event> &elist = liter->second;
-		auto iter = elist.begin();
-		while(iter != elist.end()) {
-			if((*iter).encounter_name.compare(name) == 0) {
-				iter = elist.erase(iter);
-			} else {
-				++iter;
-			}
-		}
-
-		if(elist.size() == 0) {
-			lua_encounter_events_registered.erase(liter++);
-		} else {
-			++liter;
-		}
-	}
-
-	lua_encounters[name]->Depop();
-	lua_encounters.erase(name);
-	lua_encounters_loaded.erase(name);
-	parse->EventEncounter(EVENT_ENCOUNTER_UNLOAD, name, "", 0);
+	parse->UnloadEncounter(name);
 }
 
 void unload_encounter_with_data(std::string name, std::string info_str) {
-	if(lua_encounters_loaded.count(name) == 0)
-		return;
-
-	auto liter = lua_encounter_events_registered.begin();
-	while(liter != lua_encounter_events_registered.end()) {
-		std::list<lua_registered_event> &elist = liter->second;
-		auto iter = elist.begin();
-		while(iter != elist.end()) {
-			if((*iter).encounter_name.compare(name) == 0) {
-				iter = elist.erase(iter);
-			}
-			else {
-				++iter;
-			}
-		}
-
-		if(elist.size() == 0) {
-			lua_encounter_events_registered.erase(liter++);
-		}
-		else {
-			++liter;
-		}
-	}
-
-	lua_encounters[name]->Depop();
-	lua_encounters.erase(name);
-	lua_encounters_loaded.erase(name);
-	std::vector<std::any> info_ptrs;
-	info_ptrs.push_back(&info_str);
-	parse->EventEncounter(EVENT_ENCOUNTER_UNLOAD, name, "", 0, &info_ptrs);
+	parse->UnloadEncounterWithData(name, info_str);
 }
 
 void register_event(std::string package_name, std::string name, int evt, luabind::adl::object func) {
-	if(lua_encounters_loaded.count(name) == 0)
+	if(!parse->IsEncounterLoaded(name) || parse->IsEncounterUnloading(name))
 		return;
 
 	unregister_event(package_name, name, evt);

--- a/zone/lua_parser.cpp
+++ b/zone/lua_parser.cpp
@@ -383,6 +383,10 @@ LuaParser::LuaParser() {
 	SpellArgumentDispatch[EVENT_SPELL_EFFECT_TRANSLOCATE_COMPLETE] = handle_translocate_finish;
 
 	EncounterArgumentDispatch[EVENT_TIMER]            = handle_encounter_timer;
+	EncounterArgumentDispatch[EVENT_TIMER_PAUSE]      = handle_encounter_timer_pause_resume_start;
+	EncounterArgumentDispatch[EVENT_TIMER_RESUME]     = handle_encounter_timer_pause_resume_start;
+	EncounterArgumentDispatch[EVENT_TIMER_START]      = handle_encounter_timer_pause_resume_start;
+	EncounterArgumentDispatch[EVENT_TIMER_STOP]       = handle_encounter_timer_stop;
 	EncounterArgumentDispatch[EVENT_ENCOUNTER_LOAD]   = handle_encounter_load;
 	EncounterArgumentDispatch[EVENT_ENCOUNTER_UNLOAD] = handle_encounter_unload;
 

--- a/zone/lua_parser.cpp
+++ b/zone/lua_parser.cpp
@@ -202,8 +202,6 @@ struct lua_registered_event {
 };
 
 std::map<std::string, std::list<lua_registered_event>> lua_encounter_events_registered;
-std::map<std::string, bool> lua_encounters_loaded;
-std::map<std::string, Encounter *> lua_encounters;
 
 // use debug.traceback() for errors (luaL_traceback is only in luajit and lua 5.2+)
 static void PushErrorHandler(lua_State* L)
@@ -440,9 +438,7 @@ LuaParser::LuaParser() {
 
 LuaParser::~LuaParser() {
 	// valgrind didn't like when we didn't clean these up :P
-	lua_encounters.clear();
 	lua_encounter_events_registered.clear();
-	lua_encounters_loaded.clear();
 	if(L) {
 		lua_close(L);
 	}
@@ -859,7 +855,7 @@ int LuaParser::_EventEncounter(std::string package_name, QuestEventID evt, std::
 		lua_pushstring(L, encounter_name.c_str());
 		lua_setfield(L, -2, "name");
 
-		Encounter *enc = lua_encounters[encounter_name];
+		Encounter *enc = parse->GetLoadedEncounter(encounter_name);
 
 		auto arg_function = EncounterArgumentDispatch[evt];
 		arg_function(this, L, enc, data, extra_data, extra_pointers);
@@ -1044,16 +1040,6 @@ void LuaParser::ReloadQuests() {
 	errors_.clear();
 	mods_.clear();
 	lua_encounter_events_registered.clear();
-	lua_encounters_loaded.clear();
-
-	for (auto encounter : lua_encounters) {
-		encounter.second->Depop();
-	}
-
-	lua_encounters.clear();
-	// so the Depop function above depends on the Process being called again so ...
-	// And there is situations where it wouldn't be :P
-	entity_list.EncounterProcess();
 
 	if(L) {
 		lua_close(L);
@@ -1230,13 +1216,30 @@ void LuaParser::ReloadQuests() {
 }
 
 /*
- * This function is intended only to clean up lua_encounters when the Encounter object is
- * about to be destroyed. It won't clean up memory else where, since the caller of this
- * function is responsible for that
+ * This function is intended only to clean up Lua registered encounter events when the Encounter
+ * object is about to be destroyed. It won't clean up memory elsewhere, since the caller of this
+ * function is responsible for that.
  */
 void LuaParser::RemoveEncounter(const std::string &name)
 {
-	lua_encounters.erase(name);
+	auto liter = lua_encounter_events_registered.begin();
+	while(liter != lua_encounter_events_registered.end()) {
+		std::list<lua_registered_event> &elist = liter->second;
+		auto iter = elist.begin();
+		while(iter != elist.end()) {
+			if(iter->encounter_name.compare(name) == 0) {
+				iter = elist.erase(iter);
+			} else {
+				++iter;
+			}
+		}
+
+		if(elist.size() == 0) {
+			liter = lua_encounter_events_registered.erase(liter);
+		} else {
+			++liter;
+		}
+	}
 }
 
 void LuaParser::LoadScript(std::string filename, std::string package_name) {
@@ -1311,7 +1314,11 @@ bool LuaParser::HasEncounterSub(const std::string& package_name, QuestEventID ev
 	auto it = lua_encounter_events_registered.find(package_name);
 	if (it != lua_encounter_events_registered.end()) {
 		for (auto & riter : it->second) {
-			if (riter.event_id == evt) {
+			if (
+				riter.event_id == evt &&
+				parse->IsEncounterLoaded(riter.encounter_name) &&
+				!parse->IsEncounterUnloading(riter.encounter_name)
+			) {
 				return true;
 			}
 		}

--- a/zone/lua_parser.cpp
+++ b/zone/lua_parser.cpp
@@ -1418,15 +1418,14 @@ int LuaParser::DispatchEventNPC(QuestEventID evt, NPC* npc, Mob *init, std::stri
 
 	auto iter = lua_encounter_events_registered.find(package_name);
 	if(iter != lua_encounter_events_registered.end()) {
-		auto riter = iter->second.begin();
-		while(riter != iter->second.end()) {
-			if(riter->event_id == evt) {
-				std::string package_name = "encounter_" + riter->encounter_name;
-				int i = _EventNPC(package_name, evt, npc, init, data, extra_data, extra_pointers, &riter->lua_reference);
+		auto registered_events = iter->second;
+		for(auto &registered_event : registered_events) {
+			if(registered_event.event_id == evt) {
+				std::string package_name = "encounter_" + registered_event.encounter_name;
+				int i = _EventNPC(package_name, evt, npc, init, data, extra_data, extra_pointers, &registered_event.lua_reference);
                 if(i != 0)
                     ret = i;
 			}
-			++riter;
 		}
 	}
 
@@ -1435,15 +1434,14 @@ int LuaParser::DispatchEventNPC(QuestEventID evt, NPC* npc, Mob *init, std::stri
 		return ret;
 	}
 
-	auto riter = iter->second.begin();
-	while(riter != iter->second.end()) {
-		if(riter->event_id == evt) {
-			std::string package_name = "encounter_" + riter->encounter_name;
-			int i = _EventNPC(package_name, evt, npc, init, data, extra_data, extra_pointers, &riter->lua_reference);
+	auto registered_events = iter->second;
+	for(auto &registered_event : registered_events) {
+		if(registered_event.event_id == evt) {
+			std::string package_name = "encounter_" + registered_event.encounter_name;
+			int i = _EventNPC(package_name, evt, npc, init, data, extra_data, extra_pointers, &registered_event.lua_reference);
             if(i != 0)
                 ret = i;
 		}
-		++riter;
 	}
 
     return ret;
@@ -1464,15 +1462,14 @@ int LuaParser::DispatchEventPlayer(QuestEventID evt, Client *client, std::string
 	}
 
     int ret = 0;
-	auto riter = iter->second.begin();
-	while(riter != iter->second.end()) {
-		if(riter->event_id == evt) {
-			std::string package_name = "encounter_" + riter->encounter_name;
-			int i = _EventPlayer(package_name, evt, client, data, extra_data, extra_pointers, &riter->lua_reference);
+	auto registered_events = iter->second;
+	for(auto &registered_event : registered_events) {
+		if(registered_event.event_id == evt) {
+			std::string package_name = "encounter_" + registered_event.encounter_name;
+			int i = _EventPlayer(package_name, evt, client, data, extra_data, extra_pointers, &registered_event.lua_reference);
             if(i != 0)
                 ret = i;
 		}
-		++riter;
 	}
 
     return ret;
@@ -1494,15 +1491,14 @@ int LuaParser::DispatchEventItem(QuestEventID evt, Client *client, EQ::ItemInsta
 
 	auto iter = lua_encounter_events_registered.find(package_name);
 	if(iter != lua_encounter_events_registered.end()) {
-		auto riter = iter->second.begin();
-		while(riter != iter->second.end()) {
-			if(riter->event_id == evt) {
-				std::string package_name = "encounter_" + riter->encounter_name;
-				int i = _EventItem(package_name, evt, client, item, mob, data, extra_data, extra_pointers, &riter->lua_reference);
+		auto registered_events = iter->second;
+		for(auto &registered_event : registered_events) {
+			if(registered_event.event_id == evt) {
+				std::string package_name = "encounter_" + registered_event.encounter_name;
+				int i = _EventItem(package_name, evt, client, item, mob, data, extra_data, extra_pointers, &registered_event.lua_reference);
                 if(i != 0)
                     ret = i;
 			}
-			++riter;
 		}
 	}
 
@@ -1511,15 +1507,14 @@ int LuaParser::DispatchEventItem(QuestEventID evt, Client *client, EQ::ItemInsta
 		return ret;
 	}
 
-	auto riter = iter->second.begin();
-	while(riter != iter->second.end()) {
-		if(riter->event_id == evt) {
-			std::string package_name = "encounter_" + riter->encounter_name;
-			int i = _EventItem(package_name, evt, client, item, mob, data, extra_data, extra_pointers, &riter->lua_reference);
+	auto registered_events = iter->second;
+	for(auto &registered_event : registered_events) {
+		if(registered_event.event_id == evt) {
+			std::string package_name = "encounter_" + registered_event.encounter_name;
+			int i = _EventItem(package_name, evt, client, item, mob, data, extra_data, extra_pointers, &registered_event.lua_reference);
             if(i != 0)
                 ret = i;
 		}
-		++riter;
 	}
     return ret;
 }
@@ -1536,16 +1531,15 @@ int LuaParser::DispatchEventSpell(QuestEventID evt, Mob* mob, Client *client, ui
     int ret = 0;
 	auto iter = lua_encounter_events_registered.find(package_name);
 	if(iter != lua_encounter_events_registered.end()) {
-	    auto riter = iter->second.begin();
-		while(riter != iter->second.end()) {
-			if(riter->event_id == evt) {
-				std::string package_name = "encounter_" + riter->encounter_name;
-				int i = _EventSpell(package_name, evt, mob, client, spell_id, data, extra_data, extra_pointers, &riter->lua_reference);
+	    auto registered_events = iter->second;
+		for(auto &registered_event : registered_events) {
+			if(registered_event.event_id == evt) {
+				std::string package_name = "encounter_" + registered_event.encounter_name;
+				int i = _EventSpell(package_name, evt, mob, client, spell_id, data, extra_data, extra_pointers, &registered_event.lua_reference);
                 if(i != 0) {
                     ret = i;
                 }
 			}
-			++riter;
 		}
 	}
 
@@ -1554,15 +1548,14 @@ int LuaParser::DispatchEventSpell(QuestEventID evt, Mob* mob, Client *client, ui
 		return ret;
 	}
 
-	auto riter = iter->second.begin();
-	while(riter != iter->second.end()) {
-		if(riter->event_id == evt) {
-			std::string package_name = "encounter_" + riter->encounter_name;
-			int i = _EventSpell(package_name, evt, mob, client, spell_id, data, extra_data, extra_pointers, &riter->lua_reference);
+	auto registered_events = iter->second;
+	for(auto &registered_event : registered_events) {
+		if(registered_event.event_id == evt) {
+			std::string package_name = "encounter_" + registered_event.encounter_name;
+			int i = _EventSpell(package_name, evt, mob, client, spell_id, data, extra_data, extra_pointers, &registered_event.lua_reference);
             if(i != 0)
                 ret = i;
 		}
-		++riter;
 	}
     return ret;
 }
@@ -1878,17 +1871,15 @@ int LuaParser::DispatchEventBot(
 	}
 
 	int ret = 0;
-	auto riter = iter->second.begin();
-	while (riter != iter->second.end()) {
-		if (riter->event_id == evt) {
-			package_name = fmt::format("encounter_{}", riter->encounter_name);
-			int i = _EventBot(package_name, evt, bot, init, data, extra_data, extra_pointers, &riter->lua_reference);
+	auto registered_events = iter->second;
+	for (auto &registered_event : registered_events) {
+		if (registered_event.event_id == evt) {
+			package_name = fmt::format("encounter_{}", registered_event.encounter_name);
+			int i = _EventBot(package_name, evt, bot, init, data, extra_data, extra_pointers, &registered_event.lua_reference);
 			if (i != 0) {
 				ret = i;
 			}
 		}
-
-		++riter;
 	}
 
 	return ret;
@@ -2071,17 +2062,15 @@ int LuaParser::DispatchEventMerc(
 	}
 
 	int ret = 0;
-	auto riter = iter->second.begin();
-	while (riter != iter->second.end()) {
-		if (riter->event_id == evt) {
-			package_name = fmt::format("encounter_{}", riter->encounter_name);
-			int i = _EventMerc(package_name, evt, merc, init, data, extra_data, extra_pointers, &riter->lua_reference);
+	auto registered_events = iter->second;
+	for (auto &registered_event : registered_events) {
+		if (registered_event.event_id == evt) {
+			package_name = fmt::format("encounter_{}", registered_event.encounter_name);
+			int i = _EventMerc(package_name, evt, merc, init, data, extra_data, extra_pointers, &registered_event.lua_reference);
 			if (i != 0) {
 				ret = i;
 			}
 		}
-
-		++riter;
 	}
 
 	return ret;
@@ -2258,17 +2247,15 @@ int LuaParser::DispatchEventZone(
 	}
 
 	int ret = 0;
-	auto riter = iter->second.begin();
-	while (riter != iter->second.end()) {
-		if (riter->event_id == evt) {
-			package_name = fmt::format("encounter_{}", riter->encounter_name);
-			int i = _EventZone(package_name, evt, zone, data, extra_data, extra_pointers, &riter->lua_reference);
+	auto registered_events = iter->second;
+	for (auto &registered_event : registered_events) {
+		if (registered_event.event_id == evt) {
+			package_name = fmt::format("encounter_{}", registered_event.encounter_name);
+			int i = _EventZone(package_name, evt, zone, data, extra_data, extra_pointers, &registered_event.lua_reference);
 			if (i != 0) {
 				ret = i;
 			}
 		}
-
-		++riter;
 	}
 
 	return ret;

--- a/zone/lua_parser.cpp
+++ b/zone/lua_parser.cpp
@@ -1420,7 +1420,11 @@ int LuaParser::DispatchEventNPC(QuestEventID evt, NPC* npc, Mob *init, std::stri
 	if(iter != lua_encounter_events_registered.end()) {
 		auto registered_events = iter->second;
 		for(auto &registered_event : registered_events) {
-			if(registered_event.event_id == evt) {
+			if(
+				registered_event.event_id == evt &&
+				parse->IsEncounterLoaded(registered_event.encounter_name) &&
+				!parse->IsEncounterUnloading(registered_event.encounter_name)
+			) {
 				std::string package_name = "encounter_" + registered_event.encounter_name;
 				int i = _EventNPC(package_name, evt, npc, init, data, extra_data, extra_pointers, &registered_event.lua_reference);
                 if(i != 0)
@@ -1436,7 +1440,11 @@ int LuaParser::DispatchEventNPC(QuestEventID evt, NPC* npc, Mob *init, std::stri
 
 	auto registered_events = iter->second;
 	for(auto &registered_event : registered_events) {
-		if(registered_event.event_id == evt) {
+		if(
+			registered_event.event_id == evt &&
+			parse->IsEncounterLoaded(registered_event.encounter_name) &&
+			!parse->IsEncounterUnloading(registered_event.encounter_name)
+		) {
 			std::string package_name = "encounter_" + registered_event.encounter_name;
 			int i = _EventNPC(package_name, evt, npc, init, data, extra_data, extra_pointers, &registered_event.lua_reference);
             if(i != 0)
@@ -1464,7 +1472,11 @@ int LuaParser::DispatchEventPlayer(QuestEventID evt, Client *client, std::string
     int ret = 0;
 	auto registered_events = iter->second;
 	for(auto &registered_event : registered_events) {
-		if(registered_event.event_id == evt) {
+		if(
+			registered_event.event_id == evt &&
+			parse->IsEncounterLoaded(registered_event.encounter_name) &&
+			!parse->IsEncounterUnloading(registered_event.encounter_name)
+		) {
 			std::string package_name = "encounter_" + registered_event.encounter_name;
 			int i = _EventPlayer(package_name, evt, client, data, extra_data, extra_pointers, &registered_event.lua_reference);
             if(i != 0)
@@ -1493,7 +1505,11 @@ int LuaParser::DispatchEventItem(QuestEventID evt, Client *client, EQ::ItemInsta
 	if(iter != lua_encounter_events_registered.end()) {
 		auto registered_events = iter->second;
 		for(auto &registered_event : registered_events) {
-			if(registered_event.event_id == evt) {
+			if(
+				registered_event.event_id == evt &&
+				parse->IsEncounterLoaded(registered_event.encounter_name) &&
+				!parse->IsEncounterUnloading(registered_event.encounter_name)
+			) {
 				std::string package_name = "encounter_" + registered_event.encounter_name;
 				int i = _EventItem(package_name, evt, client, item, mob, data, extra_data, extra_pointers, &registered_event.lua_reference);
                 if(i != 0)
@@ -1509,7 +1525,11 @@ int LuaParser::DispatchEventItem(QuestEventID evt, Client *client, EQ::ItemInsta
 
 	auto registered_events = iter->second;
 	for(auto &registered_event : registered_events) {
-		if(registered_event.event_id == evt) {
+		if(
+			registered_event.event_id == evt &&
+			parse->IsEncounterLoaded(registered_event.encounter_name) &&
+			!parse->IsEncounterUnloading(registered_event.encounter_name)
+		) {
 			std::string package_name = "encounter_" + registered_event.encounter_name;
 			int i = _EventItem(package_name, evt, client, item, mob, data, extra_data, extra_pointers, &registered_event.lua_reference);
             if(i != 0)
@@ -1533,7 +1553,11 @@ int LuaParser::DispatchEventSpell(QuestEventID evt, Mob* mob, Client *client, ui
 	if(iter != lua_encounter_events_registered.end()) {
 	    auto registered_events = iter->second;
 		for(auto &registered_event : registered_events) {
-			if(registered_event.event_id == evt) {
+			if(
+				registered_event.event_id == evt &&
+				parse->IsEncounterLoaded(registered_event.encounter_name) &&
+				!parse->IsEncounterUnloading(registered_event.encounter_name)
+			) {
 				std::string package_name = "encounter_" + registered_event.encounter_name;
 				int i = _EventSpell(package_name, evt, mob, client, spell_id, data, extra_data, extra_pointers, &registered_event.lua_reference);
                 if(i != 0) {
@@ -1550,7 +1574,11 @@ int LuaParser::DispatchEventSpell(QuestEventID evt, Mob* mob, Client *client, ui
 
 	auto registered_events = iter->second;
 	for(auto &registered_event : registered_events) {
-		if(registered_event.event_id == evt) {
+		if(
+			registered_event.event_id == evt &&
+			parse->IsEncounterLoaded(registered_event.encounter_name) &&
+			!parse->IsEncounterUnloading(registered_event.encounter_name)
+		) {
 			std::string package_name = "encounter_" + registered_event.encounter_name;
 			int i = _EventSpell(package_name, evt, mob, client, spell_id, data, extra_data, extra_pointers, &registered_event.lua_reference);
             if(i != 0)
@@ -1873,7 +1901,11 @@ int LuaParser::DispatchEventBot(
 	int ret = 0;
 	auto registered_events = iter->second;
 	for (auto &registered_event : registered_events) {
-		if (registered_event.event_id == evt) {
+		if (
+			registered_event.event_id == evt &&
+			parse->IsEncounterLoaded(registered_event.encounter_name) &&
+			!parse->IsEncounterUnloading(registered_event.encounter_name)
+		) {
 			package_name = fmt::format("encounter_{}", registered_event.encounter_name);
 			int i = _EventBot(package_name, evt, bot, init, data, extra_data, extra_pointers, &registered_event.lua_reference);
 			if (i != 0) {
@@ -2064,7 +2096,11 @@ int LuaParser::DispatchEventMerc(
 	int ret = 0;
 	auto registered_events = iter->second;
 	for (auto &registered_event : registered_events) {
-		if (registered_event.event_id == evt) {
+		if (
+			registered_event.event_id == evt &&
+			parse->IsEncounterLoaded(registered_event.encounter_name) &&
+			!parse->IsEncounterUnloading(registered_event.encounter_name)
+		) {
 			package_name = fmt::format("encounter_{}", registered_event.encounter_name);
 			int i = _EventMerc(package_name, evt, merc, init, data, extra_data, extra_pointers, &registered_event.lua_reference);
 			if (i != 0) {
@@ -2249,7 +2285,11 @@ int LuaParser::DispatchEventZone(
 	int ret = 0;
 	auto registered_events = iter->second;
 	for (auto &registered_event : registered_events) {
-		if (registered_event.event_id == evt) {
+		if (
+			registered_event.event_id == evt &&
+			parse->IsEncounterLoaded(registered_event.encounter_name) &&
+			!parse->IsEncounterUnloading(registered_event.encounter_name)
+		) {
 			package_name = fmt::format("encounter_{}", registered_event.encounter_name);
 			int i = _EventZone(package_name, evt, zone, data, extra_data, extra_pointers, &registered_event.lua_reference);
 			if (i != 0) {

--- a/zone/lua_parser_events.cpp
+++ b/zone/lua_parser_events.cpp
@@ -2262,6 +2262,35 @@ void handle_encounter_timer(
 	lua_setfield(L, -2, "timer");
 }
 
+void handle_encounter_timer_pause_resume_start(
+	QuestInterface *parse,
+	lua_State* L,
+	Encounter* encounter,
+	std::string data,
+	uint32 extra_data,
+	std::vector<std::any> *extra_pointers
+) {
+	Seperator sep(data.c_str());
+
+	lua_pushstring(L, sep.arg[0]);
+	lua_setfield(L, -2, "timer");
+
+	lua_pushinteger(L, Strings::ToUnsignedInt(sep.arg[1]));
+	lua_setfield(L, -2, "duration");
+}
+
+void handle_encounter_timer_stop(
+	QuestInterface *parse,
+	lua_State* L,
+	Encounter* encounter,
+	std::string data,
+	uint32 extra_data,
+	std::vector<std::any> *extra_pointers
+) {
+	lua_pushstring(L, data.c_str());
+	lua_setfield(L, -2, "timer");
+}
+
 void handle_encounter_load(
 	QuestInterface *parse,
 	lua_State* L,

--- a/zone/lua_parser_events.h
+++ b/zone/lua_parser_events.h
@@ -1090,6 +1090,24 @@ void handle_encounter_timer(
 	std::vector<std::any> *extra_pointers
 );
 
+void handle_encounter_timer_pause_resume_start(
+	QuestInterface *parse,
+	lua_State* L,
+	Encounter* encounter,
+	std::string data,
+	uint32 extra_data,
+	std::vector<std::any> *extra_pointers
+);
+
+void handle_encounter_timer_stop(
+	QuestInterface *parse,
+	lua_State* L,
+	Encounter* encounter,
+	std::string data,
+	uint32 extra_data,
+	std::vector<std::any> *extra_pointers
+);
+
 void handle_encounter_load(
 	QuestInterface *parse,
 	lua_State* L,

--- a/zone/quest_parser_collection.cpp
+++ b/zone/quest_parser_collection.cpp
@@ -160,6 +160,8 @@ void QuestParserCollection::FinalizeEncounterUnload(const std::string& name)
 
 	// Finalize now so same-tick unload/reload sees the encounter as unloaded.
 	entity_list.EncounterProcess();
+	// Encounter stores a bounded copy of its name; also clear the caller's key.
+	RemoveEncounter(name);
 }
 
 bool QuestParserCollection::IsEncounterLoaded(const std::string& name) const

--- a/zone/quest_parser_collection.cpp
+++ b/zone/quest_parser_collection.cpp
@@ -25,6 +25,7 @@
 #include "common/repositories/perl_event_export_settings_repository.h"
 #include "zone/quest_interface.h"
 #include "zone/questmgr.h"
+#include "zone/masterentity.h"
 #include "zone/zone.h"
 
 #include <cstdio>
@@ -106,6 +107,18 @@ void QuestParserCollection::ReloadQuests(bool reset_timers)
 	_item_quest_status.clear();
 	_encounter_quest_status.clear();
 
+	for (const auto& encounter : _encounters) {
+		if (encounter.second) {
+			_encounters_unloading[encounter.first] = true;
+			quest_manager.stopalltimers(encounter.second);
+			encounter.second->Depop();
+		}
+	}
+
+	entity_list.EncounterProcess();
+	_encounters.clear();
+	_encounters_unloading.clear();
+
 	for (const auto& e: _load_precedence) {
 		e->ReloadQuests();
 	}
@@ -113,9 +126,105 @@ void QuestParserCollection::ReloadQuests(bool reset_timers)
 
 void QuestParserCollection::RemoveEncounter(const std::string& name)
 {
+	_encounters.erase(name);
+	_encounters_unloading.erase(name);
+	RemoveEncounterRegistrations(name);
+}
+
+void QuestParserCollection::RemoveEncounterRegistrations(const std::string& name)
+{
 	for (const auto& e: _load_precedence) {
 		e->RemoveEncounter(name);
 	}
+}
+
+bool QuestParserCollection::IsEncounterLoaded(const std::string& name) const
+{
+	return _encounters.find(name) != _encounters.end();
+}
+
+bool QuestParserCollection::IsEncounterUnloading(const std::string& name) const
+{
+	return _encounters_unloading.find(name) != _encounters_unloading.end();
+}
+
+Encounter* QuestParserCollection::GetLoadedEncounter(const std::string& name)
+{
+	auto iter = _encounters.find(name);
+	if (iter == _encounters.end()) {
+		return nullptr;
+	}
+
+	return iter->second;
+}
+
+void QuestParserCollection::LoadEncounter(const std::string& name)
+{
+	if (name.empty() || IsEncounterLoaded(name) || IsEncounterUnloading(name)) {
+		return;
+	}
+
+	auto* encounter = new Encounter(name.c_str());
+	entity_list.AddEncounter(encounter);
+	_encounters[name] = encounter;
+
+	EventEncounter(EVENT_ENCOUNTER_LOAD, name, "", 0, nullptr);
+}
+
+void QuestParserCollection::LoadEncounterWithData(const std::string& name, const std::string& data)
+{
+	if (name.empty() || IsEncounterLoaded(name) || IsEncounterUnloading(name)) {
+		return;
+	}
+
+	auto* encounter = new Encounter(name.c_str());
+	entity_list.AddEncounter(encounter);
+	_encounters[name] = encounter;
+
+	std::string mutable_data = data;
+	std::vector<std::any> extra_pointers;
+	extra_pointers.push_back(&mutable_data);
+	EventEncounter(EVENT_ENCOUNTER_LOAD, name, "", 0, &extra_pointers);
+}
+
+void QuestParserCollection::UnloadEncounter(const std::string& name)
+{
+	if (!IsEncounterLoaded(name) || IsEncounterUnloading(name)) {
+		return;
+	}
+
+	_encounters_unloading[name] = true;
+	EventEncounter(EVENT_ENCOUNTER_UNLOAD, name, "", 0, nullptr);
+
+	auto* encounter = GetLoadedEncounter(name);
+	if (encounter) {
+		quest_manager.stopalltimers(encounter);
+		encounter->Depop();
+	}
+
+	RemoveEncounterRegistrations(name);
+}
+
+void QuestParserCollection::UnloadEncounterWithData(const std::string& name, const std::string& data)
+{
+	if (!IsEncounterLoaded(name) || IsEncounterUnloading(name)) {
+		return;
+	}
+
+	_encounters_unloading[name] = true;
+
+	std::string mutable_data = data;
+	std::vector<std::any> extra_pointers;
+	extra_pointers.push_back(&mutable_data);
+	EventEncounter(EVENT_ENCOUNTER_UNLOAD, name, "", 0, &extra_pointers);
+
+	auto* encounter = GetLoadedEncounter(name);
+	if (encounter) {
+		quest_manager.stopalltimers(encounter);
+		encounter->Depop();
+	}
+
+	RemoveEncounterRegistrations(name);
 }
 
 bool QuestParserCollection::HasQuestSub(uint32 npc_id, QuestEventID event_id)

--- a/zone/quest_parser_collection.cpp
+++ b/zone/quest_parser_collection.cpp
@@ -132,6 +132,7 @@ void QuestParserCollection::RemoveEncounter(const std::string& name)
 {
 	_encounters.erase(name);
 	_encounters_unloading.erase(name);
+	_encounter_quest_status.erase(name);
 	RemoveEncounterRegistrations(name);
 }
 

--- a/zone/quest_parser_collection.cpp
+++ b/zone/quest_parser_collection.cpp
@@ -50,6 +50,7 @@ QuestParserCollection::QuestParserCollection()
 	_global_merc_quest_status   = QuestUnloaded;
 	_zone_quest_status          = QuestUnloaded;
 	_global_zone_quest_status   = QuestUnloaded;
+	_encounters_reloading       = false;
 }
 
 QuestParserCollection::~QuestParserCollection() { }
@@ -106,6 +107,8 @@ void QuestParserCollection::ReloadQuests(bool reset_timers)
 	_spell_quest_status.clear();
 	_item_quest_status.clear();
 
+	_encounters_reloading = true;
+
 	for (const auto& encounter : _encounters) {
 		if (encounter.second) {
 			_encounters_unloading[encounter.first] = true;
@@ -118,6 +121,7 @@ void QuestParserCollection::ReloadQuests(bool reset_timers)
 	_encounters.clear();
 	_encounters_unloading.clear();
 	_encounter_quest_status.clear();
+	_encounters_reloading = false;
 
 	for (const auto& e: _load_precedence) {
 		e->ReloadQuests();
@@ -145,7 +149,7 @@ bool QuestParserCollection::IsEncounterLoaded(const std::string& name) const
 
 bool QuestParserCollection::IsEncounterUnloading(const std::string& name) const
 {
-	return _encounters_unloading.find(name) != _encounters_unloading.end();
+	return _encounters_reloading || _encounters_unloading.find(name) != _encounters_unloading.end();
 }
 
 Encounter* QuestParserCollection::GetLoadedEncounter(const std::string& name)

--- a/zone/quest_parser_collection.cpp
+++ b/zone/quest_parser_collection.cpp
@@ -111,6 +111,7 @@ void QuestParserCollection::ReloadQuests(bool reset_timers)
 	for (const auto& encounter : _encounters) {
 		if (encounter.second) {
 			_encounters_unloading[encounter.first] = true;
+			EventEncounter(EVENT_ENCOUNTER_UNLOAD, encounter.first, "", 0, nullptr);
 			quest_manager.stopalltimers(encounter.second);
 			encounter.second->Depop();
 		}

--- a/zone/quest_parser_collection.cpp
+++ b/zone/quest_parser_collection.cpp
@@ -105,7 +105,6 @@ void QuestParserCollection::ReloadQuests(bool reset_timers)
 
 	_spell_quest_status.clear();
 	_item_quest_status.clear();
-	_encounter_quest_status.clear();
 
 	for (const auto& encounter : _encounters) {
 		if (encounter.second) {
@@ -118,6 +117,7 @@ void QuestParserCollection::ReloadQuests(bool reset_timers)
 	entity_list.EncounterProcess();
 	_encounters.clear();
 	_encounters_unloading.clear();
+	_encounter_quest_status.clear();
 
 	for (const auto& e: _load_precedence) {
 		e->ReloadQuests();

--- a/zone/quest_parser_collection.cpp
+++ b/zone/quest_parser_collection.cpp
@@ -86,7 +86,6 @@ void QuestParserCollection::Init()
 void QuestParserCollection::ReloadQuests(bool reset_timers)
 {
 	if (reset_timers) {
-		quest_manager.ClearAllTimers();
 		zone->StopAllTimers();
 	}
 
@@ -122,6 +121,10 @@ void QuestParserCollection::ReloadQuests(bool reset_timers)
 	_encounters_unloading.clear();
 	_encounter_quest_status.clear();
 	_encounters_reloading = false;
+
+	if (reset_timers) {
+		quest_manager.ClearAllTimers();
+	}
 
 	for (const auto& e: _load_precedence) {
 		e->ReloadQuests();

--- a/zone/quest_parser_collection.cpp
+++ b/zone/quest_parser_collection.cpp
@@ -143,6 +143,21 @@ void QuestParserCollection::RemoveEncounterRegistrations(const std::string& name
 	}
 }
 
+void QuestParserCollection::FinalizeEncounterUnload(const std::string& name)
+{
+	auto* encounter = GetLoadedEncounter(name);
+	if (!encounter) {
+		RemoveEncounter(name);
+		return;
+	}
+
+	quest_manager.stopalltimers(encounter);
+	encounter->Depop();
+
+	// Finalize now so same-tick unload/reload sees the encounter as unloaded.
+	entity_list.EncounterProcess();
+}
+
 bool QuestParserCollection::IsEncounterLoaded(const std::string& name) const
 {
 	return _encounters.find(name) != _encounters.end();
@@ -201,13 +216,7 @@ void QuestParserCollection::UnloadEncounter(const std::string& name)
 	_encounters_unloading[name] = true;
 	EventEncounter(EVENT_ENCOUNTER_UNLOAD, name, "", 0, nullptr);
 
-	auto* encounter = GetLoadedEncounter(name);
-	if (encounter) {
-		quest_manager.stopalltimers(encounter);
-		encounter->Depop();
-	}
-
-	RemoveEncounterRegistrations(name);
+	FinalizeEncounterUnload(name);
 }
 
 void QuestParserCollection::UnloadEncounterWithData(const std::string& name, const std::string& data)
@@ -223,13 +232,7 @@ void QuestParserCollection::UnloadEncounterWithData(const std::string& name, con
 	extra_pointers.push_back(&mutable_data);
 	EventEncounter(EVENT_ENCOUNTER_UNLOAD, name, "", 0, &extra_pointers);
 
-	auto* encounter = GetLoadedEncounter(name);
-	if (encounter) {
-		quest_manager.stopalltimers(encounter);
-		encounter->Depop();
-	}
-
-	RemoveEncounterRegistrations(name);
+	FinalizeEncounterUnload(name);
 }
 
 bool QuestParserCollection::HasQuestSub(uint32 npc_id, QuestEventID event_id)

--- a/zone/quest_parser_collection.h
+++ b/zone/quest_parser_collection.h
@@ -408,6 +408,7 @@ private:
 	std::map<std::string, uint32> _encounter_quest_status;
 	std::map<std::string, Encounter*> _encounters;
 	std::map<std::string, bool> _encounters_unloading;
+	bool _encounters_reloading;
 };
 
 extern QuestParserCollection *parse;

--- a/zone/quest_parser_collection.h
+++ b/zone/quest_parser_collection.h
@@ -61,6 +61,13 @@ public:
 	void Init();
 	void ReloadQuests(bool reset_timers = true);
 	void RemoveEncounter(const std::string& name);
+	bool IsEncounterLoaded(const std::string& name) const;
+	bool IsEncounterUnloading(const std::string& name) const;
+	Encounter* GetLoadedEncounter(const std::string& name);
+	void LoadEncounter(const std::string& name);
+	void LoadEncounterWithData(const std::string& name, const std::string& data);
+	void UnloadEncounter(const std::string& name);
+	void UnloadEncounterWithData(const std::string& name, const std::string& data);
 
 	bool HasQuestSub(uint32 npc_id, QuestEventID event_id);
 	bool PlayerHasQuestSub(QuestEventID event_id);
@@ -380,6 +387,8 @@ private:
 		std::vector<std::any>* extra_pointers
 	);
 
+	void RemoveEncounterRegistrations(const std::string& name);
+
 	std::map<uint32, QuestInterface*> _interfaces;
 	std::map<uint32, std::string>     _extensions;
 	std::list<QuestInterface*>        _load_precedence;
@@ -397,6 +406,8 @@ private:
 	std::map<uint32, uint32>      _spell_quest_status;
 	std::map<uint32, uint32>      _item_quest_status;
 	std::map<std::string, uint32> _encounter_quest_status;
+	std::map<std::string, Encounter*> _encounters;
+	std::map<std::string, bool> _encounters_unloading;
 };
 
 extern QuestParserCollection *parse;

--- a/zone/quest_parser_collection.h
+++ b/zone/quest_parser_collection.h
@@ -387,6 +387,7 @@ private:
 		std::vector<std::any>* extra_pointers
 	);
 
+	void FinalizeEncounterUnload(const std::string& name);
 	void RemoveEncounterRegistrations(const std::string& name);
 
 	std::map<uint32, QuestInterface*> _interfaces;

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -55,6 +55,28 @@ extern EntityList entity_list;
 
 QuestManager quest_manager;
 
+namespace {
+
+void DispatchQuestTimerEvent(
+	QuestEventID event_id,
+	Mob* mob,
+	const std::function<std::string()>& lazy_data
+)
+{
+	if (!mob) {
+		return;
+	}
+
+	if (mob->IsEncounter()) {
+		parse->EventEncounter(event_id, mob->CastToEncounter()->GetEncounterName(), lazy_data(), 0, nullptr);
+		return;
+	}
+
+	parse->EventMob(event_id, mob, nullptr, lazy_data);
+}
+
+}
+
 #define QuestManagerCurrentQuestVars() \
 	Mob *owner = nullptr; \
 	Client *initiator = nullptr; \
@@ -545,7 +567,7 @@ void QuestManager::settimer(const std::string& timer_name, uint32 seconds, Mob* 
 			if (e.mob && e.mob == mob && e.name == timer_name) {
 				e.Timer_.Start(seconds * 1000, false);
 
-				parse->EventMob(EVENT_TIMER_START, mob, nullptr, f);
+				DispatchQuestTimerEvent(EVENT_TIMER_START, mob, f);
 
 				return;
 			}
@@ -554,7 +576,7 @@ void QuestManager::settimer(const std::string& timer_name, uint32 seconds, Mob* 
 
 	QTimerList.emplace_back(QuestTimer(seconds * 1000, mob, timer_name));
 
-	parse->EventMob(EVENT_TIMER_START, mob, nullptr, f);
+	DispatchQuestTimerEvent(EVENT_TIMER_START, mob, f);
 }
 
 void QuestManager::settimerMS(const std::string& timer_name, uint32 milliseconds)
@@ -594,7 +616,7 @@ void QuestManager::settimerMS(const std::string& timer_name, uint32 milliseconds
 			if (e.mob && e.mob == owner && e.name == timer_name) {
 				e.Timer_.Start(milliseconds, false);
 
-				parse->EventMob(EVENT_TIMER_START, owner, nullptr, f);
+				DispatchQuestTimerEvent(EVENT_TIMER_START, owner, f);
 
 				return;
 			}
@@ -603,7 +625,7 @@ void QuestManager::settimerMS(const std::string& timer_name, uint32 milliseconds
 
 	QTimerList.emplace_back(QuestTimer(milliseconds, owner, timer_name));
 
-	parse->EventMob(EVENT_TIMER_START, owner, nullptr, f);
+	DispatchQuestTimerEvent(EVENT_TIMER_START, owner, f);
 }
 
 void QuestManager::settimerMS(const std::string& timer_name, uint32 milliseconds, EQ::ItemInstance* inst)
@@ -632,7 +654,7 @@ void QuestManager::settimerMS(const std::string& timer_name, uint32 milliseconds
 			if (e.mob && e.mob == m && e.name == timer_name) {
 				e.Timer_.Start(milliseconds, false);
 
-				parse->EventMob(EVENT_TIMER_START, m, nullptr, f);
+				DispatchQuestTimerEvent(EVENT_TIMER_START, m, f);
 
 				return;
 			}
@@ -641,7 +663,7 @@ void QuestManager::settimerMS(const std::string& timer_name, uint32 milliseconds
 
 	QTimerList.emplace_back(QuestTimer(milliseconds, m, timer_name));
 
-	parse->EventMob(EVENT_TIMER_START, m, nullptr, f);
+	DispatchQuestTimerEvent(EVENT_TIMER_START, m, f);
 }
 
 void QuestManager::stoptimer(const std::string& timer_name)
@@ -668,7 +690,7 @@ void QuestManager::stoptimer(const std::string& timer_name)
 
 	for (auto e = QTimerList.begin(); e != QTimerList.end(); ++e) {
 		if (e->mob && e->mob == owner && e->name == timer_name) {
-			parse->EventMob(EVENT_TIMER_STOP, owner, nullptr, [&]() { return timer_name; });
+			DispatchQuestTimerEvent(EVENT_TIMER_STOP, owner, [&]() { return timer_name; });
 
 			QTimerList.erase(e);
 			break;
@@ -695,7 +717,7 @@ void QuestManager::stoptimer(const std::string& timer_name, Mob* m)
 
 	for (auto e = QTimerList.begin(); e != QTimerList.end(); ++e) {
 		if (e->mob && e->mob == m && e->name == timer_name) {
-			parse->EventMob(EVENT_TIMER_STOP, m, nullptr, [&]() { return timer_name; });
+			DispatchQuestTimerEvent(EVENT_TIMER_STOP, m, [&]() { return timer_name; });
 
 			QTimerList.erase(e);
 			break;
@@ -736,7 +758,7 @@ void QuestManager::stopalltimers()
 
 	for (auto e = QTimerList.begin(); e != QTimerList.end();) {
 		if (e->mob && e->mob == owner) {
-			parse->EventMob(EVENT_TIMER_STOP, owner, nullptr, [&]() { return e->name; });
+			DispatchQuestTimerEvent(EVENT_TIMER_STOP, owner, [&]() { return e->name; });
 
 			e = QTimerList.erase(e);
 		} else {
@@ -778,7 +800,7 @@ void QuestManager::stopalltimers(Mob* m)
 
 	for (auto e = QTimerList.begin(); e != QTimerList.end();) {
 		if (e->mob && e->mob == m) {
-			parse->EventMob(EVENT_TIMER_STOP, m, nullptr, [&]() { return e->name; });
+			DispatchQuestTimerEvent(EVENT_TIMER_STOP, m, [&]() { return e->name; });
 
 			e = QTimerList.erase(e);
 		} else {
@@ -832,7 +854,7 @@ void QuestManager::pausetimer(const std::string& timer_name, Mob* m)
 		}
 	);
 
-	parse->EventMob(EVENT_TIMER_PAUSE, mob, nullptr, [&]() {
+	DispatchQuestTimerEvent(EVENT_TIMER_PAUSE, mob, [&]() {
 		return fmt::format(
 			"{} {}",
 			timer_name,
@@ -896,7 +918,7 @@ void QuestManager::resumetimer(const std::string& timer_name, Mob* m)
 					milliseconds
 				);
 
-				parse->EventMob(EVENT_TIMER_RESUME, mob, nullptr, f);
+				DispatchQuestTimerEvent(EVENT_TIMER_RESUME, mob, f);
 
 				return;
 			}
@@ -905,7 +927,7 @@ void QuestManager::resumetimer(const std::string& timer_name, Mob* m)
 
 	QTimerList.emplace_back(QuestTimer(milliseconds, mob, timer_name));
 
-	parse->EventMob(EVENT_TIMER_RESUME, mob, nullptr, f);
+	DispatchQuestTimerEvent(EVENT_TIMER_RESUME, mob, f);
 
 	LogQuests(
 		"Creating a new timer and resuming [{}] for [{}] with [{}] ms remaining",


### PR DESCRIPTION
## Summary

Adds Perl support for the encounter system while preserving the existing Lua workflow. Perl quests can now load and unload named encounters, receive encounter lifecycle and timer events, own timers through the encounter object, and register encounter-scoped callbacks for NPC, player, item, and spell events.

The core lifecycle now lives in `QuestParserCollection`, so Lua and Perl share the same named encounter entity. Either language can load or unload an encounter, and dispatch resolves through the shared registry.

## How To Use It From Perl

Create an encounter script using the encounter name as the filename:

- `quests/<zone>/encounters/<name>.pl`
- `quests/<zone>/v<instance_version>/encounters/<name>.pl`
- `quests/global/encounters/<name>.pl`

Load and unload that encounter from a quest script:

```perl
quest::load_encounter("arena_wave");
quest::load_encounter_with_data("arena_wave", "wave=1");

quest::unload_encounter("arena_wave");
quest::unload_encounter_with_data("arena_wave", "complete");
```

In the encounter script, handle lifecycle and timers normally:

```perl
sub EVENT_ENCOUNTER_LOAD {
    quest::settimer("tick", 10, $encounter);
}

sub EVENT_TIMER {
    return unless $timer eq "tick";
    # encounter logic here
}

sub EVENT_ENCOUNTER_UNLOAD {
    quest::stopalltimers($encounter);
}
```

Encounter scripts receive these globals where relevant:

- `$encounter`
- `$encounter_name` and `$name`
- `$data`
- `$timer`
- `$duration`

Register encounter-scoped callbacks by subroutine name:

```perl
sub EVENT_ENCOUNTER_LOAD {
    quest::register_npc_event($encounter_name, EVENT_SAY, -1, "OnAnyNpcSay");
    quest::register_player_event($encounter_name, EVENT_ENTER_ZONE, "OnPlayerEnter");
}

sub OnAnyNpcSay {
    # runs only while this encounter is loaded
}

sub OnPlayerEnter {
    # player-scoped encounter callback
}
```

Inside an encounter context, the shorter overloads use the current encounter from `quest::get_encounter()`:

```perl
quest::register_npc_event(EVENT_SAY, -1, "OnAnyNpcSay");
quest::unregister_npc_event(EVENT_SAY, -1);
```

Supported registered callback families are:

- `quest::register_npc_event` / `quest::unregister_npc_event`
- `quest::register_player_event` / `quest::unregister_player_event`
- `quest::register_item_event` / `quest::unregister_item_event`
- `quest::register_spell_event` / `quest::unregister_spell_event`

## Lifecycle And Safety Notes

- Encounter-owned timers can use `quest::settimer`, `quest::settimerMS`, `quest::stoptimer`, and `quest::stopalltimers` with `$encounter`.
- `EVENT_ENCOUNTER_UNLOAD` runs before depop cleanup so scripts still have encounter context during unload.
- Encounter timers are stopped during unload and quest reload cleanup.
- Registered callbacks are removed when an encounter is removed.
- Dispatch copies callback lists so callbacks can unregister themselves or unload the encounter while dispatch is in progress.
- Unloading guards prevent duplicate unload/reload races.
- Perl encounter package names are sanitized and hash-suffixed to avoid package collisions.
- Lua keeps its public API shape; only the underlying encounter ownership moved into the shared parser layer.

## Validation

Current PR checks are green on `aff7489be`:

- GitHub Actions `pre_job`
- GitHub Actions `Linux`
- GitHub Actions `Windows`
- Cursor Bugbot

Local validation during the PR included zone builds, the repo unit-test binary, `git diff --check`, Perl smoke-script syntax checks, and an AkkStack Linux compile/deploy pass.