### PR TITLE
[Bug Fix] Fix bandolier off-hand visual desync

### DIFF
--- a/zone/inventory.cpp
+++ b/zone/inventory.cpp
@@ -3120,6 +3120,17 @@ void Client::SetBandolier(const EQApplicationPacket *app)
 	EQ::ItemInstance *BandolierItems[4] = { nullptr, nullptr, nullptr, nullptr }; // Temporary holding area for the weapons we pull out of their inventory
 	int16 BandolierSourceSlots[4] = { INVALID_INDEX, INVALID_INDEX, INVALID_INDEX, INVALID_INDEX };
 	bool bandolier_persistence_ok = true;
+	bool bandolier_primary_visual_touched = false;
+	bool bandolier_secondary_visual_touched = false;
+
+	auto mark_bandolier_weapon_visual_touched = [&](int16 slot_id) {
+		if (slot_id == EQ::invslot::slotPrimary) {
+			bandolier_primary_visual_touched = true;
+		}
+		else if (slot_id == EQ::invslot::slotSecondary) {
+			bandolier_secondary_visual_touched = true;
+		}
+	};
 
 	auto fail_bandolier_persistence = [&](const std::string &reason) {
 		if (bandolier_persistence_ok) {
@@ -3527,6 +3538,7 @@ void Client::SetBandolier(const EQApplicationPacket *app)
 					LogInventory("Character does not have required bandolier item for slot [{}]", WeaponSlot);
 					EQ::ItemInstance *InvItem = m_inv.PopItem(WeaponSlot);
 					if(InvItem) {
+						mark_bandolier_weapon_visual_touched(WeaponSlot);
 						// If there was an item in that weapon slot, put it in the inventory
 						LogInventory("returning item [{}] in weapon slot [{}] to inventory",
 						InvItem->GetItem()->Name, WeaponSlot);
@@ -3749,6 +3761,7 @@ void Client::SetBandolier(const EQApplicationPacket *app)
 				// Pull the item that we are going to replace
 				EQ::ItemInstance *InvItem = m_inv.PopItem(WeaponSlot);
 				add_bandolier_resync_slot(WeaponSlot);
+				mark_bandolier_weapon_visual_touched(WeaponSlot);
 				LogInventory(
 					"Bandolier set [{}] equipping bandolier slot [{}] item [{}] ([{}]) into weapon slot [{}], replacing [{}] ([{}])",
 					bss->Number,
@@ -3825,6 +3838,7 @@ void Client::SetBandolier(const EQApplicationPacket *app)
 			// put it in the player's inventory.
 			EQ::ItemInstance *InvItem = m_inv.PopItem(WeaponSlot);
 			add_bandolier_resync_slot(WeaponSlot);
+			mark_bandolier_weapon_visual_touched(WeaponSlot);
 			if(InvItem) {
 				LogInventory("Bandolier has no item for slot [{}], returning item [{}] to inventory", WeaponSlot, InvItem->GetItem()->Name);
 				// If there was an item in that weapon slot, put it in the inventory
@@ -3929,6 +3943,14 @@ void Client::SetBandolier(const EQApplicationPacket *app)
 		bss->Number,
 		bandolier_resync_slots.size()
 	);
+
+	if (bandolier_primary_visual_touched) {
+		SendWearChange(EQ::textures::weaponPrimary, nullptr, true);
+	}
+
+	if (bandolier_secondary_visual_touched) {
+		SendWearChange(EQ::textures::weaponSecondary, nullptr, true);
+	}
 
 	// finally, recalculate any stat bonuses from the item change
 	CalcBonuses();

--- a/zone/inventory.cpp
+++ b/zone/inventory.cpp
@@ -3470,6 +3470,7 @@ void Client::SetBandolier(const EQApplicationPacket *app)
 				BandolierItems[BandolierSlot] = m_inv.PopItem(slot);
 				BandolierSourceSlots[BandolierSlot] = slot;
 				if (BandolierItems[BandolierSlot]) {
+					mark_bandolier_weapon_visual_touched(slot);
 					LogInventory(
 						"Bandolier set [{}] pulled item [{}] ([{}]) for bandolier slot [{}] from source slot [{}]",
 						bss->Number,

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -333,7 +333,7 @@ public:
 
 	virtual void SendArmorAppearance(Client *one_client = nullptr);
 	virtual void SendTextureWC(uint8 slot, uint32 texture, uint32 hero_forge_model = 0, uint32 elite_material = 0, uint32 unknown06 = 0, uint32 unknown18 = 0);
-	virtual void SendWearChange(uint8 material_slot, Client *one_client = nullptr);
+	virtual void SendWearChange(uint8 material_slot, Client *one_client = nullptr, bool force_send = false);
 	virtual void SetSlotTint(uint8 material_slot, uint8 red_tint, uint8 green_tint, uint8 blue_tint);
 	virtual void WearChange(uint8 material_slot, uint32 texture, uint32 color = 0, uint32 hero_forge_model = 0);
 

--- a/zone/mob_appearance.cpp
+++ b/zone/mob_appearance.cpp
@@ -375,7 +375,7 @@ void Mob::SendArmorAppearance(Client *one_client)
 	}
 }
 
-void Mob::SendWearChange(uint8 material_slot, Client *one_client)
+void Mob::SendWearChange(uint8 material_slot, Client *one_client, bool force_send)
 {
 	auto packet = new EQApplicationPacket(OP_WearChange, sizeof(WearChange_Struct));
 	auto w      = (WearChange_Struct *) packet->pBuffer;
@@ -424,7 +424,7 @@ void Mob::SendWearChange(uint8 material_slot, Client *one_client)
 	auto dedupe_key = build_key(*w);
 	auto send_if_changed = [&](Client* client) {
 		auto& last_key = m_last_seen_wearchange[client->GetID()][material_slot];
-		if (last_key == dedupe_key) {
+		if (!force_send && last_key == dedupe_key) {
 			return;
 		}
 		last_key = dedupe_key;


### PR DESCRIPTION
## Summary
- Add an explicit force-send path for weapon wear-change packets while preserving the existing dedupe behavior by default.
- Track primary/secondary weapon visual touches during bandolier activation.
- Force-refresh touched weapon appearance slots after successful bandolier commit and inventory resync.

## Root Cause
Recent bandolier resync logic corrected inventory slots, but weapon visuals use `OP_WearChange` for primary/secondary model slots. When bandolier activation leaves the off hand empty, the client can keep a stale locally predicted off-hand model even though the server inventory is correct. If the server already believes secondary is visually empty, the wear-change dedupe can suppress the authoritative clear packet, leaving the bad local visual in place.

The originally reported ranged-item case is one way to notice the issue, but the ranged item is not causal; the same off-hand visual desync can occur with no ranged item equipped.

## Validation
- `git diff --check`
- `cmake --build build-codex --target zone --config Debug`

The zone build passed. The build still emits existing conversion warnings in unrelated files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized bandolier and appearance-packet behavior; no auth, persistence, or payment paths changed.
> 
> **Overview**
> Fixes **bandolier off-hand visual desync** when inventory resync is correct but the client still shows a stale secondary weapon model.
> 
> **`SetBandolier`** now marks when primary/secondary **weapon inventory slots** are involved in the swap, then after slot resync calls **`SendWearChange`** for **`weaponPrimary`** / **`weaponSecondary`** with **forced send**.
> 
> **`Mob::SendWearChange`** gains an optional **`force_send`** flag so **`OP_WearChange`** is not skipped when the dedupe cache already matches an empty off-hand—addressing cases where the server thinks the slot is visually clear but the client does not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8124bc0011e825d4037f9bb9ac981281c7ea9585. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->