### PR TITLE
[Feature] Allow expedition requesters in boss-only spawns

### DIFF
--- a/tests/expedition_schema_test.h
+++ b/tests/expedition_schema_test.h
@@ -115,6 +115,12 @@ private:
 		disabled_request_npc.spawn2_id = 40;
 		template_data.request_npcs.push_back(disabled_request_npc);
 
+		ExpeditionDB::RequestNpc boss_spawn_request_npc;
+		boss_spawn_request_npc.enabled = true;
+		boss_spawn_request_npc.npc_type_id = 500;
+		boss_spawn_request_npc.spawn2_id = 20;
+		template_data.request_npcs.push_back(boss_spawn_request_npc);
+
 		ExpeditionDB::Event event_data;
 		ExpeditionDB::EventNpc trash_npc;
 		trash_npc.role = "trash";
@@ -138,10 +144,12 @@ private:
 		TEST_ASSERT(!filter.AllowsSpawn2(40));
 		TEST_ASSERT(!filter.AllowsSpawn2(50));
 		TEST_ASSERT(filter.unrestricted_spawn2_ids.contains(30));
+		TEST_ASSERT(!filter.unrestricted_spawn2_ids.contains(20));
 
 		const auto* boss_allowed_types = filter.AllowedNPCTypeIDs(20);
 		TEST_ASSERT(boss_allowed_types != nullptr);
 		TEST_ASSERT(boss_allowed_types->contains(200));
+		TEST_ASSERT(boss_allowed_types->contains(500));
 		TEST_ASSERT(!boss_allowed_types->contains(100));
 
 		TEST_ASSERT(filter.AllowedNPCTypeIDs(30) == nullptr);

--- a/tests/expedition_schema_test.h
+++ b/tests/expedition_schema_test.h
@@ -19,6 +19,7 @@ public:
 		TEST_ADD(ExpeditionSchemaTest::BossOnlyMigrationUpdatesExistingTemplates);
 		TEST_ADD(ExpeditionSchemaTest::BinaryDatabaseVersionIncludesExpeditionMigrations);
 		TEST_ADD(ExpeditionSchemaTest::BossOnlyDefaultsAreOff);
+		TEST_ADD(ExpeditionSchemaTest::BossOnlyFilterKeepsRequestersUnrestricted);
 		TEST_ADD(ExpeditionSchemaTest::SimpleBuilderDefaultsAreGroupReady);
 	}
 
@@ -92,6 +93,58 @@ private:
 		ExpeditionDB::BossOnlySpawnFilter filter;
 		TEST_ASSERT(!filter.enabled);
 		TEST_ASSERT(filter.npc_type_ids_by_spawn2_id.empty());
+		TEST_ASSERT(filter.unrestricted_spawn2_ids.empty());
+		TEST_ASSERT(filter.AllowsSpawn2(1));
+		TEST_ASSERT(filter.AllowedNPCTypeIDs(1) == nullptr);
+	}
+
+	void BossOnlyFilterKeepsRequestersUnrestricted()
+	{
+		ExpeditionDB::Template template_data;
+		template_data.boss_only_spawn = true;
+
+		ExpeditionDB::RequestNpc request_npc;
+		request_npc.enabled = true;
+		request_npc.npc_type_id = 300;
+		request_npc.spawn2_id = 30;
+		template_data.request_npcs.push_back(request_npc);
+
+		ExpeditionDB::RequestNpc disabled_request_npc;
+		disabled_request_npc.enabled = false;
+		disabled_request_npc.npc_type_id = 400;
+		disabled_request_npc.spawn2_id = 40;
+		template_data.request_npcs.push_back(disabled_request_npc);
+
+		ExpeditionDB::Event event_data;
+		ExpeditionDB::EventNpc trash_npc;
+		trash_npc.role = "trash";
+		trash_npc.npc_type_id = 100;
+		trash_npc.spawn2_id = 10;
+		event_data.npcs.push_back(trash_npc);
+
+		ExpeditionDB::EventNpc boss_npc;
+		boss_npc.role = "boss";
+		boss_npc.npc_type_id = 200;
+		boss_npc.spawn2_id = 20;
+		event_data.npcs.push_back(boss_npc);
+		template_data.events.push_back(event_data);
+
+		const auto filter = ExpeditionDB::BuildBossOnlySpawnFilter(template_data);
+
+		TEST_ASSERT(filter.enabled);
+		TEST_ASSERT(filter.AllowsSpawn2(20));
+		TEST_ASSERT(filter.AllowsSpawn2(30));
+		TEST_ASSERT(!filter.AllowsSpawn2(10));
+		TEST_ASSERT(!filter.AllowsSpawn2(40));
+		TEST_ASSERT(!filter.AllowsSpawn2(50));
+		TEST_ASSERT(filter.unrestricted_spawn2_ids.contains(30));
+
+		const auto* boss_allowed_types = filter.AllowedNPCTypeIDs(20);
+		TEST_ASSERT(boss_allowed_types != nullptr);
+		TEST_ASSERT(boss_allowed_types->contains(200));
+		TEST_ASSERT(!boss_allowed_types->contains(100));
+
+		TEST_ASSERT(filter.AllowedNPCTypeIDs(30) == nullptr);
 	}
 
 	void SimpleBuilderDefaultsAreGroupReady()

--- a/zone/expedition_db.cpp
+++ b/zone/expedition_db.cpp
@@ -1558,30 +1558,12 @@ bool HandleNpcSpawn(NPC& npc)
 
 BossOnlySpawnFilter GetBossOnlySpawnFilter(DynamicZone* expedition)
 {
-	BossOnlySpawnFilter filter;
 	if (!expedition || !expedition->IsExpedition()) {
-		return filter;
+		return {};
 	}
 
 	const Template* template_data = FindTemplateByDz(*expedition);
-	if (!template_data || !template_data->boss_only_spawn) {
-		return filter;
-	}
-
-	for (const auto& event_data : template_data->events) {
-		for (const auto& event_npc : event_data.npcs) {
-			if (
-				Strings::EqualFold(event_npc.role, "boss") &&
-				event_npc.npc_type_id != 0 &&
-				event_npc.spawn2_id != 0
-			) {
-				filter.npc_type_ids_by_spawn2_id[event_npc.spawn2_id].insert(event_npc.npc_type_id);
-			}
-		}
-	}
-
-	filter.enabled = !filter.npc_type_ids_by_spawn2_id.empty();
-	return filter;
+	return template_data ? BuildBossOnlySpawnFilter(*template_data) : BossOnlySpawnFilter{};
 }
 
 void ApplyRequesterLastName(NPC& npc)

--- a/zone/expedition_db.h
+++ b/zone/expedition_db.h
@@ -141,12 +141,6 @@ inline BossOnlySpawnFilter BuildBossOnlySpawnFilter(const Template& template_dat
 		return filter;
 	}
 
-	for (const auto& request_npc : template_data.request_npcs) {
-		if (request_npc.enabled && request_npc.npc_type_id != 0 && request_npc.spawn2_id != 0) {
-			filter.unrestricted_spawn2_ids.insert(request_npc.spawn2_id);
-		}
-	}
-
 	for (const auto& event_data : template_data.events) {
 		for (const auto& event_npc : event_data.npcs) {
 			if (
@@ -156,6 +150,20 @@ inline BossOnlySpawnFilter BuildBossOnlySpawnFilter(const Template& template_dat
 			) {
 				filter.npc_type_ids_by_spawn2_id[event_npc.spawn2_id].insert(event_npc.npc_type_id);
 			}
+		}
+	}
+
+	for (const auto& request_npc : template_data.request_npcs) {
+		if (!request_npc.enabled || request_npc.npc_type_id == 0 || request_npc.spawn2_id == 0) {
+			continue;
+		}
+
+		auto allowed_it = filter.npc_type_ids_by_spawn2_id.find(request_npc.spawn2_id);
+		if (allowed_it != filter.npc_type_ids_by_spawn2_id.end()) {
+			allowed_it->second.insert(request_npc.npc_type_id);
+		}
+		else {
+			filter.unrestricted_spawn2_ids.insert(request_npc.spawn2_id);
 		}
 	}
 

--- a/zone/expedition_db.h
+++ b/zone/expedition_db.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "common/repositories/dynamic_zone_templates_repository.h"
+#include "common/strings.h"
 
 #include <cstdint>
 #include <optional>
@@ -113,7 +114,54 @@ struct BuilderState {
 struct BossOnlySpawnFilter {
 	bool enabled = false;
 	std::unordered_map<uint32_t, std::unordered_set<uint32_t>> npc_type_ids_by_spawn2_id;
+	std::unordered_set<uint32_t> unrestricted_spawn2_ids;
+
+	bool AllowsSpawn2(uint32_t spawn2_id) const
+	{
+		return !enabled ||
+			unrestricted_spawn2_ids.contains(spawn2_id) ||
+			npc_type_ids_by_spawn2_id.contains(spawn2_id);
+	}
+
+	const std::unordered_set<uint32_t>* AllowedNPCTypeIDs(uint32_t spawn2_id) const
+	{
+		if (!enabled || unrestricted_spawn2_ids.contains(spawn2_id)) {
+			return nullptr;
+		}
+
+		const auto allowed_it = npc_type_ids_by_spawn2_id.find(spawn2_id);
+		return allowed_it != npc_type_ids_by_spawn2_id.end() ? &allowed_it->second : nullptr;
+	}
 };
+
+inline BossOnlySpawnFilter BuildBossOnlySpawnFilter(const Template& template_data)
+{
+	BossOnlySpawnFilter filter;
+	if (!template_data.boss_only_spawn) {
+		return filter;
+	}
+
+	for (const auto& request_npc : template_data.request_npcs) {
+		if (request_npc.enabled && request_npc.npc_type_id != 0 && request_npc.spawn2_id != 0) {
+			filter.unrestricted_spawn2_ids.insert(request_npc.spawn2_id);
+		}
+	}
+
+	for (const auto& event_data : template_data.events) {
+		for (const auto& event_npc : event_data.npcs) {
+			if (
+				Strings::EqualFold(event_npc.role, "boss") &&
+				event_npc.npc_type_id != 0 &&
+				event_npc.spawn2_id != 0
+			) {
+				filter.npc_type_ids_by_spawn2_id[event_npc.spawn2_id].insert(event_npc.npc_type_id);
+			}
+		}
+	}
+
+	filter.enabled = !filter.npc_type_ids_by_spawn2_id.empty();
+	return filter;
+}
 
 uint32_t CreateTemplateFromClient(Database& db, Client& client, const std::string& name);
 uint32_t CloneTemplate(Database& db, uint32_t source_template_id, const std::string& name);

--- a/zone/spawn2.cpp
+++ b/zone/spawn2.cpp
@@ -569,12 +569,11 @@ bool ZoneDatabase::PopulateZoneSpawnList(uint32 zoneid, LinkedList<Spawn2*> &spa
 
 		const std::unordered_set<uint32_t>* allowed_npc_type_ids = nullptr;
 		if (boss_only_filter.enabled) {
-			const auto allowed_it = boss_only_filter.npc_type_ids_by_spawn2_id.find(s.id);
-			if (allowed_it == boss_only_filter.npc_type_ids_by_spawn2_id.end()) {
+			if (!boss_only_filter.AllowsSpawn2(s.id)) {
 				spawn_enabled = false;
 			}
 			else {
-				allowed_npc_type_ids = &allowed_it->second;
+				allowed_npc_type_ids = boss_only_filter.AllowedNPCTypeIDs(s.id);
 			}
 		}
 

--- a/zone/zone_save_state.cpp
+++ b/zone/zone_save_state.cpp
@@ -491,12 +491,11 @@ bool Zone::LoadZoneState(
 
 		const std::unordered_set<uint32_t>* allowed_npc_type_ids = nullptr;
 		if (boss_only_filter.enabled) {
-			const auto allowed_it = boss_only_filter.npc_type_ids_by_spawn2_id.find(s.spawn2_id);
-			if (allowed_it == boss_only_filter.npc_type_ids_by_spawn2_id.end()) {
+			if (!boss_only_filter.AllowsSpawn2(s.spawn2_id)) {
 				spawn_enabled = false;
 			}
 			else {
-				allowed_npc_type_ids = &allowed_it->second;
+				allowed_npc_type_ids = boss_only_filter.AllowedNPCTypeIDs(s.spawn2_id);
 			}
 		}
 
@@ -585,12 +584,11 @@ bool Zone::LoadZoneState(
 
 			const std::unordered_set<uint32_t>* allowed_npc_type_ids = nullptr;
 			if (boss_only_filter.enabled) {
-				const auto allowed_it = boss_only_filter.npc_type_ids_by_spawn2_id.find(s.id);
-				if (allowed_it == boss_only_filter.npc_type_ids_by_spawn2_id.end()) {
+				if (!boss_only_filter.AllowsSpawn2(s.id)) {
 					spawn_enabled = false;
 				}
 				else {
-					allowed_npc_type_ids = &allowed_it->second;
+					allowed_npc_type_ids = boss_only_filter.AllowedNPCTypeIDs(s.id);
 				}
 			}
 


### PR DESCRIPTION
## Summary

Builds on #138 by letting configured expedition requestor NPC spawn points remain active when boss-only spawning is enabled.

- Adds requestor spawn2 IDs to the boss-only spawn filter as unrestricted spawn points.
- Keeps boss spawn points filtered to their configured boss NPC type IDs.
- Applies the shared filter helpers to normal spawn loading and zone-state resume loading.
- Adds coverage for requestors staying allowed while non-boss/non-requestor spawn points remain disabled.

## QA

- Reviewed the diff for spawn filtering behavior and zone-state resume coverage.
- `git diff --check`
- `cmake --build build-codex --target tests --config RelWithDebInfo`
- `./build-codex/bin/RelWithDebInfo/tests.exe` (104/104)
- `cmake --build build-codex --target zone --config RelWithDebInfo`

Note: the local tests executable prints an existing non-fatal reader parse message after reporting 104/104 tests passing and exits 0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes expedition spawn enablement and NPC-type filtering on zone load and zone-state restore; misconfiguration could hide or over-spawn NPCs, though behavior is covered by new unit tests.
> 
> **Overview**
> When **boss-only spawn** is enabled on an expedition template, configured **requester** spawn points can stay active instead of being suppressed with other non-boss spawns.
> 
> **`BuildBossOnlySpawnFilter`** now lives on **`BossOnlySpawnFilter`** in `expedition_db.h`. It still restricts boss **`spawn2`** IDs to mapped boss NPC types, and additionally treats enabled request NPCs as allowed: requesters on a boss **`spawn2`** add their NPC type to that point’s allow-list; requesters on their own **`spawn2`** go into **`unrestricted_spawn2_ids`** (any NPC type). **`GetBossOnlySpawnFilter`** delegates to this builder instead of duplicating logic.
> 
> **`spawn2.cpp`** and **`zone_save_state.cpp`** use **`AllowsSpawn2`** / **`AllowedNPCTypeIDs`** for both normal zone load and resumed zone state. Tests cover default filter behavior and requesters staying unrestricted while trash stays blocked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdf29310336861f1eea75928561a21897dac69cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->