### PR TITLE
[Bug Fix] Fix hack detection edge cases

### DIFF
--- a/world/client.cpp
+++ b/world/client.cpp
@@ -1410,7 +1410,7 @@ bool Client::HandlePacket(const EQApplicationPacket *app) {
 	if (RuleB(World, GMAccountIPList) && GetAdmin() >= (RuleI(World, MinGMAntiHackStatus))) {
 		const auto source_ip = long2ip(GetIP());
 		if(!database.CheckGMIPs(source_ip, GetAccountID())) {
-			LogInfo("GM Account not permited from source address [{}] and accountid [{}]", source_ip.c_str(), GetAccountID());
+			LogInfo("GM Account not permitted from source address [{}] and accountid [{}]", source_ip.c_str(), GetAccountID());
 			RecordPossibleHack(
 				fmt::format(
 					"[GMAntiHack] GM account packet rejected from unauthorized source address [{}] account_id [{}]",

--- a/world/client.cpp
+++ b/world/client.cpp
@@ -1408,9 +1408,18 @@ bool Client::HandlePacket(const EQApplicationPacket *app) {
 
 	// Voidd: Anti-GM Account hack, Checks source ip against valid GM Account IP Addresses
 	if (RuleB(World, GMAccountIPList) && GetAdmin() >= (RuleI(World, MinGMAntiHackStatus))) {
-		if(!database.CheckGMIPs(long2ip(GetIP()), GetAccountID())) {
-			LogInfo("GM Account not permited from source address [{}] and accountid [{}]", long2ip(GetIP()).c_str(), GetAccountID());
+		const auto source_ip = long2ip(GetIP());
+		if(!database.CheckGMIPs(source_ip, GetAccountID())) {
+			LogInfo("GM Account not permited from source address [{}] and accountid [{}]", source_ip.c_str(), GetAccountID());
+			RecordPossibleHack(
+				fmt::format(
+					"[GMAntiHack] GM account packet rejected from unauthorized source address [{}] account_id [{}]",
+					source_ip,
+					GetAccountID()
+				)
+			);
 			eqs->Close();
+			return false;
 		}
 	}
 

--- a/zone/cheat_manager.cpp
+++ b/zone/cheat_manager.cpp
@@ -11,12 +11,6 @@
 extern WorldServer worldserver;
 extern QueryServ *QServ;
 
-namespace {
-	constexpr uint32 MovementHistoryTimeoutMS = 70000;
-	constexpr uint32 WarpDetectionCooldownMS = 2500;
-	constexpr uint32 FastMemorizationWindowMS = 1;
-}
-
 void CheatManager::SetClient(Client *cli)
 {
 	m_target = cli;
@@ -257,7 +251,7 @@ void CheatManager::MovementCheck(glm::vec3 updated_position)
 			m_last_position_check_location   = current_position;
 		}
 		else {
-			MovementCheck(2500);
+			MovementCheck(PositionCheckIntervalMS);
 		}
 	}
 }
@@ -308,7 +302,7 @@ void CheatManager::MovementCheck(uint32 time_between_checks)
 				}
 			}
 		}
-		if (time_between_checks != 1000) {
+		if (time_between_checks != DefaultMovementCheckIntervalMS) {
 			SetExemptStatus(ShadowStep, false);
 			SetExemptStatus(KnockBack, false);
 			SetExemptStatus(Port, false);

--- a/zone/cheat_manager.cpp
+++ b/zone/cheat_manager.cpp
@@ -6,8 +6,16 @@
 #include "zone/worldserver.h"
 #include "zone/queryserv.h"
 
+#include <algorithm>
+
 extern WorldServer worldserver;
 extern QueryServ *QServ;
+
+namespace {
+	constexpr uint32 MovementHistoryTimeoutMS = 70000;
+	constexpr uint32 WarpDetectionCooldownMS = 2500;
+	constexpr uint32 FastMemorizationWindowMS = 1;
+}
 
 void CheatManager::SetClient(Client *cli)
 {
@@ -58,6 +66,8 @@ void CheatManager::CheatDetected(CheatTypes type, glm::vec3 position1, glm::vec3
 
 					parse->EventPlayer(EVENT_WARP, m_target, export_string, 0);
 				}
+
+				m_time_since_last_warp_detection.Start(WarpDetectionCooldownMS);
 			}
 			break;
 		case MQWarpAbsolute:
@@ -87,7 +97,7 @@ void CheatManager::CheatDetected(CheatTypes type, glm::vec3 position1, glm::vec3
 					parse->EventPlayer(EVENT_WARP, m_target, export_string, 0);
 				}
 
-				m_time_since_last_warp_detection.Start(2500);
+				m_time_since_last_warp_detection.Start(WarpDetectionCooldownMS);
 			}
 			break;
 		case MQWarpShadowStep:
@@ -122,10 +132,14 @@ void CheatManager::CheatDetected(CheatTypes type, glm::vec3 position1, glm::vec3
 				((m_target->Admin() < RuleI(Cheat, MQWarpExemptStatus) || (RuleI(Cheat, MQWarpExemptStatus)) == -1))) {
 				if (RuleB(Cheat, MarkMQWarpLT)) {
 					std::string message = fmt::format(
-						"/MQWarp(Knockback) with location from x [{:.2f}] y [{:.2f}] z [{:.2f}] running fast but not fast enough to get killed, possibly: small warp, speed hack, excessive lag, marked as suspicious.",
+						"/MQWarp (light) with location from x [{:.2f}] y [{:.2f}] z [{:.2f}] to x [{:.2f}] y [{:.2f}] z [{:.2f}] Distance [{:.2f}] running fast but not fast enough to get killed, possibly: small warp, speed hack, excessive lag, marked as suspicious.",
 						position1.x,
 						position1.y,
-						position1.z
+						position1.z,
+						position2.x,
+						position2.y,
+						position2.z,
+						Distance(position1, position2)
 					);
 					RecordPlayerEventLogWithClient(m_target, PlayerEvent::POSSIBLE_HACK, PlayerEvent::PossibleHackEvent{.message = message});
 					LogCheat(fmt::runtime(message));
@@ -219,22 +233,28 @@ void CheatManager::MovementCheck(glm::vec3 updated_position)
 		CheatDetected(MQGhost, updated_position);
 	}
 
-	float  dist     = DistanceNoZ(m_target->GetPosition(), updated_position);
+	glm::vec3 current_position = glm::vec3(m_target->GetPosition());
+	float  dist     = DistanceNoZ(current_position, updated_position);
 	uint32 cur_time = Timer::GetCurrentTime();
 	if (dist == 0) {
 		if (m_distance_since_last_position_check > 0.0f) {
+			m_current_position_check_location = updated_position;
 			MovementCheck(0);
 		}
 		else {
 			m_time_since_last_position_check = cur_time;
+			m_last_position_check_location   = updated_position;
+			m_current_position_check_location = updated_position;
 			m_cheat_detect_moved             = false;
 		}
 	}
 	else {
 		m_distance_since_last_position_check += dist;
+		m_current_position_check_location = updated_position;
 		m_cheat_detect_moved = true;
 		if (m_time_since_last_position_check == 0) {
 			m_time_since_last_position_check = cur_time;
+			m_last_position_check_location   = current_position;
 		}
 		else {
 			MovementCheck(2500);
@@ -251,39 +271,39 @@ void CheatManager::MovementCheck(uint32 time_between_checks)
 
 		// MQWarpDetection shouldn't go below 1.0f so we can't end up dividing by 0.
 		float run_speed = m_target->GetRunspeed() /
-						  std::min(
+						  std::max(
 							  RuleR(Cheat, MQWarpDetectionDistanceFactor),
 							  1.0f
 						  );
 		if (estimated_speed > run_speed) {
 			bool using_gm_speed = m_target->GetGMSpeed();
 			bool is_immobile    = m_target->GetRunspeed() == 0; // this covers stuns, roots, mez, and pseudorooted.
+			const auto from      = m_last_position_check_location;
+			const auto to        = m_current_position_check_location;
 			if (!using_gm_speed && !is_immobile) {
 				if (GetExemptStatus(ShadowStep)) {
 					if (m_distance_since_last_position_check > 800) {
 						CheatDetected(
 							MQWarpShadowStep,
-							glm::vec3(
-								m_target->GetX(),
-								m_target->GetY(),
-								m_target->GetZ()
-							)
+							from,
+							to
 						);
 					}
 				}
 				else if (GetExemptStatus(KnockBack)) {
 					if (estimated_speed > 30.0f) {
-						CheatDetected(MQWarpKnockBack, glm::vec3(m_target->GetX(), m_target->GetY(), m_target->GetZ()));
+						CheatDetected(MQWarpKnockBack, from, to);
 					}
 				}
 				else if (!GetExemptStatus(Port)) {
 					if (estimated_speed > (run_speed * 1.5)) {
-						CheatDetected(MQWarp, glm::vec3(m_target->GetX(), m_target->GetY(), m_target->GetZ()));
+						CheatDetected(MQWarp, from, to);
 						m_time_since_last_position_check     = cur_time;
+						m_last_position_check_location       = to;
 						m_distance_since_last_position_check = 0.0f;
 					}
 					else {
-						CheatDetected(MQWarpLight, glm::vec3(m_target->GetX(), m_target->GetY(), m_target->GetZ()));
+						CheatDetected(MQWarpLight, from, to);
 					}
 				}
 			}
@@ -294,6 +314,7 @@ void CheatManager::MovementCheck(uint32 time_between_checks)
 			SetExemptStatus(Port, false);
 		}
 		m_time_since_last_position_check     = cur_time;
+		m_last_position_check_location       = m_current_position_check_location;
 		m_distance_since_last_position_check = 0.0f;
 	}
 }
@@ -303,18 +324,22 @@ void CheatManager::CheckMemTimer()
 	if (m_target == nullptr) {
 		return;
 	}
-	if (m_time_since_last_memorization - Timer::GetCurrentTime() <= 1) {
+	const uint32 current_time = Timer::GetCurrentTime();
+	if (
+		m_time_since_last_memorization != 0 &&
+		(current_time - m_time_since_last_memorization) <= FastMemorizationWindowMS
+	) {
 		glm::vec3 pos = m_target->GetPosition();
 		CheatDetected(MQFastMem, pos);
 	}
-	m_time_since_last_memorization = Timer::GetCurrentTime();
+	m_time_since_last_memorization = current_time;
 }
 
 void CheatManager::ProcessMovementHistory(const EQApplicationPacket *app)
 {
 	// if they haven't sent sent the packet within this time... they are probably spoofing...
 	// linux users reported that they don't send this packet at all but i can't prove they don't so i'm not sure if thats a fake or not.
-	m_time_since_last_movement_history.Start(70000);
+	m_time_since_last_movement_history.Start(MovementHistoryTimeoutMS);
 	if (GetExemptStatus(Port)) {
 		return;
 	}
@@ -350,20 +375,10 @@ void CheatManager::ProcessMovementHistory(const EQApplicationPacket *app)
 	}
 }
 
-void CheatManager::ProcessSpawnApperance(uint16 spawn_id, uint16 type, uint32 parameter)
+void CheatManager::ProcessSpawnApperance(uint16, uint16 type, uint32 parameter)
 {
 	if (type == AppearanceType::Animation && parameter == Animation::Sitting) {
 		m_time_since_last_memorization = Timer::GetCurrentTime();
-	}
-	else if (spawn_id == 0 && type == AppearanceType::AntiCheat) {
-		m_time_since_last_action = parameter;
-	}
-}
-
-void CheatManager::ProcessItemVerifyRequest(int32 slot_id, uint32 target_id)
-{
-	if (slot_id == -1 && m_warp_counter != target_id) {
-		m_warp_counter = target_id;
 	}
 }
 

--- a/zone/cheat_manager.h
+++ b/zone/cheat_manager.h
@@ -54,13 +54,14 @@ public:
 		SetExemptStatus(Assist, false);
 		SetExemptStatus(Sense, false);
 		m_distance_since_last_position_check = 0.0f;
+		m_last_position_check_location       = glm::vec3(0.0f);
+		m_current_position_check_location    = glm::vec3(0.0f);
 		m_cheat_detect_moved                 = false;
 		m_target                             = nullptr;
 		m_time_since_last_memorization       = 0;
 		m_time_since_last_position_check     = 0;
 		m_time_since_last_warp_detection.Start();
 		m_time_since_last_movement_history.Start(70000);
-		m_warp_counter = 0;
 	}
 	void SetClient(Client *cli);
 	void SetExemptStatus(ExemptionType type, bool v);
@@ -71,18 +72,17 @@ public:
 	void CheckMemTimer();
 	void ProcessMovementHistory(const EQApplicationPacket *app);
 	void ProcessSpawnApperance(uint16 spawn_id, uint16 type, uint32 parameter);
-	void ProcessItemVerifyRequest(int32 slot_id, uint32 target_id);
 	void ClientProcess();
 private:
 	bool  m_exemption[ExemptionType::MAX_EXEMPTIONS]{};
 	float m_distance_since_last_position_check;
+	glm::vec3 m_last_position_check_location;
+	glm::vec3 m_current_position_check_location;
 	bool  m_cheat_detect_moved;
 
 	Client *m_target;
 	uint32 m_time_since_last_position_check;
 	uint32 m_time_since_last_memorization;
-	uint32 m_time_since_last_action{};
 	Timer  m_time_since_last_warp_detection;
 	Timer  m_time_since_last_movement_history;
-	uint32 m_warp_counter;
 };

--- a/zone/cheat_manager.h
+++ b/zone/cheat_manager.h
@@ -45,6 +45,13 @@ typedef enum {
 } CheatTypes;
 
 class CheatManager {
+private:
+	static constexpr uint32 MovementHistoryTimeoutMS = 70000;
+	static constexpr uint32 WarpDetectionCooldownMS = 2500;
+	static constexpr uint32 PositionCheckIntervalMS = 2500;
+	static constexpr uint32 DefaultMovementCheckIntervalMS = 1000;
+	static constexpr uint32 FastMemorizationWindowMS = 1;
+
 public:
 	CheatManager()
 	{
@@ -61,14 +68,14 @@ public:
 		m_time_since_last_memorization       = 0;
 		m_time_since_last_position_check     = 0;
 		m_time_since_last_warp_detection.Start();
-		m_time_since_last_movement_history.Start(70000);
+		m_time_since_last_movement_history.Start(MovementHistoryTimeoutMS);
 	}
 	void SetClient(Client *cli);
 	void SetExemptStatus(ExemptionType type, bool v);
 	bool GetExemptStatus(ExemptionType type);
 	void CheatDetected(CheatTypes type, glm::vec3 position1, glm::vec3 position2 = glm::vec3(0, 0, 0));
 	void MovementCheck(glm::vec3 updated_position);
-	void MovementCheck(uint32 time_between_checks = 1000);
+	void MovementCheck(uint32 time_between_checks = DefaultMovementCheckIntervalMS);
 	void CheckMemTimer();
 	void ProcessMovementHistory(const EQApplicationPacket *app);
 	void ProcessSpawnApperance(uint16 spawn_id, uint16 type, uint32 parameter);

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -9462,8 +9462,6 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 	slot_id = request->slot;
 	target_id = request->target;
 
-	cheat_manager.ProcessItemVerifyRequest(request->slot, request->target);
-
 	EQApplicationPacket *outapp = nullptr;
 	outapp = new EQApplicationPacket(OP_ItemVerifyReply, sizeof(ItemVerifyReply_Struct));
 	ItemVerifyReply_Struct* reply = (ItemVerifyReply_Struct*)outapp->pBuffer;

--- a/zone/inventory.cpp
+++ b/zone/inventory.cpp
@@ -678,6 +678,7 @@ void Client::DropItem(int16 slot_id, bool recurse)
 
 	if (GetInv().CheckNoDrop(slot_id, recurse) && !CanTradeFVNoDropItem()) {
 		auto invalid_drop = m_inv.GetItem(slot_id);
+		const auto invalid_item = invalid_drop ? invalid_drop->GetItem() : nullptr;
 		if (!invalid_drop) {
 			LogInventory("Error in InventoryProfile::CheckNoDrop() - returned 'true' for empty slot");
 		}
@@ -701,8 +702,8 @@ void Client::DropItem(int16 slot_id, bool recurse)
 
 		std::string message = fmt::format(
 			"Tried to drop an item on the ground that was no-drop! item_name [{}] item_id ({})",
-			invalid_drop->GetItem()->Name,
-			invalid_drop->GetItem()->ID
+			invalid_item ? invalid_item->Name : "UNKNOWN ITEM",
+			invalid_item ? invalid_item->ID : 0
 		);
 
 		invalid_drop = nullptr;
@@ -1905,6 +1906,17 @@ bool Client::SwapItem(MoveItem_Struct* move_in) {
 		}
 		LogError("WorldKick() of Player [{}](id:[{}], acct:[{}]) due to 'NoDrop Hack' detection >> SlotID:[{}], ItemData:[{}]",
 			GetName(), CharacterID(), AccountID(), src_slot_id, ndh_item_data.c_str());
+		RecordPlayerEventLog(
+			PlayerEvent::POSSIBLE_HACK,
+			PlayerEvent::PossibleHackEvent{
+				.message = fmt::format(
+					"NoDrop Hack detected while moving item from slot [{}] to slot [{}]. ItemData:[{}]",
+					src_slot_id,
+					dst_slot_id,
+					ndh_item_data
+				)
+			}
+		);
 		ndh_inst = nullptr;
 
 		DeleteItemInInventory(src_slot_id);


### PR DESCRIPTION
## Summary
- Fixes MQWarp threshold clamping so `Cheat:MQWarpDetectionDistanceFactor` is actually honored
- Records meaningful from/to coordinates for warp detections and applies the existing warp cooldown consistently
- Fixes the unsigned elapsed-time check in fast-memorization detection without widening the one-millisecond detection window
- Removes unused anti-cheat state paths and hardens no-drop/GM IP possible-hack logging

## Root Cause
Several detector paths were keeping state or formatting evidence incorrectly: the movement factor used an upper-bound clamp instead of a lower-bound clamp, large warp detection passed only the current location, and fast-mem timing subtracted timestamps in the wrong order.

## Validation
- `git diff --check -- world/client.cpp zone/cheat_manager.cpp zone/cheat_manager.h zone/client_packet.cpp zone/inventory.cpp`
- `cmake --build build-codex --target zone --config Debug -- /m:4`
- `cmake --build build-codex --target world --config Debug -- /m:4`
- `cmake --build build-codex --target tests --config Debug -- /m:4`
- `.\build-codex\bin\Debug\tests.exe`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cheat/hack detection logic and enforcement (movement thresholds, cooldowns, disconnect/kick paths), which can affect false positives/negatives and player experience, but changes are localized and mostly tighten evidence/logging.
> 
> **Overview**
> Improves anti-cheat/hack detection accuracy and evidence quality. Warp detection now consistently records *from/to* coordinates, applies a shared cooldown, and fixes movement speed threshold scaling so `Cheat:MQWarpDetectionDistanceFactor` is honored.
> 
> Fixes fast-memorization timing by using a correct elapsed-time check, removes unused anti-cheat state paths (`ProcessItemVerifyRequest` and related fields), and hardens possible-hack logging for GM IP rejections and no-drop item violations (null-safe item details plus explicit event logging before kicks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e015941d8f0d705ea032c385017f4c9a986b0a95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->