### PR TITLE
[Bug Fix] Include base skill damage in special attacks

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -5176,7 +5176,7 @@ int Bot::GetBaseSkillDamage(EQ::skills::SkillType skill, Mob *target)
 				ac_bonus = inst->GetItemArmorClass(true) / 25.0f;
 			if (ac_bonus > skill_bonus)
 				ac_bonus = skill_bonus;
-			return static_cast<int>(ac_bonus + skill_bonus);
+			return base + static_cast<int>(ac_bonus + skill_bonus);
 		}
 		case EQ::skills::SkillKick: {
 			float skill_bonus = skill_level / 10.0f;
@@ -5186,7 +5186,7 @@ int Bot::GetBaseSkillDamage(EQ::skills::SkillType skill, Mob *target)
 				ac_bonus = inst->GetItemArmorClass(true) / 25.0f;
 			if (ac_bonus > skill_bonus)
 				ac_bonus = skill_bonus;
-			return static_cast<int>(ac_bonus + skill_bonus);
+			return base + static_cast<int>(ac_bonus + skill_bonus);
 		}
 		case EQ::skills::SkillBash: {
 			float skill_bonus = skill_level / 10.0f;
@@ -5200,7 +5200,7 @@ int Bot::GetBaseSkillDamage(EQ::skills::SkillType skill, Mob *target)
 				ac_bonus = inst->GetItemArmorClass(true) / 25.0f;
 			if (ac_bonus > skill_bonus)
 				ac_bonus = skill_bonus;
-			return static_cast<int>(ac_bonus + skill_bonus);
+			return base + static_cast<int>(ac_bonus + skill_bonus);
 		}
 		case EQ::skills::SkillBackstab: {
 			float skill_bonus = static_cast<float>(skill_level) * 0.02f;

--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -103,10 +103,10 @@ int Mob::GetBaseSkillDamage(EQ::skills::SkillType skill, Mob *target)
 			}
 
 			if (RuleB(Character, ItemExtraSkillDamageCalcAsPercent) && GetSkillDmgAmt(skill) > 0) {
-				return static_cast<int>(ac_bonus + skill_bonus) * std::abs(GetSkillDmgAmt(skill) / 100);
+				return (base + static_cast<int>(ac_bonus + skill_bonus)) * std::abs(GetSkillDmgAmt(skill) / 100);
 			}
 
-			return static_cast<int>(ac_bonus + skill_bonus);
+			return base + static_cast<int>(ac_bonus + skill_bonus);
 		}
 		case EQ::skills::SkillKick:
 		case EQ::skills::SkillRoundKick: {
@@ -129,10 +129,10 @@ int Mob::GetBaseSkillDamage(EQ::skills::SkillType skill, Mob *target)
 			}
 
 			if (RuleB(Character, ItemExtraSkillDamageCalcAsPercent) && GetSkillDmgAmt(skill) > 0) {
-				return static_cast<int>(ac_bonus + skill_bonus) * std::abs(GetSkillDmgAmt(skill) / 100);
+				return (base + static_cast<int>(ac_bonus + skill_bonus)) * std::abs(GetSkillDmgAmt(skill) / 100);
 			}
 
-			return static_cast<int>(ac_bonus + skill_bonus);
+			return base + static_cast<int>(ac_bonus + skill_bonus);
 		}
 		case EQ::skills::SkillBash: {
 			float                  skill_bonus = skill_level / 10.0f;
@@ -161,10 +161,10 @@ int Mob::GetBaseSkillDamage(EQ::skills::SkillType skill, Mob *target)
 			}
 
 			if (RuleB(Character, ItemExtraSkillDamageCalcAsPercent) && GetSkillDmgAmt(skill) > 0) {
-				return static_cast<int>(ac_bonus + skill_bonus) * std::abs(GetSkillDmgAmt(skill) / 100);
+				return (base + static_cast<int>(ac_bonus + skill_bonus)) * std::abs(GetSkillDmgAmt(skill) / 100);
 			}
 
-			return static_cast<int>(ac_bonus + skill_bonus);
+			return base + static_cast<int>(ac_bonus + skill_bonus);
 		}
 		case EQ::skills::SkillBackstab: {
 			float skill_bonus = static_cast<float>(skill_level) * 0.02f;


### PR DESCRIPTION
## What changed

Cherry-picks the merged EQEmu/EQEmu#5061 fix into this repository.

`GetBaseSkillDamage()` already reads configured base damage from `EQ::skills::GetBaseDamage()`, but several special attack paths discarded that `base` value and returned only armor/skill-derived bonus damage. This updates the affected client/NPC and bot paths so the configured base damage is included for:

- `FlyingKick`
- `Kick`
- `RoundKick` in `Mob::GetBaseSkillDamage`
- `Bash`

## Local integration notes

The upstream commit applied cleanly as a cherry-pick with no conflicts. The resulting branch changes only `zone/bot.cpp` and `zone/special_attacks.cpp`.

## Validation

- `git diff --check master...HEAD`
- `cmake --build build-codex --config Debug --target zone -- /m`
- `ctest -N --test-dir build-codex -C Debug` reported `Total Tests: 0`

The Debug `zone` target built successfully.