### PR TITLE
[CI] Harden release packaging workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -117,11 +117,9 @@ jobs:
 
           git add package.json common/version.h CMakeLists.txt
           git commit -m "chore(release): ${TAG}"
-          git tag -a "$TAG" -m "Release ${TAG}"
 
           release_sha="$(git rev-parse HEAD)"
           git push origin HEAD:${RELEASE_BRANCH}
-          git push origin "$TAG"
 
           echo "release_sha=${release_sha}" >> "$GITHUB_OUTPUT"
 
@@ -182,10 +180,10 @@ jobs:
       image: akkadius/eqemu-server:v16
       options: --user 0
     steps:
-      - name: Checkout release tag
+      - name: Checkout release commit
         uses: actions/checkout@v5
         with:
-          ref: ${{ needs.prepare-release.outputs.tag }}
+          ref: ${{ needs.prepare-release.outputs.release_sha }}
           fetch-depth: 0
           submodules: recursive
 
@@ -263,10 +261,10 @@ jobs:
     needs: prepare-release
     runs-on: windows-latest
     steps:
-      - name: Checkout release tag
+      - name: Checkout release commit
         uses: actions/checkout@v5
         with:
-          ref: ${{ needs.prepare-release.outputs.tag }}
+          ref: ${{ needs.prepare-release.outputs.release_sha }}
           fetch-depth: 0
           submodules: recursive
 

--- a/utils/scripts/release/package-windows.ps1
+++ b/utils/scripts/release/package-windows.ps1
@@ -79,12 +79,7 @@ function Get-DumpbinDependencies {
     return $dependencies
 }
 
-function Test-RuntimeDependencies {
-    $dumpbin = Get-Command dumpbin -ErrorAction SilentlyContinue
-    if (-not $dumpbin) {
-        throw "dumpbin was not found. Run this script from an MSVC developer environment."
-    }
-
+function New-SystemDllSet {
     $systemDlls = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
     @(
         "advapi32.dll", "authz.dll", "bcrypt.dll", "bcryptprimitives.dll",
@@ -105,6 +100,129 @@ function Test-RuntimeDependencies {
         "wldap32.dll"
     ) | ForEach-Object { [void]$systemDlls.Add($_) }
 
+    return $systemDlls
+}
+
+function Get-RuntimeSearchDirectories {
+    $directories = [System.Collections.Generic.List[string]]::new()
+
+    function Add-SearchDirectory {
+        param([string]$Path)
+
+        if ([string]::IsNullOrWhiteSpace($Path)) {
+            return
+        }
+
+        try {
+            $resolvedPath = (Resolve-Path -LiteralPath $Path -ErrorAction Stop).Path
+        }
+        catch {
+            return
+        }
+
+        if (-not $directories.Contains($resolvedPath)) {
+            [void]$directories.Add($resolvedPath)
+        }
+    }
+
+    Add-SearchDirectory -Path $stageDir
+    Add-SearchDirectory -Path $binDir
+
+    foreach ($libraryRoot in $libraryRoots) {
+        if (-not (Test-Path $libraryRoot)) {
+            continue
+        }
+
+        Add-SearchDirectory -Path $libraryRoot
+        Get-ChildItem -Path $libraryRoot -Recurse -Directory |
+            Where-Object { $_.FullName -notmatch "\\debug\\" } |
+            ForEach-Object { Add-SearchDirectory -Path $_.FullName }
+    }
+
+    @(
+        (Join-Path $env:SystemDrive "Strawberry/perl/bin"),
+        (Join-Path $env:SystemDrive "Strawberry/c/bin")
+    ) | ForEach-Object { Add-SearchDirectory -Path $_ }
+
+    if ($env:PATH) {
+        $env:PATH -split ";" | ForEach-Object { Add-SearchDirectory -Path $_ }
+    }
+
+    return $directories
+}
+
+function Find-RuntimeDependency {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true)]
+        [System.Collections.Generic.List[string]]$SearchDirectories
+    )
+
+    foreach ($directory in $SearchDirectories) {
+        $candidate = Join-Path $directory $Name
+        if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+            return (Resolve-Path -LiteralPath $candidate).Path
+        }
+    }
+
+    return $null
+}
+
+function Resolve-RuntimeDependencies {
+    $dumpbin = Get-Command dumpbin -ErrorAction SilentlyContinue
+    if (-not $dumpbin) {
+        throw "dumpbin was not found. Run this script from an MSVC developer environment."
+    }
+
+    $systemDlls = New-SystemDllSet
+    $searchDirectories = Get-RuntimeSearchDirectories
+
+    for ($pass = 1; $pass -le 10; $pass++) {
+        $presentDlls = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+        Get-ChildItem -Path $stageDir -File -Filter "*.dll" | ForEach-Object {
+            [void]$presentDlls.Add($_.Name)
+        }
+
+        $copiedCount = 0
+        Get-ChildItem -Path $stageDir -File | Where-Object { $_.Extension -in @(".exe", ".dll") } | ForEach-Object {
+            foreach ($dependency in (Get-DumpbinDependencies -Path $_.FullName)) {
+                if ($dependency -match "^(api-ms-win-|ext-ms-)") {
+                    continue
+                }
+                if ($systemDlls.Contains($dependency)) {
+                    continue
+                }
+                if ($presentDlls.Contains($dependency)) {
+                    continue
+                }
+
+                $candidate = Find-RuntimeDependency -Name $dependency -SearchDirectories $searchDirectories
+                if ($candidate) {
+                    Write-Host "Copying runtime dependency $dependency from $candidate"
+                    Copy-UniqueFile -Path $candidate
+                    [void]$presentDlls.Add($dependency)
+                    $copiedCount++
+                }
+            }
+        }
+
+        if ($copiedCount -eq 0) {
+            return
+        }
+    }
+
+    throw "Runtime dependency resolution did not converge after 10 passes."
+}
+
+function Test-RuntimeDependencies {
+    $dumpbin = Get-Command dumpbin -ErrorAction SilentlyContinue
+    if (-not $dumpbin) {
+        throw "dumpbin was not found. Run this script from an MSVC developer environment."
+    }
+
+    $systemDlls = New-SystemDllSet
     $presentDlls = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
     Get-ChildItem -Path $stageDir -File -Filter "*.dll" | ForEach-Object {
         [void]$presentDlls.Add($_.Name)
@@ -167,6 +285,7 @@ foreach ($libraryRoot in $libraryRoots) {
 }
 
 Copy-VisualCppRuntime
+Resolve-RuntimeDependencies
 Test-RuntimeDependencies
 
 $manifestFiles = @(Get-ChildItem -Path $stageDir -File | Sort-Object Name | ForEach-Object {


### PR DESCRIPTION
## Summary
- resolve Windows runtime DLL dependencies from build, vcpkg, and runner PATH locations before final dependency validation
- allow the release action to build from the release commit SHA and create the tag only when the GitHub Release is created
- prevent future failed packaging runs from leaving a pushed tag without release assets

## Validation
- git diff --check
- parsed build/release workflow YAML
- actionlint for build.yaml and release.yaml
- PowerShell parser check for package-windows.ps1
- release_version.py py_compile and bump samples

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes adjust the release/tagging flow and Windows runtime dependency packaging, which can break automated releases if assumptions about commit SHAs or DLL search paths are wrong. No application/runtime logic is modified, but CI/release output correctness is impacted.
> 
> **Overview**
> **Release workflow hardening:** stops creating/pushing the git tag during `prepare-release`, and switches Linux/Windows builds to checkout the computed `release_sha` commit instead of a tag, so failed packaging runs don’t leave orphaned tags.
> 
> **Windows packaging robustness:** enhances `package-windows.ps1` to proactively resolve/copy non-system runtime DLL dependencies by scanning staged `.exe`/`.dll` imports with `dumpbin` and searching build/vcpkg/PATH locations (with bounded multi-pass convergence) before running the missing-dependency check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8f9b2c82c789fe51f61f6dffdec458d094051d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->