### PR TITLE
[CI] Use Ninja for Windows CI build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -122,7 +122,7 @@ jobs:
       - name: Configure
         shell: pwsh
         run: |
-          cmake -S . -B build -G "Visual Studio 17 2022" -A x64 `
+          cmake -S . -B build -G Ninja `
             -DCMAKE_BUILD_TYPE=RelWithDebInfo `
             -DEQEMU_BUILD_TESTS=ON `
             -DEQEMU_BUILD_LOGIN=ON `
@@ -132,8 +132,8 @@ jobs:
 
       - name: Build
         shell: pwsh
-        run: cmake --build build --config RelWithDebInfo --target ALL_BUILD -- /m
+        run: cmake --build build --parallel
 
       - name: Test
         working-directory: build
-        run: ./bin/RelWithDebInfo/tests.exe
+        run: ./bin/tests.exe


### PR DESCRIPTION
## Summary
- switches the Windows PR CI build from the Visual Studio generator to Ninja while keeping the MSVC developer environment
- removes the Visual Studio-only `-A x64` and `--config RelWithDebInfo` build path assumptions
- updates the Windows test command to the single-config Ninja output path: `build/bin/tests.exe`

## Why
This is the second staged Ninja rollout PR, stacked on the Linux Ninja PR. Keeping it separate isolates the Windows output-layout risk from the already-proven Linux generator change.

## Validation
- `git diff --check`
- parsed `.github/workflows/build.yaml` with PyYAML
- stacked on PR #129, which passed Linux Ninja warm validation and the unchanged Windows control check

## Notes
After PR #129 merges, this PR should be retargeted to `master` before merge. Release workflow packaging remains unchanged until Windows PR CI proves the Ninja output paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that alters the Windows build generator/output layout; main risk is unexpected build/test path differences on `windows-latest`.
> 
> **Overview**
> Updates the Windows GitHub Actions build to use the single-config Ninja generator instead of the Visual Studio generator.
> 
> This removes Visual Studio-specific build assumptions (no `-A x64`, no `--config RelWithDebInfo`/`ALL_BUILD`, uses `cmake --build ... --parallel`) and adjusts the test invocation to the Ninja output path (`build/bin/tests.exe`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3086e3e4ed21625718bda2b0f1a8311a72cc485. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->