### PR TITLE
[Feature] Add expedition boss-only spawn toggle

### DIFF
--- a/common/database/database_update_manifest.h
+++ b/common/database/database_update_manifest.h
@@ -7418,6 +7418,7 @@ CREATE TABLE IF NOT EXISTS `expedition_templates` (
 	`replay_lockout_seconds` INT(10) UNSIGNED NOT NULL DEFAULT '0',
 	`replay_on_join` TINYINT(1) UNSIGNED NOT NULL DEFAULT '1',
 	`silent` TINYINT(1) UNSIGNED NOT NULL DEFAULT '0',
+	`boss_only_spawn` TINYINT(1) UNSIGNED NOT NULL DEFAULT '0',
 	`request_phrase` VARCHAR(64) NOT NULL DEFAULT 'expedition',
 	`request_mode` VARCHAR(32) NOT NULL DEFAULT 'db_only',
 	`notes` TEXT NULL,
@@ -7480,6 +7481,18 @@ CREATE TABLE IF NOT EXISTS `expedition_template_actions` (
 	PRIMARY KEY (`id`),
 	KEY `idx_expedition_actions_event` (`event_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+)",
+		.content_schema_update = true
+	},
+	ManifestEntry{
+		.version = 9345,
+		.description = "2026_05_31_expedition_boss_only_spawn.sql",
+		.check = "SHOW COLUMNS FROM `expedition_templates` LIKE 'boss_only_spawn'",
+		.condition = "empty",
+		.match = "",
+		.sql = R"(
+ALTER TABLE `expedition_templates`
+ADD COLUMN `boss_only_spawn` TINYINT(1) UNSIGNED NOT NULL DEFAULT '0' AFTER `silent`;
 )",
 		.content_schema_update = true
 	},

--- a/common/version.h
+++ b/common/version.h
@@ -41,6 +41,6 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9344
+#define CURRENT_BINARY_DATABASE_VERSION 9345
 #define CURRENT_BINARY_BOTS_DATABASE_VERSION 9054
 #define CUSTOM_BINARY_DATABASE_VERSION 0

--- a/tests/expedition_schema_test.h
+++ b/tests/expedition_schema_test.h
@@ -16,7 +16,9 @@ public:
 	{
 		TEST_ADD(ExpeditionSchemaTest::ContentSchemaIncludesExpeditionAuthoringTables);
 		TEST_ADD(ExpeditionSchemaTest::CreationMigrationHasFinalSchema);
+		TEST_ADD(ExpeditionSchemaTest::BossOnlyMigrationUpdatesExistingTemplates);
 		TEST_ADD(ExpeditionSchemaTest::BinaryDatabaseVersionIncludesExpeditionMigrations);
+		TEST_ADD(ExpeditionSchemaTest::BossOnlyDefaultsAreOff);
 		TEST_ADD(ExpeditionSchemaTest::SimpleBuilderDefaultsAreGroupReady);
 	}
 
@@ -37,9 +39,9 @@ private:
 
 	void CreationMigrationHasFinalSchema()
 	{
-		// The DB-driven expedition feature ships as a single creation migration that
-		// already contains the final schema (request_mode, versioned requests, and
-		// spawn-completion); there are no follow-up ALTER migrations to apply.
+		// The DB-driven expedition feature creation migration contains the full
+		// schema for a fresh database. Later ALTER migrations only update existing
+		// installs.
 		auto entry = std::find_if(manifest_entries.begin(), manifest_entries.end(), [](const ManifestEntry& e) {
 			return e.version == 9344 && e.description == "2026_05_21_db_driven_expeditions.sql";
 		});
@@ -49,6 +51,7 @@ private:
 		TEST_ASSERT(entry->check == "SHOW TABLES LIKE 'expedition_templates'");
 		TEST_ASSERT(entry->condition == "empty");
 		TEST_ASSERT(entry->sql.find("request_mode") != std::string::npos);
+		TEST_ASSERT(entry->sql.find("boss_only_spawn") != std::string::npos);
 		TEST_ASSERT(entry->sql.find("db_only") != std::string::npos);
 		TEST_ASSERT(entry->sql.find("zone_version") != std::string::npos);
 		TEST_ASSERT(entry->sql.find("complete_on_spawn") != std::string::npos);
@@ -61,9 +64,34 @@ private:
 		TEST_ASSERT(followup == manifest_entries.end());
 	}
 
+	void BossOnlyMigrationUpdatesExistingTemplates()
+	{
+		auto entry = std::find_if(manifest_entries.begin(), manifest_entries.end(), [](const ManifestEntry& e) {
+			return e.version == 9345 && e.description == "2026_05_31_expedition_boss_only_spawn.sql";
+		});
+
+		TEST_ASSERT(entry != manifest_entries.end());
+		TEST_ASSERT(entry->content_schema_update);
+		TEST_ASSERT(entry->check == "SHOW COLUMNS FROM `expedition_templates` LIKE 'boss_only_spawn'");
+		TEST_ASSERT(entry->condition == "empty");
+		TEST_ASSERT(entry->sql.find("ALTER TABLE `expedition_templates`") != std::string::npos);
+		TEST_ASSERT(entry->sql.find("boss_only_spawn") != std::string::npos);
+		TEST_ASSERT(entry->sql.find("DEFAULT '0'") != std::string::npos);
+	}
+
 	void BinaryDatabaseVersionIncludesExpeditionMigrations()
 	{
-		TEST_ASSERT(CURRENT_BINARY_DATABASE_VERSION >= 9344);
+		TEST_ASSERT(CURRENT_BINARY_DATABASE_VERSION >= 9345);
+	}
+
+	void BossOnlyDefaultsAreOff()
+	{
+		ExpeditionDB::Template template_data;
+		TEST_ASSERT(!template_data.boss_only_spawn);
+
+		ExpeditionDB::BossOnlySpawnFilter filter;
+		TEST_ASSERT(!filter.enabled);
+		TEST_ASSERT(filter.npc_type_ids_by_spawn2_id.empty());
 	}
 
 	void SimpleBuilderDefaultsAreGroupReady()

--- a/zone/expedition_db.cpp
+++ b/zone/expedition_db.cpp
@@ -1251,7 +1251,7 @@ ValidationResult ValidateTemplate(const Template& template_data)
 		}
 
 		if (!has_concrete_boss) {
-			result.errors.push_back("Boss-only spawn mode requires at least one boss NPC mapping with a spawn-specific id.");
+			result.errors.push_back("Boss-only spawn mode requires at least one boss NPC mapping with a concrete spawn2_id.");
 		}
 	}
 
@@ -1568,7 +1568,6 @@ BossOnlySpawnFilter GetBossOnlySpawnFilter(DynamicZone* expedition)
 		return filter;
 	}
 
-	filter.enabled = true;
 	for (const auto& event_data : template_data->events) {
 		for (const auto& event_npc : event_data.npcs) {
 			if (
@@ -1581,6 +1580,7 @@ BossOnlySpawnFilter GetBossOnlySpawnFilter(DynamicZone* expedition)
 		}
 	}
 
+	filter.enabled = !filter.npc_type_ids_by_spawn2_id.empty();
 	return filter;
 }
 

--- a/zone/expedition_db.cpp
+++ b/zone/expedition_db.cpp
@@ -693,6 +693,7 @@ uint32_t CreateTemplateFromClient(Database& db, Client& client, const std::strin
 		kSimpleSetupReplaySeconds,
 		true,
 		false,
+		false,
 		kSimpleRequestPhrase,
 		kSimpleRequestMode,
 		""
@@ -816,6 +817,13 @@ bool SetTemplateReplay(Database& db, uint32_t template_id, uint32_t seconds)
 bool SetTemplateSilent(Database& db, uint32_t template_id, bool silent)
 {
 	const bool ok = ExpeditionRepository::UpdateTemplateSilent(db, template_id, silent);
+	Reload(db);
+	return ok;
+}
+
+bool SetTemplateBossOnlySpawn(Database& db, uint32_t template_id, bool enabled)
+{
+	const bool ok = ExpeditionRepository::UpdateTemplateBossOnlySpawn(db, template_id, enabled);
 	Reload(db);
 	return ok;
 }
@@ -1232,6 +1240,21 @@ ValidationResult ValidateTemplate(const Template& template_data)
 		result.warnings.push_back("Request mode is script_can_opt_in, so request NPC mappings are documentation only unless scripts call DB template APIs.");
 	}
 
+	if (template_data.boss_only_spawn) {
+		bool has_concrete_boss = false;
+		for (const auto& event_data : template_data.events) {
+			for (const auto& event_npc : event_data.npcs) {
+				if (Strings::EqualFold(event_npc.role, "boss") && event_npc.npc_type_id != 0 && event_npc.spawn2_id != 0) {
+					has_concrete_boss = true;
+				}
+			}
+		}
+
+		if (!has_concrete_boss) {
+			result.errors.push_back("Boss-only spawn mode requires at least one boss NPC mapping with a spawn-specific id.");
+		}
+	}
+
 	for (const auto& [other_id, other_template] : g_templates) {
 		if (
 			other_id != template_data.id &&
@@ -1531,6 +1554,34 @@ bool HandleNpcSpawn(NPC& npc)
 	}
 
 	return handled;
+}
+
+BossOnlySpawnFilter GetBossOnlySpawnFilter(DynamicZone* expedition)
+{
+	BossOnlySpawnFilter filter;
+	if (!expedition || !expedition->IsExpedition()) {
+		return filter;
+	}
+
+	const Template* template_data = FindTemplateByDz(*expedition);
+	if (!template_data || !template_data->boss_only_spawn) {
+		return filter;
+	}
+
+	filter.enabled = true;
+	for (const auto& event_data : template_data->events) {
+		for (const auto& event_npc : event_data.npcs) {
+			if (
+				Strings::EqualFold(event_npc.role, "boss") &&
+				event_npc.npc_type_id != 0 &&
+				event_npc.spawn2_id != 0
+			) {
+				filter.npc_type_ids_by_spawn2_id[event_npc.spawn2_id].insert(event_npc.npc_type_id);
+			}
+		}
+	}
+
+	return filter;
 }
 
 void ApplyRequesterLastName(NPC& npc)

--- a/zone/expedition_db.h
+++ b/zone/expedition_db.h
@@ -6,6 +6,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 class Client;
@@ -79,6 +80,7 @@ struct Template {
 	uint32_t replay_lockout_seconds = 0;
 	bool replay_on_join = true;
 	bool silent = false;
+	bool boss_only_spawn = false;
 	std::string request_phrase = "expedition";
 	std::string request_mode = "db_only";
 	std::string notes;
@@ -108,6 +110,11 @@ struct BuilderState {
 	bool edit_mode = false;
 };
 
+struct BossOnlySpawnFilter {
+	bool enabled = false;
+	std::unordered_map<uint32_t, std::unordered_set<uint32_t>> npc_type_ids_by_spawn2_id;
+};
+
 uint32_t CreateTemplateFromClient(Database& db, Client& client, const std::string& name);
 uint32_t CloneTemplate(Database& db, uint32_t source_template_id, const std::string& name);
 bool DeleteTemplate(Database& db, uint32_t template_id);
@@ -115,6 +122,7 @@ bool SetTemplateName(Database& db, uint32_t template_id, const std::string& name
 bool SetTemplateEnabled(Database& db, uint32_t template_id, bool enabled);
 bool SetTemplateReplay(Database& db, uint32_t template_id, uint32_t seconds);
 bool SetTemplateSilent(Database& db, uint32_t template_id, bool silent);
+bool SetTemplateBossOnlySpawn(Database& db, uint32_t template_id, bool enabled);
 bool SetTemplateRequestMode(Database& db, uint32_t template_id, const std::string& request_mode);
 bool SetDzTemplateZone(Database& db, uint32_t dz_template_id, uint32_t zone_id, uint32_t version);
 bool SetDzTemplateDuration(Database& db, uint32_t dz_template_id, uint32_t seconds);
@@ -155,6 +163,7 @@ bool CanCreateExpeditionFromTemplate(Client& client, const Template& template_da
 bool HandleRequestSay(Client& client, NPC& npc, const std::string& message);
 bool HandleNpcDeath(NPC& npc, Client* killer);
 bool HandleNpcSpawn(NPC& npc);
+BossOnlySpawnFilter GetBossOnlySpawnFilter(DynamicZone* expedition);
 // Stamps the "Expeditions" surname on configured requester NPCs (and clears a stale one when an
 // NPC is no longer a requester). Safe to call for any NPC spawn in any zone.
 void ApplyRequesterLastName(NPC& npc);

--- a/zone/expedition_repository.cpp
+++ b/zone/expedition_repository.cpp
@@ -59,7 +59,7 @@ std::vector<ExpeditionDB::Template> LoadAllTemplates(Database& db)
 {
 	std::vector<ExpeditionDB::Template> out;
 	auto results = db.QueryDatabase(
-		"SELECT id, dz_template_id, name, slug, enabled, replay_lockout_seconds, replay_on_join, silent, request_phrase, request_mode, notes "
+		"SELECT id, dz_template_id, name, slug, enabled, replay_lockout_seconds, replay_on_join, silent, boss_only_spawn, request_phrase, request_mode, notes "
 		"FROM expedition_templates"
 	);
 
@@ -77,9 +77,10 @@ std::vector<ExpeditionDB::Template> LoadAllTemplates(Database& db)
 		e.replay_lockout_seconds = UInt(row[5]);
 		e.replay_on_join = Truthy(row[6]);
 		e.silent = Truthy(row[7]);
-		e.request_phrase = Text(row[8]);
-		e.request_mode = Text(row[9]);
-		e.notes = Text(row[10]);
+		e.boss_only_spawn = Truthy(row[8]);
+		e.request_phrase = Text(row[9]);
+		e.request_mode = Text(row[10]);
+		e.notes = Text(row[11]);
 		out.push_back(std::move(e));
 	}
 
@@ -210,14 +211,15 @@ uint32_t InsertTemplate(
 	uint32_t replay_lockout_seconds,
 	bool replay_on_join,
 	bool silent,
+	bool boss_only_spawn,
 	const std::string& request_phrase,
 	const std::string& request_mode,
 	const std::string& notes)
 {
 	return InsertID(db, fmt::format(
 		"INSERT INTO expedition_templates "
-		"(dz_template_id, name, slug, enabled, replay_lockout_seconds, replay_on_join, silent, request_phrase, request_mode, notes) "
-		"VALUES ({}, '{}', '{}', {}, {}, {}, {}, '{}', '{}', '{}')",
+		"(dz_template_id, name, slug, enabled, replay_lockout_seconds, replay_on_join, silent, boss_only_spawn, request_phrase, request_mode, notes) "
+		"VALUES ({}, '{}', '{}', {}, {}, {}, {}, {}, '{}', '{}', '{}')",
 		dz_template_id,
 		Escape(name),
 		Escape(slug),
@@ -225,6 +227,7 @@ uint32_t InsertTemplate(
 		replay_lockout_seconds,
 		replay_on_join ? 1 : 0,
 		silent ? 1 : 0,
+		boss_only_spawn ? 1 : 0,
 		Escape(request_phrase),
 		Escape(request_mode),
 		Escape(notes)
@@ -240,8 +243,8 @@ uint32_t InsertTemplateFrom(
 {
 	return InsertID(db, fmt::format(
 		"INSERT INTO expedition_templates "
-		"(dz_template_id, name, slug, enabled, replay_lockout_seconds, replay_on_join, silent, request_phrase, request_mode, notes) "
-		"SELECT {}, '{}', '{}', 0, replay_lockout_seconds, replay_on_join, silent, request_phrase, request_mode, notes "
+		"(dz_template_id, name, slug, enabled, replay_lockout_seconds, replay_on_join, silent, boss_only_spawn, request_phrase, request_mode, notes) "
+		"SELECT {}, '{}', '{}', 0, replay_lockout_seconds, replay_on_join, silent, boss_only_spawn, request_phrase, request_mode, notes "
 		"FROM expedition_templates WHERE id = {}",
 		dz_template_id,
 		Escape(name),
@@ -273,6 +276,11 @@ bool UpdateTemplateReplay(Database& db, uint32_t template_id, uint32_t seconds)
 bool UpdateTemplateSilent(Database& db, uint32_t template_id, bool silent)
 {
 	return QueryOK(db, fmt::format("UPDATE expedition_templates SET silent = {} WHERE id = {}", silent ? 1 : 0, template_id));
+}
+
+bool UpdateTemplateBossOnlySpawn(Database& db, uint32_t template_id, bool enabled)
+{
+	return QueryOK(db, fmt::format("UPDATE expedition_templates SET boss_only_spawn = {} WHERE id = {}", enabled ? 1 : 0, template_id));
 }
 
 bool UpdateTemplateRequestMode(Database& db, uint32_t template_id, const std::string& request_mode)

--- a/zone/expedition_repository.h
+++ b/zone/expedition_repository.h
@@ -36,6 +36,7 @@ uint32_t InsertTemplate(
 	uint32_t replay_lockout_seconds,
 	bool replay_on_join,
 	bool silent,
+	bool boss_only_spawn,
 	const std::string& request_phrase,
 	const std::string& request_mode,
 	const std::string& notes
@@ -53,6 +54,7 @@ bool UpdateTemplateName(Database& db, uint32_t template_id, const std::string& n
 bool UpdateTemplateEnabled(Database& db, uint32_t template_id, bool enabled);
 bool UpdateTemplateReplay(Database& db, uint32_t template_id, uint32_t seconds);
 bool UpdateTemplateSilent(Database& db, uint32_t template_id, bool silent);
+bool UpdateTemplateBossOnlySpawn(Database& db, uint32_t template_id, bool enabled);
 bool UpdateTemplateRequestMode(Database& db, uint32_t template_id, const std::string& request_mode);
 bool DeleteTemplate(Database& db, uint32_t template_id);
 

--- a/zone/gm_commands/expedition.cpp
+++ b/zone/gm_commands/expedition.cpp
@@ -966,6 +966,7 @@ namespace {
 		SendSectionHeader(c, "Behavior");
 		SendHelpLink(c, "#expedition set requestmode db_only|script_can_opt_in|script_only", "choose DB/script request handling");
 		SendHelpLink(c, "#expedition set silent on|off", "toggle normal create/failure messages");
+		SendHelpLink(c, "#expedition set bossonly on|off", "toggle spawning only mapped boss NPCs in expedition instances");
 		SendHelpLink(c, "#expedition set switchid target|<id>", "set dynamic-zone switch entity id");
 
 		SendActionGroup(c, "Common Setup Actions", {
@@ -1190,6 +1191,7 @@ namespace {
 		SendInfoLine(c, "Duration", Duration(template_data.dz_template.duration_seconds));
 		SendInfoLine(c, "Replay", Duration(template_data.replay_lockout_seconds));
 		SendInfoLine(c, "Requests", template_data.request_mode);
+		SendInfoLine(c, "Boss-only spawns", OnOff(template_data.boss_only_spawn));
 		c->Message(Chat::White, ChatSeparator());
 
 		c->Message(Chat::Yellow, "Bosses & Chests:");
@@ -1256,6 +1258,7 @@ namespace {
 			Duration(template_data.replay_lockout_seconds),
 			OnOff(template_data.silent)
 		).c_str());
+		c->Message(Chat::White, fmt::format("Boss-only spawns: {}", OnOff(template_data.boss_only_spawn)).c_str());
 		c->Message(Chat::White, fmt::format(
 			"Zone-in: {}",
 			Location(template_data.dz_template.zone_id, template_data.dz_template.zone_in_x, template_data.dz_template.zone_in_y, template_data.dz_template.zone_in_z, template_data.dz_template.zone_in_h)
@@ -1769,6 +1772,7 @@ void ShowConfigScreen(Client* c, const ExpeditionDB::Template& template_data)
 		SendInfoLine(c, "Players", fmt::format("{} - {}", dz.min_players, dz.max_players));
 		SendInfoLine(c, "Zone-in", dz.override_zone_in ? "set" : "NOT SET");
 		SendInfoLine(c, "Safe return", dz.return_zone_id ? "set" : "default");
+		SendInfoLine(c, "Boss-only spawns", OnOff(template_data.boss_only_spawn));
 		c->Message(Chat::White, ChatSeparator());
 
 		c->Message(Chat::White, "  Duration (how long the instance stays open):");
@@ -1809,6 +1813,11 @@ void ShowConfigScreen(Client* c, const ExpeditionDB::Template& template_data)
 			{"#expedition config zonein", "Set Zone-in Here"},
 			{"#expedition config safereturn", "Set Safe Return Here"},
 			{"#expedition config compass", "Set Compass Here"}
+		});
+		c->Message(Chat::White, "  Spawn behavior:");
+		SendActionRow(c, {
+			{"#expedition config bossonly on", "Bosses Only"},
+			{"#expedition config bossonly off", "Normal Spawns"}
 		});
 		c->Message(Chat::White, ChatSeparator());
 		SendActionRow(c, {
@@ -1936,6 +1945,15 @@ void HandleConfig(Client* c, const Seperator* sep)
 		else if (action == "compass") {
 			ExpeditionDB::SetDzTemplateCompass(content_db, dz_template_id, zone->GetZoneID(), pos.x, pos.y, pos.z);
 			c->Message(Chat::Green, "Set the compass marker to your current location.");
+		}
+		else if (action == "bossonly" || action == "boss_only") {
+			bool enabled = false;
+			if (!ParseOnOffArg(sep->arg[3], enabled)) {
+				c->Message(Chat::Red, "Usage: #expedition config bossonly on|off");
+				return;
+			}
+			ExpeditionDB::SetTemplateBossOnlySpawn(content_db, template_id, enabled);
+			c->Message(Chat::Green, fmt::format("Set boss-only spawns to [{}].", OnOff(enabled)).c_str());
 		}
 		else {
 			ShowConfigScreen(c, *template_data);
@@ -3052,6 +3070,15 @@ void HandleSet(Client* c, const Seperator* sep)
 			}
 			ExpeditionDB::SetTemplateSilent(content_db, template_data->id, enabled);
 			c->Message(Chat::Green, fmt::format("Set silent to [{}].", OnOff(enabled)).c_str());
+		}
+		else if (field == "bossonly" || field == "boss_only") {
+			bool enabled = false;
+			if (!ParseOnOffArg(sep->arg[3], enabled)) {
+				c->Message(Chat::Red, "Usage: #expedition set bossonly on|off");
+				return;
+			}
+			ExpeditionDB::SetTemplateBossOnlySpawn(content_db, template_data->id, enabled);
+			c->Message(Chat::Green, fmt::format("Set boss-only spawns to [{}].", OnOff(enabled)).c_str());
 		}
 		else if (field == "requestmode") {
 			if (!IsRequestModeArg(sep->arg[3])) {

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -2137,6 +2137,7 @@ luabind::object Lua_Client::GetExpeditionTemplate(lua_State* L, uint32_t expedit
 	result["max_players"] = template_data->dz_template.max_players;
 	result["replay_lockout_seconds"] = template_data->replay_lockout_seconds;
 	result["silent"] = template_data->silent;
+	result["boss_only_spawn"] = template_data->boss_only_spawn;
 	result["request_phrase"] = template_data->request_phrase;
 	result["request_mode"] = template_data->request_mode;
 	return result;

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -2035,6 +2035,7 @@ perl::reference Perl_Client_GetExpeditionTemplate(Client* self, uint32_t expedit
 	result["max_players"] = template_data->dz_template.max_players;
 	result["replay_lockout_seconds"] = template_data->replay_lockout_seconds;
 	result["silent"] = template_data->silent;
+	result["boss_only_spawn"] = template_data->boss_only_spawn;
 	result["request_phrase"] = template_data->request_phrase;
 	result["request_mode"] = template_data->request_mode;
 	return perl::reference(result);

--- a/zone/spawn2.cpp
+++ b/zone/spawn2.cpp
@@ -29,6 +29,7 @@
 #include "common/strings.h"
 #include "zone/client.h"
 #include "zone/entity.h"
+#include "zone/expedition_db.h"
 #include "zone/spawngroup.h"
 #include "zone/worldserver.h"
 #include "zone/zone.h"
@@ -202,11 +203,16 @@ bool Spawn2::Process() {
 
 		//have the spawn group pick an NPC for us
 		uint32 npcid = 0;
+		const auto* allowed_npc_type_ids = m_allowed_npc_type_ids.empty() ? nullptr : &m_allowed_npc_type_ids;
 		if (m_resumed_npc_id > 0) {
 			npcid = m_resumed_npc_id;
 			m_resumed_npc_id = 0;
+			if (allowed_npc_type_ids && !allowed_npc_type_ids->contains(npcid)) {
+				LogSpawns("Spawn2 [{}]: resumed NPC type [{}] is not allowed by the boss-only spawn filter", spawn2_id, npcid);
+				npcid = 0;
+			}
 		} else {
-			npcid = spawn_group->GetNPCType(condition_value);
+			npcid = spawn_group->GetNPCType(condition_value, allowed_npc_type_ids);
 		}
 
 		if (npcid == 0) {
@@ -537,6 +543,8 @@ bool ZoneDatabase::PopulateZoneSpawnList(uint32 zoneid, LinkedList<Spawn2*> &spa
 
 	NPC::SpawnZoneController();
 
+	const auto boss_only_filter = ExpeditionDB::GetBossOnlySpawnFilter(zone ? zone->GetDynamicZone() : nullptr);
+
 	if (RuleB(Zone, StateSavingOnShutdown) && zone->LoadZoneState(spawn_times, disabled_spawns)) {
 		LogZoneState("Loaded zone state for zone [{}] instance_id [{}]", zone_name, zone->GetInstanceID());
 		return true;
@@ -559,6 +567,17 @@ bool ZoneDatabase::PopulateZoneSpawnList(uint32 zoneid, LinkedList<Spawn2*> &spa
 			}
 		}
 
+		const std::unordered_set<uint32_t>* allowed_npc_type_ids = nullptr;
+		if (boss_only_filter.enabled) {
+			const auto allowed_it = boss_only_filter.npc_type_ids_by_spawn2_id.find(s.id);
+			if (allowed_it == boss_only_filter.npc_type_ids_by_spawn2_id.end()) {
+				spawn_enabled = false;
+			}
+			else {
+				allowed_npc_type_ids = &allowed_it->second;
+			}
+		}
+
 		auto new_spawn = new Spawn2(
 			s.id,
 			s.spawngroupID,
@@ -576,6 +595,10 @@ bool ZoneDatabase::PopulateZoneSpawnList(uint32 zoneid, LinkedList<Spawn2*> &spa
 			spawn_enabled,
 			(EmuAppearance) s.animation
 		);
+
+		if (allowed_npc_type_ids) {
+			new_spawn->SetAllowedNPCTypeIDs(*allowed_npc_type_ids);
+		}
 
 		spawn2_list.Insert(new_spawn);
 		new_spawn->Process();
@@ -1375,4 +1398,3 @@ bool SpawnConditionManager::Check(uint16 condition, int16 min_value) {
 
 	return(cond.value >= min_value);
 }
-

--- a/zone/spawn2.cpp
+++ b/zone/spawn2.cpp
@@ -543,12 +543,12 @@ bool ZoneDatabase::PopulateZoneSpawnList(uint32 zoneid, LinkedList<Spawn2*> &spa
 
 	NPC::SpawnZoneController();
 
-	const auto boss_only_filter = ExpeditionDB::GetBossOnlySpawnFilter(zone ? zone->GetDynamicZone() : nullptr);
-
 	if (RuleB(Zone, StateSavingOnShutdown) && zone->LoadZoneState(spawn_times, disabled_spawns)) {
 		LogZoneState("Loaded zone state for zone [{}] instance_id [{}]", zone_name, zone->GetInstanceID());
 		return true;
 	}
+
+	const auto boss_only_filter = ExpeditionDB::GetBossOnlySpawnFilter(zone->GetDynamicZone());
 
 	// normal spawn2 loading
 	for (auto &s: spawns) {

--- a/zone/spawn2.h
+++ b/zone/spawn2.h
@@ -21,6 +21,8 @@
 #include "common/timer.h"
 #include "zone/npc.h"
 
+#include <unordered_set>
+
 #define SC_AlwaysEnabled 0
 
 class SpawnCondition;
@@ -80,6 +82,7 @@ public:
 	inline void SetEntityVariables(std::map<std::string, std::string> vars) { m_entity_variables = vars; }
 	inline void SetResumedNPCID(uint32 npc_id) { m_resumed_npc_id = npc_id; }
 	inline void SetStoredLocation(const glm::vec4& loc) { m_stored_location = loc; }
+	inline void SetAllowedNPCTypeIDs(const std::unordered_set<uint32>& allowed_npc_type_ids) { m_allowed_npc_type_ids = allowed_npc_type_ids; }
 
 protected:
 	friend class Zone;
@@ -110,6 +113,7 @@ private:
 	uint32 m_resumed_npc_id = 0;
 	std::map<std::string, std::string> m_entity_variables = {};
 	glm::vec4 m_stored_location = {0, 0, -1000, 0}; // use -1000 to indicate unset/zero-state
+	std::unordered_set<uint32> m_allowed_npc_type_ids = {};
 };
 
 class SpawnCondition {

--- a/zone/spawngroup.cpp
+++ b/zone/spawngroup.cpp
@@ -69,7 +69,7 @@ SpawnGroup::SpawnGroup(
 	wp_spawns = wp_spawns_in;
 }
 
-uint32 SpawnGroup::GetNPCType(uint16 in_filter)
+uint32 SpawnGroup::GetNPCType(uint16 in_filter, const std::unordered_set<uint32>* allowed_npc_type_ids)
 {
 	int npcType     = 0;
 	int totalchance = 0;
@@ -81,6 +81,10 @@ uint32 SpawnGroup::GetNPCType(uint16 in_filter)
 	std::list<SpawnEntry *> possible;
 	for (auto &it : list_) {
 		auto se = it.get();
+
+		if (allowed_npc_type_ids && !allowed_npc_type_ids->contains(se->NPCType)) {
+			continue;
+		}
 
 		if (!entity_list.LimitCheckType(se->NPCType, se->npc_spawn_limit)) {
 			continue;

--- a/zone/spawngroup.h
+++ b/zone/spawngroup.h
@@ -23,6 +23,7 @@
 #include <list>
 #include <map>
 #include <memory>
+#include <unordered_set>
 
 class SpawnEntry {
 public:
@@ -57,7 +58,7 @@ public:
 	);
 
 	~SpawnGroup();
-	uint32 GetNPCType(uint16 condition_value_filter=1);
+	uint32 GetNPCType(uint16 condition_value_filter=1, const std::unordered_set<uint32>* allowed_npc_type_ids = nullptr);
 	void AddSpawnEntry(std::unique_ptr<SpawnEntry> &newEntry);
 	uint32 id;
 	bool wp_spawns;			// if true, spawn NPCs at a random waypoint location (if spawnpoint has a grid) instead of the spawnpoint's loc

--- a/zone/zone_save_state.cpp
+++ b/zone/zone_save_state.cpp
@@ -3,6 +3,7 @@
 #include "common/repositories/criteria/content_filter_criteria.h"
 #include "common/repositories/spawn2_repository.h"
 #include "zone/corpse.h"
+#include "zone/expedition_db.h"
 #include "zone/npc.h"
 #include "zone/zone.h"
 
@@ -430,6 +431,7 @@ bool Zone::LoadZoneState(
 	}
 
 	LogInfo("Loading zone state spawns for zone [{}] instance [{}] spawns [{}]", GetShortName(), zone->GetInstanceID(), spawn_states.size());
+	const auto boss_only_filter = ExpeditionDB::GetBossOnlySpawnFilter(GetDynamicZone());
 
 	if (!IsZoneStateValid(spawn_states)) {
 		LogZoneState("Invalid zone state data for zone [{}]", GetShortName());
@@ -487,6 +489,17 @@ bool Zone::LoadZoneState(
 			}
 		}
 
+		const std::unordered_set<uint32_t>* allowed_npc_type_ids = nullptr;
+		if (boss_only_filter.enabled) {
+			const auto allowed_it = boss_only_filter.npc_type_ids_by_spawn2_id.find(s.spawn2_id);
+			if (allowed_it == boss_only_filter.npc_type_ids_by_spawn2_id.end()) {
+				spawn_enabled = false;
+			}
+			else {
+				allowed_npc_type_ids = &allowed_it->second;
+			}
+		}
+
 		// find spawn 2 by id
 		Spawn2Repository::Spawn2 spawn2;
 		for (auto &sp: spawn2s) {
@@ -517,6 +530,10 @@ bool Zone::LoadZoneState(
 			(s.enabled && spawn_enabled),
 			(EmuAppearance) s.anim
 		);
+
+		if (allowed_npc_type_ids) {
+			new_spawn->SetAllowedNPCTypeIDs(*allowed_npc_type_ids);
+		}
 
 		new_spawn->SetStoredLocation(glm::vec4(s.x, s.y, s.z, s.heading));
 
@@ -566,6 +583,17 @@ bool Zone::LoadZoneState(
 				}
 			}
 
+			const std::unordered_set<uint32_t>* allowed_npc_type_ids = nullptr;
+			if (boss_only_filter.enabled) {
+				const auto allowed_it = boss_only_filter.npc_type_ids_by_spawn2_id.find(s.id);
+				if (allowed_it == boss_only_filter.npc_type_ids_by_spawn2_id.end()) {
+					spawn_enabled = false;
+				}
+				else {
+					allowed_npc_type_ids = &allowed_it->second;
+				}
+			}
+
 			LogZoneState("Missing spawn2 [{}] in zone state, this NPC spawn was newly created", s.id);
 			uint32 spawn_time_left = 0;
 			if (spawn_times.count(s.id) != 0) {
@@ -590,6 +618,10 @@ bool Zone::LoadZoneState(
 				spawn_enabled,
 				(EmuAppearance) s.animation
 			);
+
+			if (allowed_npc_type_ids) {
+				new_spawn->SetAllowedNPCTypeIDs(*allowed_npc_type_ids);
+			}
 
 			new_spawn->SetStoredLocation(glm::vec4(s.x, s.y, s.z, s.heading));
 			spawn2_list.Insert(new_spawn);


### PR DESCRIPTION
## Summary
- Add a per-expedition-template `boss_only_spawn` toggle with schema migration and repository/load/save/clone wiring.
- Add `#expedition config bossonly on|off`, `boss_only` alias support, and status/action buttons in the chat config menu.
- Filter expedition spawn2 loading and zone-state restore so boss-only instances only spawn configured boss mappings and exact allowed boss NPC types.

## QA
- Reviewed branch scope against `master`; this PR contains one feature commit and only the boss-only expedition diff.
- Verified DB migration path: fresh schema includes `boss_only_spawn`; existing installs get idempotent content-schema migration `9345`; `CURRENT_BINARY_DATABASE_VERSION` is bumped to `9345`.
- `git diff --check`
- `cmake --build "build/{presetName}" --config Debug --target tests`
- `build/{presetName}/bin/Debug/tests.exe` (103/103 passed)
- `cmake --build "build/{presetName}" --config Debug --target zone`

## Notes
- MSVC emitted existing conversion warnings in unrelated files during the Debug builds; no build errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core zone spawn loading and zone-state restore for expedition instances; misconfiguration could suppress spawns, but behavior is gated by an explicit template flag and defaults off.
> 
> **Overview**
> Adds a per-expedition-template **`boss_only_spawn`** flag (DB migration **9345**, default off) wired through repository load/save/clone and exposed on Lua/Perl template APIs.
> 
> When enabled, **`GetBossOnlySpawnFilter`** builds allowed `spawn2_id` → boss NPC type mappings from template events; **spawn2** loading, **zone state** restore, and **`SpawnGroup::GetNPCType`** then disable unmapped spawn points and restrict picks to those boss types. Template validation requires at least one boss mapping with a concrete **`spawn2_id`**.
> 
> GMs can toggle via **`#expedition set bossonly`** / **`#expedition config bossonly`** (with UI status and quick actions). Schema tests cover the new migration and defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34453a256688f0cae0d8b505ce2a5b12a72c614c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->