### PR TITLE
[CI] Use Ninja for Linux CI build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,8 +70,7 @@ jobs:
       - name: Build
         working-directory: ${{ github.workspace }}
         run: |
-          mkdir -p build && cd build
-          cmake \
+          cmake -S . -B build -G Ninja \
             -DEQEMU_BUILD_TESTS=ON \
             -DEQEMU_BUILD_LOGIN=ON \
             -DEQEMU_BUILD_LUA=ON \
@@ -79,9 +78,8 @@ jobs:
             -DEQEMU_BUILD_CLIENT_FILES=ON \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            ..
-          make -j"$(nproc)"
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          cmake --build build --parallel
 
       - name: Test
         working-directory: ${{ github.workspace }}/build


### PR DESCRIPTION
## Summary
- switches the Linux PR CI build from implicit Unix Makefiles to explicit Ninja
- keeps the existing RelWithDebInfo configuration, vcpkg binary cache, ccache launchers, and test command unchanged
- leaves Windows CI and release workflows untouched for the first staged rollout

## Why
This is the low-risk first step in moving PR CI toward a consistent single-config Ninja build flow. Linux release builds already use Ninja in this repo, so this isolates generator migration from the Windows output-layout risks.

## Validation
- `git diff --check`
- parsed `.github/workflows/build.yaml` with PyYAML

## Follow-up
After this PR is green and timing is collected, the next staged PR should migrate Windows PR CI to Ninja and verify `build/bin/tests.exe` as the test path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts the Linux GitHub Actions build invocation (CMake generator and build command) without changing build flags, caching, or test execution.
> 
> **Overview**
> Switches the Linux GitHub Actions workflow to configure CMake with the explicit `Ninja` generator (`cmake -S . -B build -G Ninja`) and to build via `cmake --build build --parallel` instead of invoking `make` from a manually-created build directory.
> 
> All existing Linux build options (tests/login/Lua/Perl/client files, `RelWithDebInfo`, and `ccache` launchers) and the test command remain the same, and the Windows job is untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6748c70419d5acb40041b4a72fbf4c81ed071767. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->