### PR TITLE
[Bug Fix] Fix familiar buff fade pet dismissal

### DIFF
--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -4520,9 +4520,9 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses, bool suppress, uint32 su
 			case SpellEffect::Familiar:
 			{
 				Mob *mypet = GetPet();
-				if (mypet && !suppress){
-					if(mypet->IsNPC())
-						mypet->CastToNPC()->Depop();
+				if (mypet && !suppress && mypet->IsNPC() &&
+				    mypet->CastToNPC()->GetPetSpellID() == buffs[slot].spellid) {
+					mypet->CastToNPC()->Depop();
 					SetPetID(0);
 				}
 				break;


### PR DESCRIPTION
## What changed

Backports the behavior from EQEmu/EQEmu#5063 into this repository's local `BuffFadeBySlot` implementation.

When a `SpellEffect::Familiar` buff fades, the code now only depops the current pet if it is an NPC pet and its `PetSpellID` matches the fading buff's spell ID. This prevents a later combat pet from being dismissed when an older familiar buff expires.

## Validation

- `git diff --check`
- `cmake --build build-codex --config Debug --target zone -- /m`
- `ctest -N --test-dir build-codex -C Debug` reported `Total Tests: 0`

The `zone` build completed successfully. Existing MSVC conversion warnings were emitted in unrelated files, but there were no compile errors from this change.