### PR TITLE
[CI] Cache Linux vcpkg binary packages

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,6 +39,21 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ runner.os }}-ccache-${{ hashFiles('CMakeLists.txt', '.github/workflows/build.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-ccache-
+
+      - name: Restore vcpkg binary cache
+        uses: actions/cache@v4
+        with:
+          path: .vcpkg-binary-cache
+          key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json', 'submodules/vcpkg/scripts/vcpkg-tool-metadata.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-vcpkg-
+
+      - name: Configure vcpkg binary cache
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/.vcpkg-binary-cache"
+          echo "VCPKG_BINARY_SOURCES=clear;files,$GITHUB_WORKSPACE/.vcpkg-binary-cache,readwrite" >> "$GITHUB_ENV"
 
       - name: Ensure ccache installed
         run: |


### PR DESCRIPTION
## Summary

Adds a low-risk vcpkg binary package cache to the Linux PR build job.

The Linux builder invokes vcpkg during CMake configure, but the default vcpkg archive path was inside the ephemeral container home and was not persisted between CI runs. This change restores/saves `.vcpkg-binary-cache` with `actions/cache@v4` and points vcpkg at it through `VCPKG_BINARY_SOURCES`.

Also adds a broad Linux ccache restore prefix so the existing compiler cache can still be reused when the exact workflow hash changes.

Scope is intentionally narrow:
- Only `.github/workflows/build.yaml` is changed.
- Build flags, CMake generator, `make -j$(nproc)`, and test execution are unchanged.
- The build directory and `vcpkg_installed` tree are not cached.
- Windows CI is unchanged in this branch.

## Validation

Local preflight:
- `git diff --check`
- YAML parse check for `.github/workflows/build.yaml`

CI validation on this PR:
- Cold Linux run passed checkout/build/test and saved vcpkg cache key `Linux-vcpkg-7cce7dc7ebefa9b230cde1a89a0a1efefe30b76eab3100fa2f9b60e32398fe45`.
- Cold Linux run: build step `16m55s`, total `17m54s`.
- Warm Linux rerun restored vcpkg cache from the primary key and restored 51 packages in `462ms`.
- Warm Linux rerun restored ccache and reported `133 / 136` cacheable compile calls as hits (`97.79%`).
- Warm Linux rerun passed build/test: build step `7m08s`, total `8m04s`.
- Windows passed unchanged on this branch.

Final PR checks: `pre_job`, `Linux`, `Windows`, and `Cursor Bugbot` are passing.