### PR TITLE
[CI] Add manual release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,9 +51,11 @@ jobs:
 
       - name: Validate manual release request
         shell: bash
+        env:
+          CONFIRM: ${{ inputs.confirm }}
         run: |
           set -euo pipefail
-          if [ "${{ inputs.confirm }}" != "release" ]; then
+          if [ "$CONFIRM" != "release" ]; then
             echo "Confirmation input must exactly equal 'release'."
             exit 1
           fi
@@ -71,6 +73,8 @@ jobs:
       - name: Compute and apply release version
         id: version
         shell: bash
+        env:
+          BUMP: ${{ inputs.bump }}
         run: |
           set -euo pipefail
           git fetch --tags --force
@@ -80,7 +84,7 @@ jobs:
             latest_tag="v${package_version}"
           fi
 
-          version="$(python3 utils/scripts/release/release_version.py compute --latest-tag "$latest_tag" --bump "${{ inputs.bump }}")"
+          version="$(python3 utils/scripts/release/release_version.py compute --latest-tag "$latest_tag" --bump "$BUMP")"
           tag="v${version}"
           if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
             echo "Tag ${tag} already exists."

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Checkout release branch
         uses: actions/checkout@v5
         with:
-          ref: master
+          ref: ${{ env.RELEASE_BRANCH }}
           fetch-depth: 0
           submodules: recursive
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,24 +1,151 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - master
-    tags:
-      - 'v*'
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: Release type
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      draft:
+        description: Create the GitHub release as a draft
+        required: true
+        type: boolean
+        default: false
+      confirm:
+        description: Type "release" to confirm
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: manual-release
+  cancel-in-progress: false
+
+env:
+  RELEASE_BRANCH: master
 
 jobs:
+  prepare-release:
+    name: Prepare Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      tag: ${{ steps.version.outputs.tag }}
+      release_sha: ${{ steps.publish.outputs.release_sha }}
+    steps:
+      - name: Checkout release branch
+        uses: actions/checkout@v5
+        with:
+          ref: master
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Validate manual release request
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ inputs.confirm }}" != "release" ]; then
+            echo "Confirmation input must exactly equal 'release'."
+            exit 1
+          fi
+          if [ "$GITHUB_REF" != "refs/heads/${RELEASE_BRANCH}" ]; then
+            echo "Release workflow must be run from ${RELEASE_BRANCH}; current ref is ${GITHUB_REF}."
+            exit 1
+          fi
+
+      - name: Configure git identity
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Compute and apply release version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --tags --force
+          latest_tag="$(git tag --list 'v*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)"
+          if [ -z "$latest_tag" ]; then
+            package_version="$(python3 -c 'import json; print(json.load(open("package.json", encoding="utf-8"))["version"])')"
+            latest_tag="v${package_version}"
+          fi
+
+          version="$(python3 utils/scripts/release/release_version.py compute --latest-tag "$latest_tag" --bump "${{ inputs.bump }}")"
+          tag="v${version}"
+          if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+            echo "Tag ${tag} already exists."
+            exit 1
+          fi
+
+          python3 utils/scripts/release/release_version.py set --version "$version" --channel release
+
+          echo "latest_tag=${latest_tag}" >> "$GITHUB_OUTPUT"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Commit release version and tag
+        id: publish
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- package.json common/version.h CMakeLists.txt; then
+            echo "No release version changes were produced."
+            exit 1
+          fi
+
+          git add package.json common/version.h CMakeLists.txt
+          git commit -m "chore(release): ${TAG}"
+          git tag -a "$TAG" -m "Release ${TAG}"
+
+          release_sha="$(git rev-parse HEAD)"
+          git push origin HEAD:${RELEASE_BRANCH}
+          git push origin "$TAG"
+
+          echo "release_sha=${release_sha}" >> "$GITHUB_OUTPUT"
+
+      - name: Restore dev version on release branch
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          python3 utils/scripts/release/release_version.py set --version "$VERSION" --channel dev
+
+          if git diff --quiet -- common/version.h; then
+            echo "CURRENT_VERSION already has the expected dev suffix."
+            exit 0
+          fi
+
+          git add common/version.h
+          git commit -m "chore(release): restore ${VERSION}-dev"
+          git push origin HEAD:${RELEASE_BRANCH}
+
   build-linux:
     name: Build Linux
+    needs: prepare-release
     runs-on: ubuntu-latest
     container:
       image: akkadius/eqemu-server:v16
-      # Run as root to avoid EACCES on GitHub Actions runner file command writes in the container.
       options: --user 0
     steps:
-      - name: Checkout source
+      - name: Checkout release tag
         uses: actions/checkout@v5
         with:
+          ref: ${{ needs.prepare-release.outputs.tag }}
+          fetch-depth: 0
           submodules: recursive
 
       - name: Mark workspace safe
@@ -28,13 +155,30 @@ jobs:
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: ${{ runner.os }}-release-ccache-${{ hashFiles('.github/workflows/release.yaml') }}
+          key: ${{ runner.os }}-release-ccache-${{ hashFiles('CMakeLists.txt', '.github/workflows/release.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-release-ccache-
+
+      - name: Restore vcpkg binary cache
+        uses: actions/cache@v4
+        with:
+          path: .vcpkg-binary-cache
+          key: ${{ runner.os }}-release-vcpkg-${{ hashFiles('vcpkg.json', 'submodules/vcpkg/scripts/vcpkg-tool-metadata.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-release-vcpkg-
+            ${{ runner.os }}-vcpkg-
+
+      - name: Configure vcpkg binary cache
+        shell: bash
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/.vcpkg-binary-cache"
+          echo "VCPKG_BINARY_SOURCES=clear;files,$GITHUB_WORKSPACE/.vcpkg-binary-cache,readwrite" >> "$GITHUB_ENV"
 
       - name: Install dependencies
         shell: bash
         run: |
           apt-get update -qq
-          DEBIAN_FRONTEND=noninteractive apt-get install -y -qq build-essential ninja-build ccache uuid-dev
+          DEBIAN_FRONTEND=noninteractive apt-get install -y -qq build-essential ninja-build ccache uuid-dev zip unzip python3 patchelf
 
       - name: Configure
         shell: bash
@@ -43,6 +187,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DEQEMU_BUILD_TESTS=ON \
             -DEQEMU_BUILD_LOGIN=ON \
             -DEQEMU_BUILD_LUA=ON \
             -DEQEMU_BUILD_PERL=ON \
@@ -52,122 +197,36 @@ jobs:
         shell: bash
         run: cmake --build build --parallel
 
+      - name: Test
+        shell: bash
+        working-directory: build
+        run: ./bin/tests
+
       - name: Package binaries
         shell: bash
         run: |
-          cd build/bin
-          
-          # Verify that critical binaries exist
-          REQUIRED_BINARIES=(world zone ucs queryserv eqlaunch shared_memory loginserver import_client_files export_client_files)
-          MISSING_BINARIES=()
-          
-          for binary in "${REQUIRED_BINARIES[@]}"; do
-            if [ ! -f "$binary" ]; then
-              MISSING_BINARIES+=("$binary")
-            fi
-          done
-          
-          if [ ${#MISSING_BINARIES[@]} -ne 0 ]; then
-            echo "Error: Required binaries not found: ${MISSING_BINARIES[*]}"
-            echo "Build may have failed. Refusing to create incomplete package."
-            exit 1
-          fi
-          
-          ZIP_CONTENTS=""
-          zip_add() {
-            zip -uj eqemu-server-linux-x64.zip "$1"
-          }
-          zip_add_unique() {
-            local target_name
-            target_name="$(basename "$1")"
-            if [ -f eqemu-server-linux-x64.zip ] && printf '%s\n' "$ZIP_CONTENTS" | grep -qx "$target_name"; then
-              echo "Skipping duplicate library: $target_name"
-              return 0
-            fi
-            zip_add "$1"
-            ZIP_CONTENTS="${ZIP_CONTENTS}${target_name}"$'\n'
-          }
-
-          # Add all executable files (excluding tests)
-          for f in *; do
-            if [ -f "$f" ] && [ -x "$f" ] && [ "$f" != "tests" ]; then
-              zip_add_unique "$f"
-            fi
-          done
-
-          # Add shared libraries needed for runtime (from build/bin, build/libs, and vcpkg_installed)
-          bin_lib_count="$(find . -maxdepth 1 -type f \( -name "*.so" -o -name "*.so.[0-9]*" \) | wc -l)"
-          if [ "$bin_lib_count" -gt 0 ]; then
-            find . -maxdepth 1 -type f \( -name "*.so" -o -name "*.so.[0-9]*" \) -print0 | \
-              while IFS= read -r -d '' lib; do
-                zip_add_unique "$lib"
-              done
-          fi
-
-          if [ -d ../libs ]; then
-            lib_count="$(find ../libs -type f \( -name "*.so" -o -name "*.so.[0-9]*" \) | wc -l)"
-            if [ "$lib_count" -gt 0 ]; then
-              find ../libs -type f \( -name "*.so" -o -name "*.so.[0-9]*" \) -print0 | \
-                while IFS= read -r -d '' lib; do
-                  zip_add_unique "$lib"
-                done
-            else
-              echo "No shared libraries found in build/libs"
-            fi
-          else
-            echo "No build/libs directory found; skipping shared library packaging"
-          fi
-
-          for vcpkg_dir in ../vcpkg_installed ../../vcpkg_installed; do
-            if [ -d "$vcpkg_dir" ]; then
-              lib_count="$(find "$vcpkg_dir" -type f \( -name "*.so" -o -name "*.so.[0-9]*" \) ! -path "*/debug/*" -print | wc -l)"
-              if [ "$lib_count" -gt 0 ]; then
-                find "$vcpkg_dir" -type f \( -name "*.so" -o -name "*.so.[0-9]*" \) ! -path "*/debug/*" -print0 | \
-                  while IFS= read -r -d '' lib; do
-                    zip_add_unique "$lib"
-                  done
-              else
-                echo "No shared libraries found in $vcpkg_dir"
-              fi
-            else
-              echo "No $vcpkg_dir directory found; skipping vcpkg shared library packaging"
-            fi
-          done
-          
-          # Verify zip file was created and contains files
-          if [ ! -f eqemu-server-linux-x64.zip ]; then
-            echo "Error: Failed to create zip file"
-            exit 1
-          fi
-          
-          FILE_COUNT=$(unzip -Z1 eqemu-server-linux-x64.zip | wc -l)
-          EXPECTED_MIN_FILES=${#REQUIRED_BINARIES[@]}
-          if [ "$FILE_COUNT" -lt "$EXPECTED_MIN_FILES" ]; then
-            echo "Error: Zip file contains fewer than expected files ($FILE_COUNT, expected at least $EXPECTED_MIN_FILES)"
-            unzip -l eqemu-server-linux-x64.zip
-            exit 1
-          fi
-          
-          echo "Successfully packaged $FILE_COUNT files"
-          ls -lh eqemu-server-linux-x64.zip
-          echo ""
-          echo "Package contents:"
-          unzip -l eqemu-server-linux-x64.zip
+          bash utils/scripts/release/package-linux.sh \
+            "${{ needs.prepare-release.outputs.version }}" \
+            "${{ needs.prepare-release.outputs.tag }}" \
+            "${{ needs.prepare-release.outputs.release_sha }}"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: eqemu-server-linux-x64
-          path: build/bin/eqemu-server-linux-x64.zip
+          path: dist/eqemu-server-linux-x64-${{ needs.prepare-release.outputs.tag }}.zip
           retention-days: 90
 
   build-windows:
     name: Build Windows
+    needs: prepare-release
     runs-on: windows-latest
     steps:
-      - name: Checkout source
+      - name: Checkout release tag
         uses: actions/checkout@v5
         with:
+          ref: ${{ needs.prepare-release.outputs.tag }}
+          fetch-depth: 0
           submodules: recursive
 
       - name: Enable long paths
@@ -178,11 +237,28 @@ jobs:
         with:
           arch: x64
 
+      - name: Restore vcpkg binary cache
+        uses: actions/cache@v4
+        with:
+          path: .vcpkg-binary-cache
+          key: ${{ runner.os }}-release-vcpkg-${{ hashFiles('vcpkg.json', 'submodules/vcpkg/scripts/vcpkg-tool-metadata.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-release-vcpkg-
+            ${{ runner.os }}-vcpkg-
+
+      - name: Configure vcpkg binary cache
+        shell: pwsh
+        run: |
+          $cachePath = Join-Path $env:GITHUB_WORKSPACE ".vcpkg-binary-cache"
+          New-Item -ItemType Directory -Force -Path $cachePath | Out-Null
+          "VCPKG_BINARY_SOURCES=clear;files,$cachePath,readwrite" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
       - name: Configure
         shell: pwsh
         run: |
-          cmake -S . -B build -G "Visual Studio 17 2022" -A x64 `
+          cmake -S . -B build -G Ninja `
             -DCMAKE_BUILD_TYPE=RelWithDebInfo `
+            -DEQEMU_BUILD_TESTS=ON `
             -DEQEMU_BUILD_LOGIN=ON `
             -DEQEMU_BUILD_LUA=ON `
             -DEQEMU_BUILD_ZLIB=ON `
@@ -191,103 +267,32 @@ jobs:
 
       - name: Build
         shell: pwsh
-        run: cmake --build build --config RelWithDebInfo --target ALL_BUILD -- /m:4
+        run: cmake --build build --parallel
+
+      - name: Test
+        shell: pwsh
+        working-directory: build
+        run: ./bin/tests.exe
 
       - name: Package binaries
         shell: pwsh
         run: |
-          $binDir = "build/bin/RelWithDebInfo"
-          $outZip = "eqemu-server-windows-x64.zip"
-          # Minimum expected zip size (core binaries should be at least this size)
-          $minZipSize = 100KB
-
-          # Verify that critical binaries exist
-          $requiredBinaries = @("world.exe", "zone.exe", "ucs.exe", "queryserv.exe", "eqlaunch.exe", "shared_memory.exe", "loginserver.exe", "import_client_files.exe", "export_client_files.exe")
-          $missingBinaries = @()
-          
-          foreach ($binary in $requiredBinaries) {
-            $path = Join-Path $binDir $binary
-            if (-not (Test-Path $path)) {
-              $missingBinaries += $binary
-            }
-          }
-          
-          if ($missingBinaries.Count -gt 0) {
-            Write-Host "Error: Required binaries not found: $($missingBinaries -join ', ')"
-            Write-Host "Build may have failed. Refusing to create incomplete package."
-            exit 1
-          }
-
-          # Collect all exe and dll files
-          $files = @()
-
-          # Add executables (exclude tests.exe)
-          Get-ChildItem -Path $binDir -Filter "*.exe" | Where-Object { $_.Name -ne "tests.exe" } | ForEach-Object {
-            $files += $_.FullName
-          }
-
-          # Add DLLs from bin directory
-          Get-ChildItem -Path $binDir -Filter "*.dll" -ErrorAction SilentlyContinue | ForEach-Object {
-            $files += $_.FullName
-          }
-
-          # Add zlib DLLs if they exist
-          $zlibDir = "build/libs/zlibng/RelWithDebInfo"
-          if (Test-Path $zlibDir) {
-            Get-ChildItem -Path $zlibDir -Filter "*.dll" -ErrorAction SilentlyContinue | ForEach-Object {
-              $files += $_.FullName
-            }
-          }
-
-          # Verify we have files to package
-          if ($files.Count -eq 0) {
-            Write-Host "Error: No files found to package"
-            exit 1
-          }
-
-          # Create zip
-          Compress-Archive -Path $files -DestinationPath $outZip -Force
-
-          # Verify zip was created successfully
-          if (-not (Test-Path $outZip)) {
-            Write-Host "Error: Failed to create zip file"
-            exit 1
-          }
-
-          # Verify zip contains files (should contain at least the core binaries)
-          $zipInfo = Get-Item $outZip
-          if ($zipInfo.Length -lt $minZipSize) {
-            Write-Host "Error: Zip file is suspiciously small ($($zipInfo.Length) bytes, expected at least $minZipSize)"
-            exit 1
-          }
-
-          # Show contents
-          Write-Host "Successfully packaged $($files.Count) files"
-          Write-Host "Package contents:"
-          Add-Type -AssemblyName System.IO.Compression.FileSystem
-          $zip = [System.IO.Compression.ZipFile]::OpenRead($outZip)
-          try {
-            foreach ($entry in $zip.Entries) {
-              Write-Host (" - {0} ({1} bytes)" -f $entry.FullName, $entry.Length)
-            }
-          }
-          finally {
-            $zip.Dispose()
-          }
+          ./utils/scripts/release/package-windows.ps1 `
+            -Version "${{ needs.prepare-release.outputs.version }}" `
+            -Tag "${{ needs.prepare-release.outputs.tag }}" `
+            -CommitSha "${{ needs.prepare-release.outputs.release_sha }}"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: eqemu-server-windows-x64
-          path: eqemu-server-windows-x64.zip
+          path: dist/eqemu-server-windows-x64-${{ needs.prepare-release.outputs.tag }}.zip
           retention-days: 90
 
   release:
     name: Create Release
-    needs: [build-linux, build-windows]
+    needs: [prepare-release, build-linux, build-windows]
     runs-on: ubuntu-latest
-    # Only run on tag pushes
-    if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
     steps:
@@ -304,9 +309,11 @@ jobs:
           path: artifacts/
 
       - name: List artifacts
+        shell: bash
         run: ls -la artifacts/
 
       - name: Generate checksums
+        shell: bash
         run: |
           cd artifacts
           sha256sum *.zip > SHA256SUMS.txt
@@ -315,26 +322,33 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
-          name: Release ${{ github.ref_name }}
-          draft: false
+          tag_name: ${{ needs.prepare-release.outputs.tag }}
+          target_commitish: ${{ needs.prepare-release.outputs.release_sha }}
+          name: Release ${{ needs.prepare-release.outputs.tag }}
+          draft: ${{ inputs.draft }}
           prerelease: false
           generate_release_notes: true
           files: |
-            artifacts/eqemu-server-linux-x64.zip
-            artifacts/eqemu-server-windows-x64.zip
+            artifacts/eqemu-server-linux-x64-${{ needs.prepare-release.outputs.tag }}.zip
+            artifacts/eqemu-server-windows-x64-${{ needs.prepare-release.outputs.tag }}.zip
             artifacts/SHA256SUMS.txt
+
       - name: Notify Discord
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          TAG_NAME: ${{ github.ref_name }}
+          TAG_NAME: ${{ needs.prepare-release.outputs.tag }}
           REPO: ${{ github.repository }}
+        shell: bash
         run: |
           if [ -z "$DISCORD_WEBHOOK_URL" ]; then
             echo "DISCORD_WEBHOOK_URL is not set; skipping Discord notification."
             exit 0
           fi
-          LINUX_URL="https://github.com/${REPO}/releases/download/${TAG_NAME}/eqemu-server-linux-x64.zip"
-          WINDOWS_URL="https://github.com/${REPO}/releases/download/${TAG_NAME}/eqemu-server-windows-x64.zip"
+
+          LINUX_ASSET="eqemu-server-linux-x64-${TAG_NAME}.zip"
+          WINDOWS_ASSET="eqemu-server-windows-x64-${TAG_NAME}.zip"
+          LINUX_URL="https://github.com/${REPO}/releases/download/${TAG_NAME}/${LINUX_ASSET}"
+          WINDOWS_URL="https://github.com/${REPO}/releases/download/${TAG_NAME}/${WINDOWS_ASSET}"
           SHA_URL="https://github.com/${REPO}/releases/download/${TAG_NAME}/SHA256SUMS.txt"
           payload=$(jq -n \
             --arg tag "$TAG_NAME" \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -370,6 +370,7 @@ jobs:
             artifacts/SHA256SUMS.txt
 
       - name: Notify Discord
+        if: ${{ !inputs.draft }}
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           TAG_NAME: ${{ needs.prepare-release.outputs.tag }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -120,10 +120,29 @@ jobs:
 
           echo "release_sha=${release_sha}" >> "$GITHUB_OUTPUT"
 
+  restore-dev-version:
+    name: Restore Dev Version
+    needs: prepare-release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout release branch
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ env.RELEASE_BRANCH }}
+          fetch-depth: 0
+
+      - name: Configure git identity
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Restore dev version on release branch
         shell: bash
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ needs.prepare-release.outputs.version }}
         run: |
           set -euo pipefail
           python3 utils/scripts/release/release_version.py set --version "$VERSION" --channel dev
@@ -135,7 +154,20 @@ jobs:
 
           git add common/version.h
           git commit -m "chore(release): restore ${VERSION}-dev"
-          git push origin HEAD:${RELEASE_BRANCH}
+
+          for attempt in 1 2 3; do
+            if git push origin HEAD:${RELEASE_BRANCH}; then
+              exit 0
+            fi
+
+            echo "Dev version push failed on attempt ${attempt}; rebasing onto origin/${RELEASE_BRANCH} and retrying."
+            git fetch origin "${RELEASE_BRANCH}"
+            git rebase "origin/${RELEASE_BRANCH}"
+            sleep "$attempt"
+          done
+
+          echo "Failed to push dev version restore commit after 3 attempts."
+          exit 1
 
   build-linux:
     name: Build Linux

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,11 @@ on:
         required: true
         type: boolean
         default: false
+      notify_discord:
+        description: Send a Discord notification for non-draft releases
+        required: true
+        type: boolean
+        default: true
       confirm:
         description: Type "release" to confirm
         required: true
@@ -370,15 +375,17 @@ jobs:
             artifacts/SHA256SUMS.txt
 
       - name: Notify Discord
-        if: ${{ !inputs.draft }}
+        if: ${{ inputs.notify_discord && !inputs.draft }}
         env:
+          DISCORD_RELEASE_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           TAG_NAME: ${{ needs.prepare-release.outputs.tag }}
           REPO: ${{ github.repository }}
         shell: bash
         run: |
+          DISCORD_WEBHOOK_URL="${DISCORD_RELEASE_WEBHOOK_URL:-${DISCORD_WEBHOOK_URL:-}}"
           if [ -z "$DISCORD_WEBHOOK_URL" ]; then
-            echo "DISCORD_WEBHOOK_URL is not set; skipping Discord notification."
+            echo "No Discord webhook secret is set; skipping Discord notification."
             exit 0
           fi
 

--- a/utils/scripts/release/package-linux.sh
+++ b/utils/scripts/release/package-linux.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+  echo "Usage: $0 <version> <tag> <commit-sha>" >&2
+  exit 2
+fi
+
+VERSION="$1"
+TAG="$2"
+COMMIT_SHA="$3"
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+BIN_DIR="${ROOT_DIR}/build/bin"
+DIST_DIR="${ROOT_DIR}/dist"
+PACKAGE_NAME="eqemu-server-linux-x64-${TAG}"
+STAGE_DIR="${DIST_DIR}/${PACKAGE_NAME}"
+ZIP_PATH="${DIST_DIR}/${PACKAGE_NAME}.zip"
+
+REQUIRED_BINARIES=(
+  world
+  zone
+  ucs
+  queryserv
+  eqlaunch
+  shared_memory
+  loginserver
+  import_client_files
+  export_client_files
+)
+
+copy_unique() {
+  local source_path="$1"
+  local target_name
+  target_name="$(basename "$source_path")"
+  if [ -e "${STAGE_DIR}/${target_name}" ]; then
+    return 0
+  fi
+
+  cp -aL "$source_path" "${STAGE_DIR}/${target_name}"
+}
+
+require_tool() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Required tool [$1] was not found." >&2
+    exit 1
+  fi
+}
+
+require_tool ldd
+require_tool patchelf
+require_tool python3
+require_tool readelf
+require_tool zip
+
+rm -rf "$STAGE_DIR" "$ZIP_PATH"
+mkdir -p "$STAGE_DIR"
+
+for binary in "${REQUIRED_BINARIES[@]}"; do
+  if [ ! -f "${BIN_DIR}/${binary}" ]; then
+    echo "Required binary is missing: ${BIN_DIR}/${binary}" >&2
+    exit 1
+  fi
+done
+
+while IFS= read -r -d '' executable; do
+  name="$(basename "$executable")"
+  if [ "$name" = "tests" ]; then
+    continue
+  fi
+  copy_unique "$executable"
+done < <(find "$BIN_DIR" -maxdepth 1 -type f -perm /111 -print0)
+
+LIBRARY_DIRS=(
+  "${BIN_DIR}"
+  "${ROOT_DIR}/build/libs"
+  "${ROOT_DIR}/build/vcpkg_installed"
+  "${ROOT_DIR}/vcpkg_installed"
+)
+
+for library_dir in "${LIBRARY_DIRS[@]}"; do
+  if [ ! -d "$library_dir" ]; then
+    continue
+  fi
+
+  while IFS= read -r -d '' library; do
+    copy_unique "$library"
+  done < <(find "$library_dir" \( -type f -o -type l \) \( -name "*.so" -o -name "*.so.[0-9]*" \) ! -path "*/debug/*" -print0)
+done
+
+while IFS= read -r -d '' elf_file; do
+  if readelf -d "$elf_file" >/dev/null 2>&1; then
+    patchelf --force-rpath --set-rpath '$ORIGIN' "$elf_file"
+  fi
+done < <(find "$STAGE_DIR" -maxdepth 1 -type f \( -perm /111 -o -name "*.so" -o -name "*.so.[0-9]*" \) -print0)
+
+for binary in "${REQUIRED_BINARIES[@]}"; do
+  ldd_output="$(LD_LIBRARY_PATH="$STAGE_DIR" ldd "${STAGE_DIR}/${binary}" || true)"
+  echo "$ldd_output"
+  if printf '%s\n' "$ldd_output" | grep -q "not found"; then
+    echo "Missing Linux runtime dependency for ${binary}." >&2
+    exit 1
+  fi
+done
+
+python3 - "$STAGE_DIR" "$VERSION" "$TAG" "$COMMIT_SHA" <<'PY'
+import hashlib
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+stage_dir = Path(sys.argv[1])
+version = sys.argv[2]
+tag = sys.argv[3]
+commit_sha = sys.argv[4]
+
+files = []
+for path in sorted(stage_dir.rglob("*")):
+    if not path.is_file() or path.name == "release-manifest.json":
+        continue
+
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    files.append({
+        "path": path.relative_to(stage_dir).as_posix(),
+        "size": path.stat().st_size,
+        "sha256": digest,
+    })
+
+manifest = {
+    "version": version,
+    "tag": tag,
+    "commit_sha": commit_sha,
+    "platform": "linux-x64",
+    "generated_at": datetime.now(timezone.utc).isoformat(),
+    "files": files,
+}
+
+(stage_dir / "release-manifest.json").write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+PY
+
+(
+  cd "$DIST_DIR"
+  zip -r "$(basename "$ZIP_PATH")" "$PACKAGE_NAME"
+)
+
+if [ ! -f "$ZIP_PATH" ]; then
+  echo "Failed to create ${ZIP_PATH}" >&2
+  exit 1
+fi
+
+echo "Created ${ZIP_PATH}"

--- a/utils/scripts/release/package-windows.ps1
+++ b/utils/scripts/release/package-windows.ps1
@@ -169,13 +169,13 @@ foreach ($libraryRoot in $libraryRoots) {
 Copy-VisualCppRuntime
 Test-RuntimeDependencies
 
-$manifestFiles = Get-ChildItem -Path $stageDir -File | Sort-Object Name | ForEach-Object {
+$manifestFiles = @(Get-ChildItem -Path $stageDir -File | Sort-Object Name | ForEach-Object {
     [PSCustomObject]@{
         path   = $_.Name
         size   = $_.Length
         sha256 = (Get-FileHash -LiteralPath $_.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
     }
-}
+})
 
 $manifest = [PSCustomObject]@{
     version      = $Version

--- a/utils/scripts/release/package-windows.ps1
+++ b/utils/scripts/release/package-windows.ps1
@@ -1,0 +1,198 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Version,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Tag,
+
+    [Parameter(Mandatory = $true)]
+    [string]$CommitSha
+)
+
+$ErrorActionPreference = "Stop"
+
+$rootDir = (Resolve-Path (Join-Path $PSScriptRoot "../../..")).Path
+$binDir = Join-Path $rootDir "build/bin"
+$distDir = Join-Path $rootDir "dist"
+$packageName = "eqemu-server-windows-x64-$Tag"
+$stageDir = Join-Path $distDir $packageName
+$zipPath = Join-Path $distDir "$packageName.zip"
+
+$requiredBinaries = @(
+    "world.exe",
+    "zone.exe",
+    "ucs.exe",
+    "queryserv.exe",
+    "eqlaunch.exe",
+    "shared_memory.exe",
+    "loginserver.exe",
+    "import_client_files.exe",
+    "export_client_files.exe"
+)
+
+function Copy-UniqueFile {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    $target = Join-Path $stageDir ([System.IO.Path]::GetFileName($Path))
+    if (Test-Path $target) {
+        return
+    }
+
+    Copy-Item -LiteralPath $Path -Destination $target
+}
+
+function Copy-VisualCppRuntime {
+    if (-not $env:VCToolsRedistDir -or -not (Test-Path $env:VCToolsRedistDir)) {
+        Write-Host "VCToolsRedistDir was not set; skipping Visual C++ runtime copy."
+        return
+    }
+
+    Get-ChildItem -Path $env:VCToolsRedistDir -Recurse -File -Filter "*.dll" |
+        Where-Object {
+            $_.FullName -match "\\x64\\" -and
+            $_.FullName -match "\\Microsoft\.VC\d+\.CRT\\"
+        } |
+        ForEach-Object { Copy-UniqueFile -Path $_.FullName }
+}
+
+function Get-DumpbinDependencies {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    $output = & dumpbin /dependents $Path 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "dumpbin failed for $Path`n$output"
+    }
+
+    $dependencies = New-Object System.Collections.Generic.List[string]
+    foreach ($line in $output) {
+        if ($line -match "^\s*([A-Za-z0-9_.-]+\.dll)\s*$") {
+            $dependencies.Add($matches[1])
+        }
+    }
+
+    return $dependencies
+}
+
+function Test-RuntimeDependencies {
+    $dumpbin = Get-Command dumpbin -ErrorAction SilentlyContinue
+    if (-not $dumpbin) {
+        throw "dumpbin was not found. Run this script from an MSVC developer environment."
+    }
+
+    $systemDlls = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+    @(
+        "advapi32.dll", "authz.dll", "bcrypt.dll", "bcryptprimitives.dll",
+        "cabinet.dll", "cfgmgr32.dll", "comctl32.dll", "comdlg32.dll",
+        "credui.dll", "crypt32.dll", "cryptbase.dll", "cryptsp.dll",
+        "cryptui.dll", "dbghelp.dll", "dhcpcsvc.dll", "dhcpcsvc6.dll",
+        "dnsapi.dll", "dwmapi.dll", "fwpuclnt.dll", "gdi32.dll",
+        "imagehlp.dll", "imm32.dll", "iphlpapi.dll", "kernel32.dll",
+        "mpr.dll", "msvcp_win.dll", "mswsock.dll", "ncrypt.dll",
+        "netapi32.dll", "netutils.dll", "normaliz.dll", "nsi.dll",
+        "ntdll.dll", "ole32.dll", "oleacc.dll", "oleaut32.dll",
+        "powrprof.dll", "profapi.dll", "propsys.dll", "psapi.dll",
+        "rasapi32.dll", "rpcrt4.dll", "sechost.dll", "secur32.dll",
+        "setupapi.dll", "shell32.dll", "shlwapi.dll", "ucrtbase.dll",
+        "user32.dll", "userenv.dll", "usp10.dll", "uxtheme.dll",
+        "version.dll", "windows.storage.dll", "winhttp.dll", "winmm.dll",
+        "winspool.drv", "wintrust.dll", "wlanapi.dll", "ws2_32.dll",
+        "wldap32.dll"
+    ) | ForEach-Object { [void]$systemDlls.Add($_) }
+
+    $presentDlls = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+    Get-ChildItem -Path $stageDir -File -Filter "*.dll" | ForEach-Object {
+        [void]$presentDlls.Add($_.Name)
+    }
+
+    $missing = [System.Collections.Generic.SortedSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+    Get-ChildItem -Path $stageDir -File | Where-Object { $_.Extension -in @(".exe", ".dll") } | ForEach-Object {
+        foreach ($dependency in (Get-DumpbinDependencies -Path $_.FullName)) {
+            if ($dependency -match "^(api-ms-win-|ext-ms-)") {
+                continue
+            }
+            if ($systemDlls.Contains($dependency)) {
+                continue
+            }
+            if (-not $presentDlls.Contains($dependency)) {
+                [void]$missing.Add("$dependency required by $($_.Name)")
+            }
+        }
+    }
+
+    if ($missing.Count -gt 0) {
+        throw "Missing Windows runtime dependencies:`n$($missing -join "`n")"
+    }
+}
+
+if (Test-Path $stageDir) {
+    Remove-Item -LiteralPath $stageDir -Recurse -Force
+}
+if (Test-Path $zipPath) {
+    Remove-Item -LiteralPath $zipPath -Force
+}
+New-Item -ItemType Directory -Force -Path $stageDir | Out-Null
+
+foreach ($binary in $requiredBinaries) {
+    $path = Join-Path $binDir $binary
+    if (-not (Test-Path $path)) {
+        throw "Required binary is missing: $path"
+    }
+}
+
+Get-ChildItem -Path $binDir -File -Filter "*.exe" |
+    Where-Object { $_.Name -ne "tests.exe" } |
+    ForEach-Object { Copy-UniqueFile -Path $_.FullName }
+
+$libraryRoots = @(
+    $binDir,
+    (Join-Path $rootDir "build/libs"),
+    (Join-Path $rootDir "build/vcpkg_installed"),
+    (Join-Path $rootDir "vcpkg_installed")
+)
+
+foreach ($libraryRoot in $libraryRoots) {
+    if (-not (Test-Path $libraryRoot)) {
+        continue
+    }
+
+    Get-ChildItem -Path $libraryRoot -Recurse -File -Filter "*.dll" |
+        Where-Object { $_.FullName -notmatch "\\debug\\" } |
+        ForEach-Object { Copy-UniqueFile -Path $_.FullName }
+}
+
+Copy-VisualCppRuntime
+Test-RuntimeDependencies
+
+$manifestFiles = Get-ChildItem -Path $stageDir -File | Sort-Object Name | ForEach-Object {
+    [PSCustomObject]@{
+        path   = $_.Name
+        size   = $_.Length
+        sha256 = (Get-FileHash -LiteralPath $_.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+    }
+}
+
+$manifest = [PSCustomObject]@{
+    version      = $Version
+    tag          = $Tag
+    commit_sha   = $CommitSha
+    platform     = "windows-x64"
+    generated_at = [DateTimeOffset]::UtcNow.ToString("o")
+    files        = $manifestFiles
+}
+
+$manifestPath = Join-Path $stageDir "release-manifest.json"
+$manifest | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $manifestPath -Encoding utf8NoBOM
+
+Compress-Archive -Path $stageDir -DestinationPath $zipPath -Force
+
+if (-not (Test-Path $zipPath)) {
+    throw "Failed to create $zipPath"
+}
+
+Write-Host "Created $zipPath"

--- a/utils/scripts/release/release_version.py
+++ b/utils/scripts/release/release_version.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import re
+from pathlib import Path
+
+
+SEMVER_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)$")
+
+
+def parse_version(value: str) -> tuple[int, int, int]:
+    match = SEMVER_RE.match(value.strip())
+    if not match:
+        raise SystemExit(f"Expected SemVer value like v1.2.3, got [{value}]")
+
+    return tuple(int(part) for part in match.groups())
+
+
+def format_version(version: tuple[int, int, int]) -> str:
+    return ".".join(str(part) for part in version)
+
+
+def compute_next(latest_tag: str, bump: str) -> str:
+    major, minor, patch = parse_version(latest_tag)
+
+    if bump == "major":
+        major += 1
+        minor = 0
+        patch = 0
+    elif bump == "minor":
+        minor += 1
+        patch = 0
+    elif bump == "patch":
+        patch += 1
+    else:
+        raise SystemExit(f"Unsupported bump [{bump}]")
+
+    return format_version((major, minor, patch))
+
+
+def replace_once(path: Path, pattern: str, replacement: str, *, flags: int = 0) -> None:
+    text = path.read_text(encoding="utf-8")
+    new_text, count = re.subn(pattern, replacement, text, count=1, flags=flags)
+    if count != 1:
+        raise SystemExit(f"Expected exactly one replacement in {path}")
+
+    path.write_text(new_text, encoding="utf-8")
+
+
+def set_package_version(root: Path, version: str) -> None:
+    path = root / "package.json"
+    data = json.loads(path.read_text(encoding="utf-8"))
+    data["version"] = version
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def set_current_version(root: Path, current_version: str) -> None:
+    replace_once(
+        root / "common" / "version.h",
+        r'(#define\s+CURRENT_VERSION\s+")[^"]+(")',
+        rf"\g<1>{current_version}\2",
+    )
+
+
+def set_cmake_version(root: Path, version: str) -> None:
+    replace_once(
+        root / "CMakeLists.txt",
+        r"(project\s*\(\s*EQEmu\s+VERSION\s+)\d+\.\d+\.\d+",
+        rf"\g<1>{version}",
+        flags=re.DOTALL,
+    )
+
+
+def set_versions(root: Path, version: str, channel: str) -> None:
+    parse_version(version)
+
+    if channel == "release":
+        set_package_version(root, version)
+        set_cmake_version(root, version)
+        set_current_version(root, version)
+    elif channel == "dev":
+        set_current_version(root, f"{version}-dev")
+    else:
+        raise SystemExit(f"Unsupported channel [{channel}]")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="EQEmu release version helper")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    compute_parser = subparsers.add_parser("compute", help="compute next release version")
+    compute_parser.add_argument("--latest-tag", required=True)
+    compute_parser.add_argument("--bump", choices=["patch", "minor", "major"], required=True)
+
+    set_parser = subparsers.add_parser("set", help="update release version files")
+    set_parser.add_argument("--root", default=".")
+    set_parser.add_argument("--version", required=True)
+    set_parser.add_argument("--channel", choices=["release", "dev"], required=True)
+
+    args = parser.parse_args()
+
+    if args.command == "compute":
+        print(compute_next(args.latest_tag, args.bump))
+        return
+
+    if args.command == "set":
+        set_versions(Path(args.root).resolve(), args.version, args.channel)
+        return
+
+    raise SystemExit(f"Unsupported command [{args.command}]")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a manual-only GitHub Actions release workflow for producing versioned EQEmu server release packages.

The new workflow:
- can only be started with `workflow_dispatch`
- requires a `patch`, `minor`, or `major` bump selection plus `confirm=release`
- computes the next `vX.Y.Z` tag, updates version files, commits/tags the release, and restores `CURRENT_VERSION` to `X.Y.Z-dev` on `master`
- builds Linux and Windows release artifacts from the release tag in the same workflow run
- uses Ninja, vcpkg binary caches, and release-job tests before packaging
- publishes versioned Linux/Windows zip assets plus `SHA256SUMS.txt`

Packaging logic was moved into helper scripts so the workflow stays readable. The packages now stage a platform folder, include runtime libraries, write `release-manifest.json`, and validate dependencies with `ldd` on Linux and `dumpbin` on Windows.

## Validation

- `git diff --check`
- `python -m py_compile utils/scripts/release/release_version.py`
- SemVer checks: `v1.2.3 + patch = 1.2.4`, `minor = 1.3.0`, `major = 2.0.0`
- Temporary release/dev version-file mutation test
- `bash -n utils/scripts/release/package-linux.sh`
- PowerShell parser check for `utils/scripts/release/package-windows.ps1`
- PyYAML parse for `.github/workflows/build.yaml` and `.github/workflows/release.yaml`
- `actionlint` on `.github/workflows/build.yaml` and `.github/workflows/release.yaml`

I did not run the actual release workflow; it requires a manual Actions dispatch and GitHub-hosted Linux/Windows runners.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release pipeline to create/push tags and commits from CI and alters build/packaging behavior on both Linux and Windows, which could impact published artifacts if misconfigured.
> 
> **Overview**
> Introduces a **manual-only** `workflow_dispatch` release workflow that validates an explicit confirmation, computes the next SemVer tag, updates version files, commits/tags the release on `master`, and then restores `CURRENT_VERSION` to a `-dev` suffix.
> 
> Updates the release build jobs to build from the created tag, enable tests, add vcpkg binary caching, and delegate packaging to new `package-linux.sh` / `package-windows.ps1` scripts that stage versioned `dist/` zips, bundle runtime libraries, emit `release-manifest.json`, and validate runtime dependencies before publishing the GitHub Release (optionally draft) and sending Discord notifications with versioned asset links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b58d62421503b4629ba4086bdad7d783bc16a6df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->