### PR TITLE
[CI] Cache Windows vcpkg binary packages

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -91,6 +91,21 @@ jobs:
         with:
           arch: x64
 
+      - name: Restore vcpkg binary cache
+        uses: actions/cache@v4
+        with:
+          path: .vcpkg-binary-cache
+          key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json', 'submodules/vcpkg/scripts/vcpkg-tool-metadata.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-vcpkg-
+
+      - name: Configure vcpkg binary cache
+        shell: pwsh
+        run: |
+          $cachePath = Join-Path $env:GITHUB_WORKSPACE ".vcpkg-binary-cache"
+          New-Item -ItemType Directory -Force -Path $cachePath | Out-Null
+          "VCPKG_BINARY_SOURCES=clear;files,$cachePath,readwrite" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
       - name: Configure
         shell: pwsh
         run: |


### PR DESCRIPTION
## Summary

Adds a low-risk vcpkg binary package cache to the Windows PR build job.

The Windows builder spends a large portion of CI time in CMake configure while vcpkg resolves/builds dependencies. This change configures a file-based vcpkg binary cache under `.vcpkg-binary-cache` and persists it with `actions/cache@v4`, so future runs can restore ABI-checked vcpkg package archives instead of rebuilding them from scratch.

Scope is intentionally narrow:
- Only `.github/workflows/build.yaml` is changed.
- Linux CI is unchanged.
- Windows still uses the same Visual Studio generator, CMake options, `ALL_BUILD` target, and test executable.
- The whole build directory and `vcpkg_installed` tree are not cached.

## Validation

Local preflight:
- `git diff --check`
- YAML parse check for `.github/workflows/build.yaml`
- Verified the pinned vcpkg supports file-based `VCPKG_BINARY_SOURCES` caching.

CI validation on this PR:
- Initial Windows run passed configure/build/test and saved cache key `Windows-vcpkg-ef7b3444686d466f7ec150451aeb0f3c079fa71894167403a4805ae3dab675cb`.
- Initial Windows run: configure `8m48s`, build `7m16s`, total `16m50s`.
- Windows rerun restored the cache from the primary key and passed configure/build/test.
- Warm-cache Windows rerun: configure `59s`, build `11m53s`, total `13m36s`.
- Linux rerun passed checkout/build/test. The earlier Linux failure happened during `actions/checkout` submodule fetch before build/test and was not related to this Windows-only workflow change.

Final PR checks: `pre_job`, `Linux`, `Windows`, and `Cursor Bugbot` are passing.