### PR TITLE
[Feature] Add configurable crash report endpoints

### DIFF
--- a/common/crash.cpp
+++ b/common/crash.cpp
@@ -90,18 +90,23 @@ std::string CrashReport::RedactCrashReportEndpoint(const std::string &endpoint)
 
 std::string CrashReport::GetCrashReportRequestTarget(const std::string &endpoint)
 {
-	const uri u(endpoint);
+	try {
+		const uri u(endpoint);
 
-	std::string request_target = "/";
-	if (!u.get_path().empty()) {
-		request_target += u.get_path();
+		std::string request_target = "/";
+		if (!u.get_path().empty()) {
+			request_target += u.get_path();
+		}
+
+		if (!u.get_query().empty()) {
+			request_target += fmt::format("?{}", u.get_query());
+		}
+
+		return request_target;
 	}
-
-	if (!u.get_query().empty()) {
-		request_target += fmt::format("?{}", u.get_query());
+	catch (const std::exception &) {
+		return {};
 	}
-
-	return request_target;
 }
 
 std::vector<std::string> CrashReport::GetCrashReportEndpoints(const std::string &additional_endpoints)
@@ -179,27 +184,40 @@ void SendCrashReport(const std::string &crash_report)
 	for (const auto &e: CrashReport::GetCrashReportEndpoints(RuleS(Analytics, CrashReportingAdditionalEndpoints))) {
 		const auto redacted_endpoint = CrashReport::RedactCrashReportEndpoint(e);
 
-		uri u(e);
-		const auto base_url = GetCrashReportBaseUrl(u);
-		const auto request_target = CrashReport::GetCrashReportRequestTarget(e);
+		try {
+			uri u(e);
+			const auto base_url = GetCrashReportBaseUrl(u);
 
-		// client
-		httplib::Client r(base_url);
-		r.set_connection_timeout(1, 0);
-		r.set_read_timeout(1, 0);
-		r.set_write_timeout(1, 0);
+			std::string request_target = "/";
+			if (!u.get_path().empty()) {
+				request_target += u.get_path();
+			}
+			if (!u.get_query().empty()) {
+				request_target += fmt::format("?{}", u.get_query());
+			}
 
-		auto res = r.Post(request_target, payload.str(), "application/json");
-		if (!res) {
-			LogError("Failed to send crash report to [{}] error [{}]", redacted_endpoint, httplib::to_string(res.error()));
+			// client
+			httplib::Client r(base_url);
+			r.set_connection_timeout(1, 0);
+			r.set_read_timeout(1, 0);
+			r.set_write_timeout(1, 0);
+
+			auto res = r.Post(request_target, payload.str(), "application/json");
+			if (!res) {
+				LogError("Failed to send crash report to [{}] error [{}]", redacted_endpoint, httplib::to_string(res.error()));
+				continue;
+			}
+
+			if (CrashReport::IsCrashReportSuccessStatus(res->status)) {
+				LogInfo("Sent crash report to [{}]", redacted_endpoint);
+			}
+			else {
+				LogError("Failed to send crash report to [{}] status [{}]", redacted_endpoint, res->status);
+			}
+		}
+		catch (const std::exception &) {
+			LogError("Failed to send crash report to [{}] exception while sending", redacted_endpoint);
 			continue;
-		}
-
-		if (CrashReport::IsCrashReportSuccessStatus(res->status)) {
-			LogInfo("Sent crash report to [{}]", redacted_endpoint);
-		}
-		else {
-			LogError("Failed to send crash report to [{}] status [{}]", redacted_endpoint, res->status);
 		}
 	}
 }

--- a/common/crash.cpp
+++ b/common/crash.cpp
@@ -88,21 +88,24 @@ std::string CrashReport::RedactCrashReportEndpoint(const std::string &endpoint)
 	}
 }
 
+std::string CrashReport::GetCrashReportRequestTarget(const uri &endpoint_uri)
+{
+	std::string request_target = "/";
+	if (!endpoint_uri.get_path().empty()) {
+		request_target += endpoint_uri.get_path();
+	}
+
+	if (!endpoint_uri.get_query().empty()) {
+		request_target += fmt::format("?{}", endpoint_uri.get_query());
+	}
+
+	return request_target;
+}
+
 std::string CrashReport::GetCrashReportRequestTarget(const std::string &endpoint)
 {
 	try {
-		const uri u(endpoint);
-
-		std::string request_target = "/";
-		if (!u.get_path().empty()) {
-			request_target += u.get_path();
-		}
-
-		if (!u.get_query().empty()) {
-			request_target += fmt::format("?{}", u.get_query());
-		}
-
-		return request_target;
+		return GetCrashReportRequestTarget(uri(endpoint));
 	}
 	catch (const std::exception &) {
 		return {};
@@ -186,15 +189,8 @@ void SendCrashReport(const std::string &crash_report)
 
 		try {
 			uri u(e);
-			const auto base_url = GetCrashReportBaseUrl(u);
-
-			std::string request_target = "/";
-			if (!u.get_path().empty()) {
-				request_target += u.get_path();
-			}
-			if (!u.get_query().empty()) {
-				request_target += fmt::format("?{}", u.get_query());
-			}
+			const auto base_url       = GetCrashReportBaseUrl(u);
+			const auto request_target = CrashReport::GetCrashReportRequestTarget(u);
 
 			// client
 			httplib::Client r(base_url);

--- a/common/crash.cpp
+++ b/common/crash.cpp
@@ -13,26 +13,175 @@
 #include "common/version.h"
 
 #include <cstdio>
+#include <exception>
+#include <sstream>
 #include <vector>
 
-void SendCrashReport(const std::string &crash_report)
-{
-	// can configure multiple endpoints if need be
-	std::vector<std::string> endpoints = {
-		"https://spire.eqemu.dev/api/v1/analytics/server-crash-report",
-//		"http://localhost:3010/api/v1/analytics/server-crash-report", // development
-	};
+namespace {
+	const std::string kBuiltInCrashReportEndpoint = "https://spire.eqemu.dev/api/v1/analytics/server-crash-report";
 
-	EQEmuLogSys* log = EQEmuLogSys::Instance();
-
-	auto      config = EQEmuConfig::get();
-	for (auto &e: endpoints) {
-		uri u(e);
-
-		std::string base_url = fmt::format("{}://{}", u.get_scheme(), u.get_host());
+	std::string GetCrashReportBaseUrl(const uri &u)
+	{
+		std::string base_url = fmt::format("{}://{}", Strings::ToLower(u.get_scheme()), u.get_host());
 		if (u.get_port()) {
 			base_url += fmt::format(":{}", u.get_port());
 		}
+
+		return base_url;
+	}
+
+	std::vector<std::string> GetPathSegments(const std::string &path)
+	{
+		std::vector<std::string> segments;
+		for (auto segment : Strings::Split(path, '/')) {
+			Strings::Trim(segment);
+			if (!segment.empty()) {
+				segments.emplace_back(segment);
+			}
+		}
+
+		return segments;
+	}
+}
+
+bool CrashReport::IsCrashReportEndpoint(const std::string &endpoint)
+{
+	try {
+		const uri   u(endpoint);
+		const auto scheme = Strings::ToLower(u.get_scheme());
+		return (scheme == "http" || scheme == "https") && !u.get_host().empty();
+	}
+	catch (const std::exception &) {
+		return false;
+	}
+}
+
+bool CrashReport::IsCrashReportSuccessStatus(int status)
+{
+	return status >= 200 && status < 300;
+}
+
+std::string CrashReport::RedactCrashReportEndpoint(const std::string &endpoint)
+{
+	try {
+		const uri u(endpoint);
+
+		std::string redacted = GetCrashReportBaseUrl(u);
+		const auto  segments = GetPathSegments(u.get_path());
+		if (segments.size() > 2) {
+			for (size_t i = 0; i < 2; ++i) {
+				redacted += fmt::format("/{}", segments[i]);
+			}
+			redacted += "/...";
+		}
+		else if (!segments.empty()) {
+			redacted += "/...";
+		}
+		else {
+			redacted += "/";
+		}
+
+		return redacted;
+	}
+	catch (const std::exception &) {
+		return "[invalid crash report endpoint]";
+	}
+}
+
+std::string CrashReport::GetCrashReportRequestTarget(const std::string &endpoint)
+{
+	const uri u(endpoint);
+
+	std::string request_target = "/";
+	if (!u.get_path().empty()) {
+		request_target += u.get_path();
+	}
+
+	if (!u.get_query().empty()) {
+		request_target += fmt::format("?{}", u.get_query());
+	}
+
+	return request_target;
+}
+
+std::vector<std::string> CrashReport::GetCrashReportEndpoints(const std::string &additional_endpoints)
+{
+	std::vector<std::string> endpoints = {
+		kBuiltInCrashReportEndpoint,
+//		"http://localhost:3010/api/v1/analytics/server-crash-report", // development
+	};
+
+	if (additional_endpoints.empty()) {
+		return endpoints;
+	}
+
+	for (auto endpoint : Strings::Split(additional_endpoints, ';')) {
+		Strings::Trim(endpoint);
+		if (endpoint.empty()) {
+			continue;
+		}
+
+		if (!IsCrashReportEndpoint(endpoint)) {
+			LogWarning("Skipping invalid crash report endpoint [{}]", RedactCrashReportEndpoint(endpoint));
+			continue;
+		}
+
+		endpoints.emplace_back(endpoint);
+	}
+
+	return endpoints;
+}
+
+void SendCrashReport(const std::string &crash_report)
+{
+	EQEmuLogSys* log = EQEmuLogSys::Instance();
+
+	auto config = EQEmuConfig::get();
+
+	// os info
+	auto os         = EQ::GetOS();
+	auto cpus       = EQ::GetCPUs();
+	auto process_id = EQ::GetPID();
+	auto rss        = EQ::GetRSS() / 1048576.0;
+	auto uptime     = static_cast<uint32>(EQ::GetUptime());
+
+	// payload
+	Json::Value p;
+	p["platform_name"]     = GetPlatformName();
+	p["crash_report"]      = crash_report;
+	p["server_version"]    = CURRENT_VERSION;
+	p["compile_date"]      = COMPILE_DATE;
+	p["compile_time"]      = COMPILE_TIME;
+	p["server_name"]       = config->LongName;
+	p["server_short_name"] = config->ShortName;
+	p["uptime"]            = uptime;
+	p["os_machine"]        = os.machine;
+	p["os_release"]        = os.release;
+	p["os_version"]        = os.version;
+	p["os_sysname"]        = os.sysname;
+	p["process_id"]        = process_id;
+	p["rss_memory"]        = rss;
+	p["cpus"]              = cpus.size();
+	p["origination_info"]  = "";
+
+	if (!log->origination_info.zone_short_name.empty()) {
+		p["origination_info"] = fmt::format(
+			"{} ({}) instance_id [{}]",
+			log->origination_info.zone_short_name,
+			log->origination_info.zone_long_name,
+			log->origination_info.instance_id
+		);
+	}
+
+	std::stringstream payload;
+	payload << p;
+
+	for (const auto &e: CrashReport::GetCrashReportEndpoints(RuleS(Analytics, CrashReportingAdditionalEndpoints))) {
+		const auto redacted_endpoint = CrashReport::RedactCrashReportEndpoint(e);
+
+		uri u(e);
+		const auto base_url = GetCrashReportBaseUrl(u);
+		const auto request_target = CrashReport::GetCrashReportRequestTarget(e);
 
 		// client
 		httplib::Client r(base_url);
@@ -40,51 +189,17 @@ void SendCrashReport(const std::string &crash_report)
 		r.set_read_timeout(1, 0);
 		r.set_write_timeout(1, 0);
 
-		// os info
-		auto os         = EQ::GetOS();
-		auto cpus       = EQ::GetCPUs();
-		auto process_id = EQ::GetPID();
-		auto rss        = EQ::GetRSS() / 1048576.0;
-		auto uptime     = static_cast<uint32>(EQ::GetUptime());
-
-		// payload
-		Json::Value p;
-		p["platform_name"]     = GetPlatformName();
-		p["crash_report"]      = crash_report;
-		p["server_version"]    = CURRENT_VERSION;
-		p["compile_date"]      = COMPILE_DATE;
-		p["compile_time"]      = COMPILE_TIME;
-		p["server_name"]       = config->LongName;
-		p["server_short_name"] = config->ShortName;
-		p["uptime"]            = uptime;
-		p["os_machine"]        = os.machine;
-		p["os_release"]        = os.release;
-		p["os_version"]        = os.version;
-		p["os_sysname"]        = os.sysname;
-		p["process_id"]        = process_id;
-		p["rss_memory"]        = rss;
-		p["cpus"]              = cpus.size();
-		p["origination_info"]  = "";
-
-		if (!log->origination_info.zone_short_name.empty()) {
-			p["origination_info"] = fmt::format(
-				"{} ({}) instance_id [{}]",
-				log->origination_info.zone_short_name,
-				log->origination_info.zone_long_name,
-				log->origination_info.instance_id
-			);
+		auto res = r.Post(request_target, payload.str(), "application/json");
+		if (!res) {
+			LogError("Failed to send crash report to [{}] error [{}]", redacted_endpoint, httplib::to_string(res.error()));
+			continue;
 		}
 
-		std::stringstream payload;
-		payload << p;
-
-		if (auto res = r.Post(e, payload.str(), "application/json")) {
-			if (res->status == 200) {
-				LogInfo("Sent crash report");
-			}
-			else {
-				LogError("Failed to send crash report to [{}]", e);
-			}
+		if (CrashReport::IsCrashReportSuccessStatus(res->status)) {
+			LogInfo("Sent crash report to [{}]", redacted_endpoint);
+		}
+		else {
+			LogError("Failed to send crash report to [{}] status [{}]", redacted_endpoint, res->status);
 		}
 	}
 }

--- a/common/crash.h
+++ b/common/crash.h
@@ -3,9 +3,12 @@
 #include <string>
 #include <vector>
 
+class uri;
+
 namespace CrashReport {
 	std::vector<std::string> GetCrashReportEndpoints(const std::string &additional_endpoints);
 	std::string RedactCrashReportEndpoint(const std::string &endpoint);
+	std::string GetCrashReportRequestTarget(const uri &endpoint_uri);
 	std::string GetCrashReportRequestTarget(const std::string &endpoint);
 	bool IsCrashReportEndpoint(const std::string &endpoint);
 	bool IsCrashReportSuccessStatus(int status);

--- a/common/crash.h
+++ b/common/crash.h
@@ -1,3 +1,15 @@
 #pragma once
 
+#include <string>
+#include <vector>
+
+namespace CrashReport {
+	std::vector<std::string> GetCrashReportEndpoints(const std::string &additional_endpoints);
+	std::string RedactCrashReportEndpoint(const std::string &endpoint);
+	std::string GetCrashReportRequestTarget(const std::string &endpoint);
+	bool IsCrashReportEndpoint(const std::string &endpoint);
+	bool IsCrashReportSuccessStatus(int status);
+}
+
+void SendCrashReport(const std::string &crash_report);
 void set_exception_handler();

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -1078,6 +1078,7 @@ RULE_CATEGORY_END()
 
 RULE_CATEGORY(Analytics)
 RULE_BOOL(Analytics, CrashReporting, true, "Automatic crash reporting analytics for EQEmu Server developers")
+RULE_STRING(Analytics, CrashReportingAdditionalEndpoints, "", "Semicolon-delimited list of additional crash report POST URLs. Spire remains the built-in default endpoint.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Logging)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ set(tests_sources
 set(tests_headers
 	atobool_test.h
 	buyer_buy_lines_repository_test.h
+	crash_report_endpoint_test.h
 	data_verification_test.h
 	fixed_memory_test.h
 	fixed_memory_variable_test.h

--- a/tests/crash_report_endpoint_test.h
+++ b/tests/crash_report_endpoint_test.h
@@ -1,0 +1,142 @@
+/*	EQEMu: Everquest Server Emulator
+	Copyright (C) 2001-2026 EQEmu Development Team (http://eqemulator.net)
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; version 2 of the License.
+
+	This program is distributed in the hope that it will be useful,
+	without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+	A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+*/
+
+#pragma once
+
+#include "common/crash.h"
+#include "common/http/httplib.h"
+#include "common/rulesys.h"
+#include "cppunit/cpptest.h"
+
+#include <atomic>
+#include <thread>
+
+class CrashReportEndpointTest : public Test::Suite {
+	typedef void(CrashReportEndpointTest::*TestFunction)(void);
+public:
+	CrashReportEndpointTest() {
+		TEST_ADD(CrashReportEndpointTest::DefaultEndpointTest);
+		TEST_ADD(CrashReportEndpointTest::AdditionalEndpointParsingTest);
+		TEST_ADD(CrashReportEndpointTest::RuleValueEndpointTest);
+		TEST_ADD(CrashReportEndpointTest::SuccessStatusTest);
+		TEST_ADD(CrashReportEndpointTest::RedactedEndpointTest);
+		TEST_ADD(CrashReportEndpointTest::RequestTargetTest);
+		TEST_ADD(CrashReportEndpointTest::LocalHttpNoContentTest);
+	}
+
+	~CrashReportEndpointTest() {
+	}
+
+private:
+	void DefaultEndpointTest() {
+		const auto endpoints = CrashReport::GetCrashReportEndpoints("");
+		TEST_ASSERT(endpoints.size() == 1);
+		TEST_ASSERT(endpoints[0] == "https://spire.eqemu.dev/api/v1/analytics/server-crash-report");
+	}
+
+	void AdditionalEndpointParsingTest() {
+		const auto endpoints = CrashReport::GetCrashReportEndpoints(
+			" https://one.example/path ; ; ftp://bad.example/token ; not-a-url ; http://two.example:8080/path "
+		);
+
+		TEST_ASSERT(endpoints.size() == 3);
+		TEST_ASSERT(endpoints[0] == "https://spire.eqemu.dev/api/v1/analytics/server-crash-report");
+		TEST_ASSERT(endpoints[1] == "https://one.example/path");
+		TEST_ASSERT(endpoints[2] == "http://two.example:8080/path");
+	}
+
+	void RuleValueEndpointTest() {
+		const auto was_set = RuleManager::Instance()->SetRule(
+			"Analytics:CrashReportingAdditionalEndpoints",
+			"https://example.com/api/webhook-inbox/webhookId/token"
+		);
+		TEST_ASSERT(was_set);
+
+		const auto endpoints = CrashReport::GetCrashReportEndpoints(RuleS(Analytics, CrashReportingAdditionalEndpoints));
+		RuleManager::Instance()->ResetRules();
+
+		TEST_ASSERT(endpoints.size() == 2);
+		TEST_ASSERT(endpoints[0] == "https://spire.eqemu.dev/api/v1/analytics/server-crash-report");
+		TEST_ASSERT(endpoints[1] == "https://example.com/api/webhook-inbox/webhookId/token");
+	}
+
+	void SuccessStatusTest() {
+		TEST_ASSERT(!CrashReport::IsCrashReportSuccessStatus(199));
+		TEST_ASSERT(CrashReport::IsCrashReportSuccessStatus(200));
+		TEST_ASSERT(CrashReport::IsCrashReportSuccessStatus(204));
+		TEST_ASSERT(CrashReport::IsCrashReportSuccessStatus(299));
+		TEST_ASSERT(!CrashReport::IsCrashReportSuccessStatus(300));
+	}
+
+	void RedactedEndpointTest() {
+		const auto redacted = CrashReport::RedactCrashReportEndpoint(
+			"https://example.com/api/webhook-inbox/webhookId/token?secret=1"
+		);
+
+		TEST_ASSERT(redacted == "https://example.com/api/webhook-inbox/...");
+		TEST_ASSERT(redacted.find("webhookId") == std::string::npos);
+		TEST_ASSERT(redacted.find("token") == std::string::npos);
+		TEST_ASSERT(redacted.find("secret") == std::string::npos);
+
+		const auto short_path_redacted = CrashReport::RedactCrashReportEndpoint("https://example.com/token");
+		TEST_ASSERT(short_path_redacted == "https://example.com/...");
+		TEST_ASSERT(short_path_redacted.find("token") == std::string::npos);
+	}
+
+	void RequestTargetTest() {
+		const auto request_target = CrashReport::GetCrashReportRequestTarget(
+			"https://example.com/api/webhook-inbox/webhookId/token?source=server"
+		);
+
+		TEST_ASSERT(request_target == "/api/webhook-inbox/webhookId/token?source=server");
+	}
+
+	void LocalHttpNoContentTest() {
+		httplib::Server server;
+		std::atomic_bool received(false);
+		std::string received_body;
+
+		server.Post("/api/webhook-inbox/webhookId/token", [&](const httplib::Request &req, httplib::Response &res) {
+			received = true;
+			received_body = req.body;
+			res.status = 204;
+		});
+
+		const auto port = server.bind_to_any_port("127.0.0.1");
+		TEST_ASSERT(port > 0);
+
+		std::thread server_thread([&server]() {
+			server.listen_after_bind();
+		});
+
+		httplib::Client client("http://127.0.0.1:" + std::to_string(port));
+		client.set_connection_timeout(1, 0);
+		client.set_read_timeout(1, 0);
+		client.set_write_timeout(1, 0);
+
+		const auto endpoint = "http://127.0.0.1:" + std::to_string(port) + "/api/webhook-inbox/webhookId/token";
+		const auto res = client.Post(
+			CrashReport::GetCrashReportRequestTarget(endpoint),
+			"{\"crash_report\":\"test\"}",
+			"application/json"
+		);
+
+		server.stop();
+		server_thread.join();
+
+		TEST_ASSERT(res);
+		TEST_ASSERT(CrashReport::IsCrashReportSuccessStatus(res->status));
+		TEST_ASSERT(res->status == 204);
+		TEST_ASSERT(received);
+		TEST_ASSERT(received_body == "{\"crash_report\":\"test\"}");
+	}
+};

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -18,6 +18,7 @@
 
 #include "tests/atobool_test.h"
 #include "tests/buyer_buy_lines_repository_test.h"
+#include "tests/crash_report_endpoint_test.h"
 #include "tests/data_verification_test.h"
 #include "tests/fixed_memory_test.h"
 #include "tests/fixed_memory_variable_test.h"
@@ -56,6 +57,7 @@ int main()
 		tests.add(new FixedMemoryVariableHashTest());
 		tests.add(new atoboolTest());
 		tests.add(new BuyerBuyLinesRepositoryTest());
+		tests.add(new CrashReportEndpointTest());
 		tests.add(new hextoi_32_64_Test());
 		tests.add(new StringUtilTest());
 		tests.add(new DataVerificationTest());


### PR DESCRIPTION
## Summary

This keeps the existing built-in Spire crash reporting path intact and adds an additive rules-based way to post the same crash payload to additional receivers.

Changes included:
- Added `Analytics:CrashReportingAdditionalEndpoints` as a string rule under the existing `Analytics` category. The default is empty, and the rule accepts a semicolon-delimited list of additional crash-report POST URLs.
- Updated `SendCrashReport(...)` to always send to the existing Spire endpoint and append any valid `http://` or `https://` URLs configured by the new rule.
- Preserved the existing crash payload shape and `Analytics:CrashReporting` gate.
- Treats any HTTP `2xx` response as success, including webhook receivers that return `204 No Content`.
- Skips blank or invalid configured endpoint entries, continues trying the remaining endpoints after failures, and redacts endpoint logs so webhook IDs/tokens are not printed.
- Added focused tests for default endpoint behavior, semicolon parsing, rule lookup, URL validation/redaction, request target handling, and `204` success handling.

## Validation

- `git diff --check`
- `cmake --build build-codex --target tests --config Debug -- /m:4`
- `./build-codex/bin/Debug/tests.exe` — `97 tests, 100% correct`
- `cmake --build build-codex --target zone --config Debug -- /m:4`
- `emu-compile` Linux test build with `-Targets tests -RunTests`
- Full `emu-compile` Linux build/deploy to `C:\AkkStack\server\bin`
- Manual AkkStack crash telemetry test with `#crash`: crash report was sent to Spire and the configured additional endpoint, and the additional receiver persisted the payload.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches crash-report sending logic and adds outbound HTTP posting to user-configured URLs; failures are handled defensively but mistakes could change where crash data is sent or logged.
> 
> **Overview**
> **Crash reporting can now POST to additional, configurable endpoints.** A new `Analytics:CrashReportingAdditionalEndpoints` string rule accepts a semicolon-delimited list of extra `http(s)` URLs that are appended to the built-in Spire endpoint.
> 
> `SendCrashReport` was refactored to validate/parse endpoints, build the correct request target (path+query), treat any *2xx* as success (including `204`), and improve failure handling (continue on errors) while redacting endpoint logs to avoid leaking webhook tokens. Focused unit tests were added to cover parsing/validation, redaction, request-target construction, and 2xx status handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 962e605e9a5747793ec7b005ddc8acd2dcf92f7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->