### PR TITLE
[Bug Fix] Fix raid connect crash

### DIFF
--- a/zone/raids.cpp
+++ b/zone/raids.cpp
@@ -1135,7 +1135,13 @@ void Raid::SendRaidCreate(Client *to)
 	auto rc = (RaidCreate_Struct*)outapp->pBuffer;
 	rc->action = raidCreate;
 	strn0cpy(rc->leader_name, leadername, 64);
-	rc->leader_id = (GetLeader()?GetLeader()->GetID():0);
+
+	Mob *raid_leader = entity_list.GetClientByName(leadername);
+	if (!raid_leader && RuleB(Bots, Enabled)) {
+		raid_leader = entity_list.GetBotByBotName(leadername);
+	}
+
+	rc->leader_id = raid_leader ? raid_leader->GetID() : 0;
 	to->QueuePacket(outapp);
 	safe_delete(outapp);
 }
@@ -1726,8 +1732,14 @@ bool Raid::LearnMembers()
 	}
 
 	int i = 0;
+	int skipped_members = 0;
 	for (const auto &e: raid_members) {
 		if (e.name.empty()) {
+			continue;
+		}
+
+		if (i >= MAX_RAID_MEMBERS) {
+			++skipped_members;
 			continue;
 		}
 
@@ -1755,6 +1767,16 @@ bool Raid::LearnMembers()
 		members[i].is_bot          = e.bot_id > 0;
 		++i;
 	}
+
+	if (skipped_members > 0) {
+		LogError(
+			"Raid [{}] has [{}] extra raid member row(s) beyond MAX_RAID_MEMBERS [{}]; ignoring extras",
+			GetID(),
+			skipped_members,
+			MAX_RAID_MEMBERS
+		);
+	}
+
 	return true;
 }
 
@@ -2976,6 +2998,17 @@ void Raid::SendMarkTargets(Client* c)
 
 void Raid::EmptyRaidMembers()
 {
+	leader = nullptr;
+	leadername[0] = '\0';
+
+	for (auto& main_assister_pc : main_assister_pcs) {
+		main_assister_pc[0] = '\0';
+	}
+
+	for (auto& main_marker_pc : main_marker_pcs) {
+		main_marker_pc[0] = '\0';
+	}
+
 	for (int i = 0; i < MAX_RAID_MEMBERS; i++) {
 		members[i].group_number    = RAID_GROUPLESS;
 		members[i].is_group_leader = 0;

--- a/zone/raids.h
+++ b/zone/raids.h
@@ -286,11 +286,11 @@ public:
 	char main_marker_pcs[MAX_NO_RAID_MAIN_MARKERS][64];
 	Raid_Marked_NPC	marked_npcs[MAX_MARKED_NPCS];
 protected:
-	Client *leader;
-	bool locked;
-	uint32 LootType;
-	bool disbandCheck;
-	bool forceDisband;
+	Client *leader{ nullptr };
+	bool locked{ false };
+	uint32 LootType{ 4 };
+	bool disbandCheck{ false };
+	bool forceDisband{ false };
 	std::string motd;
 	RaidLeadershipAA_Struct raid_aa{};
 	GroupLeadershipAA_Struct group_aa[MAX_RAID_GROUPS]{};


### PR DESCRIPTION
## Summary

Fixes a zone crash during client connect when raid state is rebuilt and `Raid::SendRaidCreate()` sends the initial raid packet.

## Root Cause

`SendRaidCreate()` dereferenced the raid object's cached `leader` pointer to populate `leader_id`. During reconnect or cross-zone raid reloads, that pointer can be stale or null while `leadername` still reflects the persisted raid leader. `LearnMembers()` also copied every `raid_members` row into a fixed 72-member array without a hard bound, which could corrupt nearby raid state if bad or duplicate persisted rows existed.

## Changes

- Resolve the current online raid leader by `leadername` when sending the raid-create packet, including bot leaders when bots are enabled.
- Safely send `leader_id = 0` when the leader is offline instead of dereferencing cached state.
- Reset cached raid leader and assist/marker names when rebuilding raid members from the database.
- Cap loaded raid members at `MAX_RAID_MEMBERS` and log ignored overflow rows instead of writing past the fixed raid-member cache.

## Validation

- `cmake --build C:\AkkStack\code\build-codex --target zone --config RelWithDebInfo --parallel 4`
- `C:\AkkStack\code\build-codex\bin\RelWithDebInfo\tests.exe` (86/86 passed)
- `git diff --check`
- `ctest --test-dir C:\AkkStack\code\build-codex -C RelWithDebInfo -N` (no registered CTest tests)