### PR TITLE
[Bug Fix] Fix expedition lockout persistence guardrails

### DIFF
--- a/common/dynamic_zone_base.cpp
+++ b/common/dynamic_zone_base.cpp
@@ -731,12 +731,15 @@ void DynamicZoneBase::AddLockout(const std::string& event, uint32_t seconds)
 
 void DynamicZoneBase::AddLockout(const DzLockout& lockout, bool members_only)
 {
+	if (!CharacterExpeditionLockoutsRepository::InsertLockout(GetDatabase(), GetMemberIds(), lockout))
+	{
+		return;
+	}
+
 	if (!members_only)
 	{
 		DynamicZoneLockoutsRepository::InsertLockouts(GetDatabase(), GetID(), { lockout });
 	}
-
-	CharacterExpeditionLockoutsRepository::InsertLockout(GetDatabase(), GetMemberIds(), lockout);
 
 	HandleLockoutUpdate(lockout, false, members_only);
 	SendServerPacket(CreateLockoutPacket(lockout, false, members_only).get());
@@ -748,7 +751,10 @@ void DynamicZoneBase::AddLockoutDuration(const std::string& event, int seconds, 
 
 	// lockout has unsigned duration, pass original seconds to support reducing existing timers
 	int secs = static_cast<int>(seconds * RuleR(Expedition, LockoutDurationMultiplier));
-	CharacterExpeditionLockoutsRepository::AddLockoutDuration(GetDatabase(), GetMemberIds(), lockout, secs);
+	if (!CharacterExpeditionLockoutsRepository::AddLockoutDuration(GetDatabase(), GetMemberIds(), lockout, secs))
+	{
+		return;
+	}
 
 	HandleLockoutDuration(lockout, seconds, members_only, true);
 	SendServerPacket(CreateLockoutDurationPacket(lockout, seconds, members_only).get());

--- a/common/dynamic_zone_base.cpp
+++ b/common/dynamic_zone_base.cpp
@@ -715,7 +715,7 @@ std::vector<uint32_t> DynamicZoneBase::GetMemberIds()
 
 bool DynamicZoneBase::HasLockout(const std::string& event)
 {
-	return std::ranges::any_of(m_lockouts, [&](const auto& l) { return l.IsEvent(event); });
+	return std::ranges::any_of(m_lockouts, [&](const auto& l) { return l.IsEvent(event) && !l.IsExpired(); });
 }
 
 bool DynamicZoneBase::HasReplayLockout()

--- a/common/repositories/character_expedition_lockouts_repository.h
+++ b/common/repositories/character_expedition_lockouts_repository.h
@@ -123,7 +123,7 @@ public:
 			fmt::join(names, "','"), Strings::Escape(expedition), Strings::Escape(event)));
 	}
 
-	static void InsertLockouts(Database& db, uint32_t char_id, const std::vector<DzLockout>& lockouts)
+	static bool InsertLockouts(Database& db, uint32_t char_id, const std::vector<DzLockout>& lockouts)
 	{
 		std::string insert_values;
 		for (const auto& lockout : lockouts)
@@ -153,11 +153,18 @@ public:
 					duration = VALUES(duration);
 			), insert_values);
 
-			db.QueryDatabase(query);
+			auto results = db.QueryDatabase(query);
+			if (!results.Success())
+			{
+				LogWarning("Failed to persist character expedition lockout(s): {}", results.ErrorMessage());
+				return false;
+			}
 		}
+
+		return true;
 	}
 
-	static void InsertLockout(Database& db, const std::vector<uint32_t>& char_ids, const DzLockout& lockout)
+	static bool InsertLockout(Database& db, const std::vector<uint32_t>& char_ids, const DzLockout& lockout)
 	{
 		std::string insert_values;
 		for (const auto& char_id : char_ids)
@@ -187,12 +194,19 @@ public:
 					duration = VALUES(duration);
 			), insert_values);
 
-			db.QueryDatabase(query);
+			auto results = db.QueryDatabase(query);
+			if (!results.Success())
+			{
+				LogWarning("Failed to persist character expedition lockout(s): {}", results.ErrorMessage());
+				return false;
+			}
 		}
+
+		return true;
 	}
 
 	// inserts a new lockout or updates existing lockout with seconds added to current time
-	static void AddLockoutDuration(Database& db, const std::vector<uint32_t>& char_ids, const DzLockout& lockout, int seconds)
+	static bool AddLockoutDuration(Database& db, const std::vector<uint32_t>& char_ids, const DzLockout& lockout, int seconds)
 	{
 		std::string insert_values;
 		for (const auto& char_id : char_ids)
@@ -222,8 +236,15 @@ public:
 					duration = GREATEST(0, CAST(duration AS SIGNED) + {1});
 			), insert_values, seconds);
 
-			db.QueryDatabase(query);
+			auto results = db.QueryDatabase(query);
+			if (!results.Success())
+			{
+				LogWarning("Failed to adjust character expedition lockout duration(s): {}", results.ErrorMessage());
+				return false;
+			}
 		}
+
+		return true;
 	}
 
 };

--- a/tests/expedition_schema_test.h
+++ b/tests/expedition_schema_test.h
@@ -19,6 +19,8 @@ public:
 		TEST_ADD(ExpeditionSchemaTest::BossOnlyMigrationUpdatesExistingTemplates);
 		TEST_ADD(ExpeditionSchemaTest::BinaryDatabaseVersionIncludesExpeditionMigrations);
 		TEST_ADD(ExpeditionSchemaTest::BossOnlyDefaultsAreOff);
+		TEST_ADD(ExpeditionSchemaTest::BossEventNpcRemovalDeletesEvent);
+		TEST_ADD(ExpeditionSchemaTest::LockoutNamespaceUsesDynamicZoneName);
 		TEST_ADD(ExpeditionSchemaTest::BossOnlyFilterKeepsRequestersUnrestricted);
 		TEST_ADD(ExpeditionSchemaTest::SimpleBuilderDefaultsAreGroupReady);
 	}
@@ -96,6 +98,49 @@ private:
 		TEST_ASSERT(filter.unrestricted_spawn2_ids.empty());
 		TEST_ASSERT(filter.AllowsSpawn2(1));
 		TEST_ASSERT(filter.AllowedNPCTypeIDs(1) == nullptr);
+	}
+
+	void BossEventNpcRemovalDeletesEvent()
+	{
+		ExpeditionDB::EventNpc boss_npc;
+		boss_npc.role = "boss";
+		TEST_ASSERT(ExpeditionDB::EventNpcRemovalDeletesEvent(boss_npc));
+
+		ExpeditionDB::EventNpc mixed_case_boss_npc;
+		mixed_case_boss_npc.role = "Boss";
+		TEST_ASSERT(ExpeditionDB::EventNpcRemovalDeletesEvent(mixed_case_boss_npc));
+
+		ExpeditionDB::EventNpc add_npc;
+		add_npc.role = "add";
+		TEST_ASSERT(!ExpeditionDB::EventNpcRemovalDeletesEvent(add_npc));
+
+		ExpeditionDB::EventNpc chest_npc;
+		chest_npc.role = "chest";
+		TEST_ASSERT(!ExpeditionDB::EventNpcRemovalDeletesEvent(chest_npc));
+	}
+
+	void LockoutNamespaceUsesDynamicZoneName()
+	{
+		ExpeditionDB::Template first_template;
+		first_template.name = "Catalog A";
+		first_template.dz_template.name = "Shared Expedition";
+		first_template.dz_template.zone_id = 1;
+		first_template.dz_template.zone_version = 0;
+
+		ExpeditionDB::Template second_template;
+		second_template.name = "Catalog B";
+		second_template.dz_template.name = "shared expedition";
+		second_template.dz_template.zone_id = 2;
+		second_template.dz_template.zone_version = 0;
+
+		ExpeditionDB::Template unique_template;
+		unique_template.name = "Catalog C";
+		unique_template.dz_template.name = "Different Expedition";
+		unique_template.dz_template.zone_id = first_template.dz_template.zone_id;
+		unique_template.dz_template.zone_version = first_template.dz_template.zone_version;
+
+		TEST_ASSERT(ExpeditionDB::SharesExpeditionLockoutNamespace(first_template, second_template));
+		TEST_ASSERT(!ExpeditionDB::SharesExpeditionLockoutNamespace(first_template, unique_template));
 	}
 
 	void BossOnlyFilterKeepsRequestersUnrestricted()

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -10186,7 +10186,32 @@ void Client::SendDynamicZoneUpdates()
 	SendDzCompassUpdate();
 	SetDynamicZoneMemberStatus(DynamicZoneMemberStatus::Online);
 
+	const auto previous_lockouts = m_dz_lockouts;
 	m_dz_lockouts = CharacterExpeditionLockoutsRepository::GetLockouts(database, CharacterID());
+
+	for (const auto& previous : previous_lockouts)
+	{
+		if (previous.IsExpired())
+		{
+			continue;
+		}
+
+		const auto reloaded = std::ranges::find_if(m_dz_lockouts, [&](const DzLockout& lockout) {
+			return lockout.IsSame(previous);
+		});
+
+		if (reloaded == m_dz_lockouts.end())
+		{
+			LogDynamicZones(
+				"Character [{}] had an unexpired expedition lockout [{}] [{}] uuid [{}] with [{}] seconds remaining before DB refresh, but it was not reloaded",
+				CharacterID(),
+				previous.DzName(),
+				previous.Event(),
+				previous.UUID(),
+				previous.GetSecondsRemaining()
+			);
+		}
+	}
 
 	// expeditions are the only dz type that keep the window updated
 	if (DynamicZone* dz = GetExpedition())
@@ -10299,16 +10324,15 @@ uint32_t Client::GetExpeditionID() const
 void Client::AddDzLockout(const DzLockout& lockout, bool update_db)
 {
 	// todo: support for account based lockouts like live AoC expeditions
+	if (update_db && !CharacterExpeditionLockoutsRepository::InsertLockouts(database, CharacterID(), { lockout }))
+	{
+		return;
+	}
 
 	// if client already has this lockout, we're replacing it with the new one
 	std::erase_if(m_dz_lockouts, [&](const DzLockout& l) { return l.IsSame(lockout); });
 
 	m_dz_lockouts.push_back(lockout);
-
-	if (update_db) // for quest api
-	{
-		CharacterExpeditionLockoutsRepository::InsertLockouts(database, CharacterID(), { lockout });
-	}
 
 	SendDzLockoutTimers();
 }
@@ -10324,18 +10348,20 @@ void Client::AddDzLockoutDuration(const DzLockout& lockout, int seconds, const s
 	auto it = std::ranges::find_if(m_dz_lockouts, [&](const DzLockout& l) { return l.IsSame(lockout); });
 	if (it != m_dz_lockouts.end())
 	{
-		it->AddLockoutTime(seconds);
+		DzLockout updated_lockout = *it;
+		updated_lockout.AddLockoutTime(seconds);
 
 		if (!uuid.empty())
 		{
-			it->SetUUID(uuid);
+			updated_lockout.SetUUID(uuid);
 		}
 
-		if (update_db)
+		if (update_db && !CharacterExpeditionLockoutsRepository::InsertLockouts(database, CharacterID(), { updated_lockout }))
 		{
-			CharacterExpeditionLockoutsRepository::InsertLockouts(database, CharacterID(), { *it });
+			return;
 		}
 
+		*it = updated_lockout;
 		SendDzLockoutTimers();
 	}
 	else if (seconds > 0) // missing lockouts inserted for reductions would be instantly expired

--- a/zone/dynamic_zone.cpp
+++ b/zone/dynamic_zone.cpp
@@ -1449,8 +1449,10 @@ void DynamicZone::AddCharacterLockout(
 	if (char_id)
 	{
 		auto lockout = DzLockout::Create(expedition, event, seconds, uuid);
-		CharacterExpeditionLockoutsRepository::InsertLockouts(database, char_id, { lockout });
-		SendWorldCharacterLockout(char_id, lockout, false);
+		if (CharacterExpeditionLockoutsRepository::InsertLockouts(database, char_id, { lockout }))
+		{
+			SendWorldCharacterLockout(char_id, lockout, false);
+		}
 	}
 }
 
@@ -1533,15 +1535,19 @@ std::vector<DzLockout> DynamicZone::GetCharacterLockouts(uint32_t char_id)
 void DynamicZone::AddClientsLockout(const DzLockout& lockout)
 {
 	std::vector<uint32_t> char_ids;
+	std::vector<Client*> clients;
 	for (const auto& it : entity_list.GetClientList())
 	{
 		char_ids.push_back(it.second->CharacterID());
-		it.second->AddDzLockout(lockout);
+		clients.push_back(it.second);
 	}
 
-	if (!char_ids.empty())
+	if (!char_ids.empty() && CharacterExpeditionLockoutsRepository::InsertLockout(database, char_ids, lockout))
 	{
-		CharacterExpeditionLockoutsRepository::InsertLockout(database, char_ids, lockout);
+		for (Client* client : clients)
+		{
+			client->AddDzLockout(lockout);
+		}
 	}
 }
 
@@ -1550,6 +1556,7 @@ void DynamicZone::HandleLockoutUpdate(const DzLockout& lockout, bool remove, boo
 	DynamicZoneBase::HandleLockoutUpdate(lockout, remove, members_only);
 
 	std::vector<uint32_t> char_ids;
+	std::vector<Client*> non_member_clients;
 	for (const auto& it : entity_list.GetClientList())
 	{
 		Client* client = it.second;
@@ -1569,13 +1576,16 @@ void DynamicZone::HandleLockoutUpdate(const DzLockout& lockout, bool remove, boo
 			// all clients inside the dz instance receive added lockouts to avoid exploits
 			// where members quit the expedition but haven't been kicked from zone yet
 			char_ids.push_back(client->CharacterID());
-			client->AddDzLockout(lockout);
+			non_member_clients.push_back(client);
 		}
 	}
 
-	if (!char_ids.empty())
+	if (!char_ids.empty() && CharacterExpeditionLockoutsRepository::InsertLockout(database, char_ids, lockout))
 	{
-		CharacterExpeditionLockoutsRepository::InsertLockout(database, char_ids, lockout);
+		for (Client* client : non_member_clients)
+		{
+			client->AddDzLockout(lockout);
+		}
 	}
 }
 
@@ -1584,6 +1594,7 @@ void DynamicZone::HandleLockoutDuration(const DzLockout& lockout, int seconds, b
 	DynamicZoneBase::HandleLockoutDuration(lockout, seconds, members_only, insert_db);
 
 	std::vector<uint32_t> char_ids;
+	std::vector<Client*> non_member_clients;
 	for (const auto& it : entity_list.GetClientList())
 	{
 		Client* client = it.second;
@@ -1594,14 +1605,20 @@ void DynamicZone::HandleLockoutDuration(const DzLockout& lockout, int seconds, b
 		else if (IsCurrentZoneDz()) // non-member client inside the dz
 		{
 			char_ids.push_back(client->CharacterID());
-			client->AddDzLockoutDuration(lockout, seconds, m_uuid);
+			non_member_clients.push_back(client);
 		}
 	}
 
 	if (!char_ids.empty()) // always update db for non-members in dz (call may be from another zone)
 	{
 		int secs = static_cast<int>(seconds * RuleR(Expedition, LockoutDurationMultiplier));
-		CharacterExpeditionLockoutsRepository::AddLockoutDuration(database, char_ids, lockout, secs);
+		if (CharacterExpeditionLockoutsRepository::AddLockoutDuration(database, char_ids, lockout, secs))
+		{
+			for (Client* client : non_member_clients)
+			{
+				client->AddDzLockoutDuration(lockout, seconds, m_uuid);
+			}
+		}
 	}
 }
 

--- a/zone/expedition_db.cpp
+++ b/zone/expedition_db.cpp
@@ -568,8 +568,8 @@ namespace {
 		// but should not shorten it.
 		const DzLockout proposed = DzLockout::Create(expedition.GetName(), DzLockout::ReplayTimer, seconds, expedition.GetUUID());
 		const auto& lockouts = expedition.GetLockouts();
-		const auto replay_timer = std::ranges::find_if(lockouts, [](const DzLockout& lockout) {
-			return lockout.IsReplay();
+		const auto replay_timer = std::ranges::find_if(lockouts, [&](const DzLockout& lockout) {
+			return lockout.IsReplay() && lockout.IsUUID(expedition.GetUUID());
 		});
 
 		if (replay_timer != lockouts.end() && replay_timer->GetExpireTime() >= proposed.GetExpireTime()) {
@@ -577,6 +577,14 @@ namespace {
 		}
 
 		expedition.AddLockout(DzLockout::ReplayTimer, seconds);
+	}
+
+	bool HasCurrentExpeditionLockout(DynamicZone& expedition, const std::string& event_name)
+	{
+		const auto& lockouts = expedition.GetLockouts();
+		return std::ranges::any_of(lockouts, [&](const DzLockout& lockout) {
+			return lockout.IsEvent(event_name) && lockout.IsUUID(expedition.GetUUID()) && !lockout.IsExpired();
+		});
 	}
 
 	void ExecuteActions(DynamicZone& expedition, const Event& event_data, const std::string& runtime_event_name)
@@ -619,7 +627,7 @@ namespace {
 	bool CompleteEventForNpc(DynamicZone& expedition, const Event& event_data, const EventNpc& event_npc, Client* notifier)
 	{
 		const std::string runtime_event_name = RuntimeEventName(event_data, event_npc);
-		if (expedition.HasLockout(runtime_event_name) || !TryMarkRuntimeEventComplete(expedition, runtime_event_name)) {
+		if (HasCurrentExpeditionLockout(expedition, runtime_event_name) || !TryMarkRuntimeEventComplete(expedition, runtime_event_name)) {
 			return false;
 		}
 
@@ -1062,7 +1070,29 @@ bool SetEventNpcCompleteOnSpawn(Database& db, uint32_t event_id, uint32_t npc_ty
 
 bool DeleteEventNpc(Database& db, uint32_t event_id, uint32_t npc_type_id, uint32_t spawn2_id)
 {
-	const bool ok = ExpeditionRepository::DeleteEventNpc(db, event_id, npc_type_id, spawn2_id);
+	bool delete_event = false;
+	auto results = db.QueryDatabase(fmt::format(
+		"SELECT role FROM expedition_template_event_npcs WHERE event_id = {} AND npc_type_id = {} AND spawn2_id = {}",
+		event_id,
+		npc_type_id,
+		spawn2_id
+	));
+	if (!results.Success()) {
+		return false;
+	}
+
+	for (auto row = results.begin(); row != results.end(); ++row) {
+		EventNpc event_npc;
+		event_npc.role = row[0] ? row[0] : "";
+		if (EventNpcRemovalDeletesEvent(event_npc)) {
+			delete_event = true;
+			break;
+		}
+	}
+
+	const bool ok = delete_event ?
+		ExpeditionRepository::DeleteEvent(db, event_id) :
+		ExpeditionRepository::DeleteEventNpc(db, event_id, npc_type_id, spawn2_id);
 	Reload(db);
 	return ok;
 }
@@ -1278,23 +1308,45 @@ ValidationResult ValidateTemplate(const Template& template_data)
 		if (
 			other_id != template_data.id &&
 			other_template.enabled &&
-			other_template.dz_template.zone_id == template_data.dz_template.zone_id &&
-			other_template.dz_template.zone_version == template_data.dz_template.zone_version &&
-			Strings::EqualFold(other_template.dz_template.name, template_data.dz_template.name)
+			SharesExpeditionLockoutNamespace(template_data, other_template)
 		) {
-			const auto message = fmt::format(
-				"Another enabled DB expedition template [{}] shares this dynamic-zone name and zone/version; runtime hooks may attach to the wrong template.",
-				other_template.name
-			);
-			if (template_data.enabled) {
-				result.errors.push_back(message);
+			if (
+				other_template.dz_template.zone_id == template_data.dz_template.zone_id &&
+				other_template.dz_template.zone_version == template_data.dz_template.zone_version
+			) {
+				result.errors.push_back(fmt::format(
+					"Another enabled DB expedition template [{}] shares this dynamic-zone name and zone/version; runtime hooks may attach to the wrong template and lockout timers can overwrite each other.",
+					other_template.name
+				));
 			}
 			else {
-				result.warnings.push_back(message);
+				result.errors.push_back(fmt::format(
+					"Another enabled DB expedition template [{}] shares dynamic-zone name [{}]; character expedition lockouts are keyed by expedition name and event name, so timers can overwrite each other.",
+					other_template.name,
+					template_data.dz_template.name
+				));
 			}
 		}
 	}
 
+	std::unordered_map<std::string, size_t> event_lockout_names;
+	std::unordered_set<std::string> duplicate_event_lockout_names;
+	auto remember_event_lockout_name = [&](size_t event_index, const std::string& event_name) {
+		if (event_name.empty()) {
+			return;
+		}
+
+		const std::string key = Strings::ToLower(event_name);
+		auto [it, inserted] = event_lockout_names.try_emplace(key, event_index);
+		if (!inserted && it->second != event_index && duplicate_event_lockout_names.insert(key).second) {
+			result.errors.push_back(fmt::format(
+				"Event lockout name [{}] is produced by multiple events; expedition timers are keyed by event name and would overwrite each other.",
+				event_name
+			));
+		}
+	};
+
+	size_t event_index = 0;
 	for (const auto& event_data : template_data.events) {
 		if (event_data.event_name.empty()) {
 			result.errors.push_back("Event is missing a name.");
@@ -1325,6 +1377,22 @@ ValidationResult ValidateTemplate(const Template& template_data)
 				result.warnings.push_back(fmt::format("Event NPC [{}] already has a death quest script; verify DB event actions do not duplicate scripted behavior.", NpcTypeLabel(event_npc.npc_type_id)));
 			}
 		}
+
+		std::unordered_set<std::string> runtime_names;
+		for (const auto& event_npc : event_data.npcs) {
+			if (event_npc.complete_on_death || event_npc.complete_on_spawn) {
+				runtime_names.insert(RuntimeEventName(event_data, event_npc));
+			}
+		}
+
+		if (runtime_names.empty()) {
+			runtime_names.insert(event_data.event_name);
+		}
+
+		for (const auto& runtime_name : runtime_names) {
+			remember_event_lockout_name(event_index, runtime_name);
+		}
+		++event_index;
 	}
 
 	for (const auto& event_data : template_data.events) {
@@ -1782,7 +1850,7 @@ void MaybeShowGmTargetMenu(Client& client, NPC& npc)
 				SendManageRow(client, {
 					{fmt::format("#expedition event loot {}", loot_protected ? "off" : "on"), loot_protected ? "Loot Protection: Off" : "Loot Protection: On"},
 					{"#expedition event lockout", "Set Lockout..."},
-					{"#expedition event npc remove confirm", "Remove from Expedition"}
+					{"#expedition event npc remove confirm", EventNpcRemovalDeletesEvent(event_npc) ? "Remove Boss/Event" : "Remove from Expedition"}
 				});
 				SendManageRow(client, {
 					{fmt::format("#expedition event completeondeath {}", event_npc.complete_on_death ? "off" : "on"), event_npc.complete_on_death ? "Death Trigger Off" : "Death Trigger On"},

--- a/zone/expedition_db.h
+++ b/zone/expedition_db.h
@@ -72,6 +72,16 @@ struct Event {
 	std::vector<Action> actions;
 };
 
+inline bool IsBossEventNpc(const EventNpc& event_npc)
+{
+	return Strings::EqualFold(event_npc.role, "boss");
+}
+
+inline bool EventNpcRemovalDeletesEvent(const EventNpc& event_npc)
+{
+	return IsBossEventNpc(event_npc);
+}
+
 struct Template {
 	uint32_t id = 0;
 	uint32_t dz_template_id = 0;
@@ -89,6 +99,11 @@ struct Template {
 	std::vector<RequestNpc> request_npcs;
 	std::vector<Event> events;
 };
+
+inline bool SharesExpeditionLockoutNamespace(const Template& lhs, const Template& rhs)
+{
+	return Strings::EqualFold(lhs.dz_template.name, rhs.dz_template.name);
+}
 
 struct ValidationResult {
 	enum class Status {
@@ -144,7 +159,7 @@ inline BossOnlySpawnFilter BuildBossOnlySpawnFilter(const Template& template_dat
 	for (const auto& event_data : template_data.events) {
 		for (const auto& event_npc : event_data.npcs) {
 			if (
-				Strings::EqualFold(event_npc.role, "boss") &&
+				IsBossEventNpc(event_npc) &&
 				event_npc.npc_type_id != 0 &&
 				event_npc.spawn2_id != 0
 			) {

--- a/zone/gm_commands/expedition.cpp
+++ b/zone/gm_commands/expedition.cpp
@@ -3424,11 +3424,21 @@ void HandleEvent(Client* c, const Seperator* sep)
 						c->Message(Chat::Yellow, "Target is not mapped to the selected event.");
 						return;
 					}
+					const bool removes_event = ExpeditionDB::EventNpcRemovalDeletesEvent(*mapped_npc);
 					if (!ExpeditionDB::DeleteEventNpc(content_db, selected_event_id, mapped_npc->npc_type_id, mapped_npc->spawn2_id)) {
 						c->Message(Chat::Red, fmt::format("Failed to remove target NPC mapping for event [{}].", selected_event_name).c_str());
 						return;
 					}
-					c->Message(Chat::Green, fmt::format("Saved: removed target NPC mapping from event [{}].", selected_event_name).c_str());
+					if (removes_event) {
+						if (const auto* refreshed_template = SelectedTemplate(c)) {
+							const uint32_t next_event_id = refreshed_template->events.empty() ? 0 : refreshed_template->events.front().id;
+							ExpeditionDB::SetSelectedEvent(c->CharacterID(), next_event_id);
+						}
+						c->Message(Chat::Green, fmt::format("Saved: removed boss [{}] and event [{}].", NpcLabel(*npc), selected_event_name).c_str());
+					}
+					else {
+						c->Message(Chat::Green, fmt::format("Saved: removed target NPC mapping from event [{}].", selected_event_name).c_str());
+					}
 					RefreshBuilderView(c);
 					return;
 				}


### PR DESCRIPTION
## Summary

Fixes DB-centric expedition cleanup and hardens expedition lockout persistence.

- Removing a boss mapping from a DB expedition now removes the associated expedition event, its NPC mappings, and actions instead of leaving an orphaned event.
- DB-driven event completion now ignores stale carried-over lockouts from previous expedition UUIDs when deciding whether the current expedition event is already complete.
- Expedition template validation now guards against lockout namespace collisions caused by duplicate dynamic-zone names and duplicate runtime event timer names.
- Character expedition lockout writes now report success/failure, log persistence errors, and avoid showing client/world timers when the backing row failed to save.
- Client timer refresh now logs when an unexpired visible timer disappears during reload from `character_expedition_lockouts`.
- Expired dynamic-zone lockouts no longer count as active in `HasLockout`.

## Root Cause

Character expedition timers persist by `character_id + expedition_name + event_name`. Correctly assigned in-memory timers can disappear later if the DB row was never written, was overwritten by a namespace collision, or if the client cache is rebuilt from DB and the row is missing. The previous write paths also did not surface persistence failures clearly.

## Validation

- `cmake --build build-codex --config RelWithDebInfo --target tests zone --parallel 8`
- `./build-codex/bin/RelWithDebInfo/tests.exe`

Tests passed with `106 tests, 100% correct`. The test binary still emits the existing JSON reader warning after the success summary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes expedition timer persistence, completion gating, and template validation—player-facing progression and data integrity paths, though guarded by explicit DB success checks.
> 
> **Overview**
> Hardens **expedition lockout** behavior so in-memory timers and world/client updates only apply after successful `character_expedition_lockouts` writes, with repository methods returning **bool** and logging failures.
> 
> **Runtime fixes:** `HasLockout` ignores expired entries; DB event completion uses **current expedition UUID** (and non-expired) lockouts so stale timers do not block progress; replay lockout extension is scoped to the active UUID.
> 
> **Authoring/cleanup:** Removing a **boss** NPC mapping deletes the whole expedition event (not an orphan); template validation flags shared **dynamic-zone names** and duplicate **runtime event lockout names** that would overwrite timers; client reload logs when a visible unexpired timer vanishes after DB refresh.
> 
> **Tests** cover boss-removal semantics and lockout namespace sharing by DZ name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db0aa589fd5b82b90cefb4856ade92364221efef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->