### PR TITLE
[Bug Fix] Fix DB expedition replay timer shortening

### DIFF
--- a/zone/expedition_db.cpp
+++ b/zone/expedition_db.cpp
@@ -558,6 +558,27 @@ namespace {
 		}
 	}
 
+	void AddReplayLockoutIfLonger(DynamicZone& expedition, uint32_t seconds)
+	{
+		if (seconds == 0) {
+			return;
+		}
+
+		// The client has one replay-timer slot per expedition; event completions can extend it
+		// but should not shorten it.
+		const DzLockout proposed = DzLockout::Create(expedition.GetName(), DzLockout::ReplayTimer, seconds, expedition.GetUUID());
+		const auto& lockouts = expedition.GetLockouts();
+		const auto replay_timer = std::ranges::find_if(lockouts, [](const DzLockout& lockout) {
+			return lockout.IsReplay();
+		});
+
+		if (replay_timer != lockouts.end() && replay_timer->GetExpireTime() >= proposed.GetExpireTime()) {
+			return;
+		}
+
+		expedition.AddLockout(DzLockout::ReplayTimer, seconds);
+	}
+
 	void ExecuteActions(DynamicZone& expedition, const Event& event_data, const std::string& runtime_event_name)
 	{
 		for (const auto& action : event_data.actions) {
@@ -575,9 +596,7 @@ namespace {
 			}
 			else if (Strings::EqualFold(action.action_type, "add_replay_lockout")) {
 				const uint32_t seconds = Strings::ToUnsignedInt(action.action_value);
-				if (seconds > 0) {
-					expedition.AddLockout(DzLockout::ReplayTimer, seconds);
-				}
+				AddReplayLockoutIfLonger(expedition, seconds);
 			}
 			else if (Strings::EqualFold(action.action_type, "depop_npc_type")) {
 				const uint32_t npc_type_id = Strings::ToUnsignedInt(action.action_value);
@@ -609,7 +628,7 @@ namespace {
 		}
 
 		if (event_data.replay_lockout_seconds > 0) {
-			expedition.AddLockout(DzLockout::ReplayTimer, event_data.replay_lockout_seconds);
+			AddReplayLockoutIfLonger(expedition, event_data.replay_lockout_seconds);
 		}
 
 		ExecuteActions(expedition, event_data, runtime_event_name);


### PR DESCRIPTION
## Summary

Fixes DB-driven expedition event completions so event replay lockouts cannot shorten an existing expedition Replay Timer.

## Root Cause

DB-driven expedition creation applies the template replay timer when the expedition is created. Boss/event completion then also applied `Replay Timer` from the event-level `replay_lockout_seconds`. Because dynamic-zone lockouts are keyed by event name, adding another `Replay Timer` replaced the existing replay lockout. A boss event with the default 2-hour replay could therefore overwrite a template replay configured for 7 days.

## Change

- Add a DB-expedition helper that computes the proposed replay expiration and skips the update when the current replay timer already expires later.
- Route event-level replay lockouts and `add_replay_lockout` actions through that helper.
- Preserve existing behavior when no replay timer exists, or when the event/action replay would extend the current timer.

## Validation

- QA pass over the creation-time replay path, dynamic-zone lockout replacement behavior, and DB event completion/action replay paths.
- `git diff --check`
- `cmake --build build-codex --target zone --config RelWithDebInfo -j 4`
- `build-codex\\bin\\RelWithDebInfo\\tests.exe` (94/94 tests passed; test runner emitted the existing non-fatal reader message at shutdown)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches expedition lockout timing on completion and scripted actions; wrong comparison logic could block legitimate replay extensions, but scope is limited to replay-timer updates in DB expedition flow.
> 
> **Overview**
> **DB expedition replay timers** no longer get shortened when a boss event or `add_replay_lockout` action applies a shorter replay duration than the template already set at creation.
> 
> A shared helper compares the proposed replay expiration to the expedition’s current **Replay Timer** lockout and skips the update when the existing timer already ends later. Event completion and action paths both use this helper instead of unconditionally replacing the replay lockout (which shared one client slot and could wipe a long template replay with a short default event replay).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d45c0b8cf932047cecb400701ddc3810a86952ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->