### PR TITLE
Fix low-risk expedition lifecycle issues

### DIFF
--- a/common/repositories/character_expedition_lockouts_repository.h
+++ b/common/repositories/character_expedition_lockouts_repository.h
@@ -118,9 +118,16 @@ public:
 			return {};
 		}
 
+		std::vector<std::string> escaped_names;
+		escaped_names.reserve(names.size());
+		for (const auto& name : names)
+		{
+			escaped_names.emplace_back(Strings::Escape(name));
+		}
+
 		return GetWhere(db, fmt::format(
 			"character_id IN (select id from character_data where name IN ('{}')) AND expire_time > NOW() AND expedition_name = '{}' AND event_name = '{}' LIMIT 1",
-			fmt::join(names, "','"), Strings::Escape(expedition), Strings::Escape(event)));
+			fmt::join(escaped_names, "','"), Strings::Escape(expedition), Strings::Escape(event)));
 	}
 
 	static bool InsertLockouts(Database& db, uint32_t char_id, const std::vector<DzLockout>& lockouts)

--- a/common/repositories/dynamic_zones_repository.h
+++ b/common/repositories/dynamic_zones_repository.h
@@ -392,6 +392,13 @@ public:
 		std::vector<CharacterDz> entries;
 		entries.reserve(names.size());
 
+		std::vector<std::string> escaped_names;
+		escaped_names.reserve(names.size());
+		for (const auto& name : names)
+		{
+			escaped_names.emplace_back(Strings::Escape(name));
+		}
+
 		auto results = db.QueryDatabase(fmt::format(SQL(
 			SELECT
 				character_data.id,
@@ -408,7 +415,7 @@ public:
 			ORDER BY FIELD(character_data.name, '{1}')
 		),
 			type,
-			fmt::join(names, "','")
+			fmt::join(escaped_names, "','")
 		));
 
 		if (results.Success())

--- a/world/dynamic_zone.cpp
+++ b/world/dynamic_zone.cpp
@@ -83,21 +83,28 @@ void DynamicZone::CheckLeader()
 DynamicZoneStatus DynamicZone::Process()
 {
 	DynamicZoneStatus status = DynamicZoneStatus::Normal;
+	bool has_members = HasMembers();
+	bool is_expired = IsExpired();
 
 	// force expire if no members
-	if (!HasMembers() || IsExpired())
+	if (!has_members || is_expired)
 	{
 		status = DynamicZoneStatus::Expired;
 
 		auto dz_zoneserver = ZSList::Instance()->FindByInstanceID(GetInstanceID());
 		if (!dz_zoneserver || dz_zoneserver->NumPlayers() == 0) // no clients inside dz
 		{
-			status = DynamicZoneStatus::ExpiredEmpty;
-
-			if (!HasMembers() && !m_is_pending_early_shutdown && RuleB(DynamicZone, EmptyShutdownEnabled))
+			if (!has_members && !is_expired && RuleB(DynamicZone, EmptyShutdownEnabled))
 			{
-				SetSecondsRemaining(RuleI(DynamicZone, EmptyShutdownDelaySeconds));
-				m_is_pending_early_shutdown = true;
+				if (!m_is_pending_early_shutdown)
+				{
+					SetSecondsRemaining(RuleI(DynamicZone, EmptyShutdownDelaySeconds));
+					m_is_pending_early_shutdown = true;
+				}
+			}
+			else
+			{
+				status = DynamicZoneStatus::ExpiredEmpty;
 			}
 		}
 	}

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -10678,12 +10678,15 @@ void Client::SetDynamicZoneMemberStatus(DynamicZoneMemberStatus status)
 	// inside a dz, only that dz has the "In Dynamic Zone" status set
 	for (auto& dz : GetDynamicZones())
 	{
+		auto dz_status = status;
+
 		// the rule to disable this status is handled internally by the dz
-		if (status == DynamicZoneMemberStatus::Online && dz->IsCurrentZoneDz())
+		if (dz_status == DynamicZoneMemberStatus::Online && dz->IsCurrentZoneDz())
 		{
-			status = DynamicZoneMemberStatus::InDynamicZone;
+			dz_status = DynamicZoneMemberStatus::InDynamicZone;
 		}
-		dz->SetMemberStatus(CharacterID(), status);
+
+		dz->SetMemberStatus(CharacterID(), dz_status);
 	}
 }
 

--- a/zone/expedition_db.cpp
+++ b/zone/expedition_db.cpp
@@ -1113,8 +1113,33 @@ bool ClearActions(Database& db, uint32_t event_id)
 
 void Reload(Database& db)
 {
+	auto template_rows = ExpeditionRepository::LoadAllTemplates(db);
+	if (!template_rows) {
+		return;
+	}
+
+	auto request_npc_rows = ExpeditionRepository::LoadAllRequestNpcs(db);
+	if (!request_npc_rows) {
+		return;
+	}
+
+	auto event_rows = ExpeditionRepository::LoadAllEvents(db);
+	if (!event_rows) {
+		return;
+	}
+
+	auto event_npc_rows = ExpeditionRepository::LoadAllEventNpcs(db);
+	if (!event_npc_rows) {
+		return;
+	}
+
+	auto action_rows = ExpeditionRepository::LoadAllActions(db);
+	if (!action_rows) {
+		return;
+	}
+
 	std::unordered_map<uint32_t, Template> templates;
-	for (auto& template_data : ExpeditionRepository::LoadAllTemplates(db)) {
+	for (auto& template_data : *template_rows) {
 		template_data.request_phrase = NormalizePhrase(template_data.request_phrase);
 		template_data.request_mode = IsKnownRequestMode(template_data.request_mode) ?
 			NormalizeRequestMode(template_data.request_mode) : template_data.request_mode;
@@ -1123,7 +1148,7 @@ void Reload(Database& db)
 		templates[id] = std::move(template_data);
 	}
 
-	for (auto& request_npc : ExpeditionRepository::LoadAllRequestNpcs(db)) {
+	for (auto& request_npc : *request_npc_rows) {
 		request_npc.phrase = NormalizePhrase(request_npc.phrase);
 		auto it = templates.find(request_npc.expedition_template_id);
 		if (it != templates.end()) {
@@ -1131,14 +1156,14 @@ void Reload(Database& db)
 		}
 	}
 
-	for (auto event_data : ExpeditionRepository::LoadAllEvents(db)) {
+	for (auto event_data : *event_rows) {
 		auto it = templates.find(event_data.expedition_template_id);
 		if (it != templates.end()) {
 			it->second.events.push_back(event_data);
 		}
 	}
 
-	for (const auto& event_npc : ExpeditionRepository::LoadAllEventNpcs(db)) {
+	for (const auto& event_npc : *event_npc_rows) {
 		for (auto& [id, template_data] : templates) {
 			auto event_it = std::ranges::find_if(template_data.events, [&](const Event& event_data) {
 				return event_data.id == event_npc.event_id;
@@ -1151,7 +1176,7 @@ void Reload(Database& db)
 		}
 	}
 
-	for (const auto& action : ExpeditionRepository::LoadAllActions(db)) {
+	for (const auto& action : *action_rows) {
 		for (auto& [id, template_data] : templates) {
 			auto event_it = std::ranges::find_if(template_data.events, [&](const Event& event_data) {
 				return event_data.id == action.event_id;

--- a/zone/expedition_repository.cpp
+++ b/zone/expedition_repository.cpp
@@ -1,6 +1,7 @@
 #include "zone/expedition_repository.h"
 
 #include "common/database.h"
+#include "common/eqemu_logsys.h"
 #include "common/strings.h"
 
 #include <fmt/format.h>
@@ -55,7 +56,7 @@ namespace {
 // LOAD OPERATIONS
 // ============================================================================
 
-std::vector<ExpeditionDB::Template> LoadAllTemplates(Database& db)
+std::optional<std::vector<ExpeditionDB::Template>> LoadAllTemplates(Database& db)
 {
 	std::vector<ExpeditionDB::Template> out;
 	auto results = db.QueryDatabase(
@@ -64,7 +65,8 @@ std::vector<ExpeditionDB::Template> LoadAllTemplates(Database& db)
 	);
 
 	if (!results.Success()) {
-		return out;
+		LogWarning("Failed to load expedition_templates: {}", results.ErrorMessage());
+		return std::nullopt;
 	}
 
 	for (auto row = results.begin(); row != results.end(); ++row) {
@@ -87,7 +89,7 @@ std::vector<ExpeditionDB::Template> LoadAllTemplates(Database& db)
 	return out;
 }
 
-std::vector<ExpeditionDB::RequestNpc> LoadAllRequestNpcs(Database& db)
+std::optional<std::vector<ExpeditionDB::RequestNpc>> LoadAllRequestNpcs(Database& db)
 {
 	std::vector<ExpeditionDB::RequestNpc> out;
 	auto results = db.QueryDatabase(
@@ -96,7 +98,8 @@ std::vector<ExpeditionDB::RequestNpc> LoadAllRequestNpcs(Database& db)
 	);
 
 	if (!results.Success()) {
-		return out;
+		LogWarning("Failed to load expedition_template_request_npcs: {}", results.ErrorMessage());
+		return std::nullopt;
 	}
 
 	for (auto row = results.begin(); row != results.end(); ++row) {
@@ -115,7 +118,7 @@ std::vector<ExpeditionDB::RequestNpc> LoadAllRequestNpcs(Database& db)
 	return out;
 }
 
-std::vector<ExpeditionDB::Event> LoadAllEvents(Database& db)
+std::optional<std::vector<ExpeditionDB::Event>> LoadAllEvents(Database& db)
 {
 	std::vector<ExpeditionDB::Event> out;
 	auto results = db.QueryDatabase(
@@ -125,7 +128,8 @@ std::vector<ExpeditionDB::Event> LoadAllEvents(Database& db)
 	);
 
 	if (!results.Success()) {
-		return out;
+		LogWarning("Failed to load expedition_template_events: {}", results.ErrorMessage());
+		return std::nullopt;
 	}
 
 	for (auto row = results.begin(); row != results.end(); ++row) {
@@ -145,7 +149,7 @@ std::vector<ExpeditionDB::Event> LoadAllEvents(Database& db)
 	return out;
 }
 
-std::vector<ExpeditionDB::EventNpc> LoadAllEventNpcs(Database& db)
+std::optional<std::vector<ExpeditionDB::EventNpc>> LoadAllEventNpcs(Database& db)
 {
 	std::vector<ExpeditionDB::EventNpc> out;
 	auto results = db.QueryDatabase(
@@ -154,7 +158,8 @@ std::vector<ExpeditionDB::EventNpc> LoadAllEventNpcs(Database& db)
 	);
 
 	if (!results.Success()) {
-		return out;
+		LogWarning("Failed to load expedition_template_event_npcs: {}", results.ErrorMessage());
+		return std::nullopt;
 	}
 
 	for (auto row = results.begin(); row != results.end(); ++row) {
@@ -173,7 +178,7 @@ std::vector<ExpeditionDB::EventNpc> LoadAllEventNpcs(Database& db)
 	return out;
 }
 
-std::vector<ExpeditionDB::Action> LoadAllActions(Database& db)
+std::optional<std::vector<ExpeditionDB::Action>> LoadAllActions(Database& db)
 {
 	std::vector<ExpeditionDB::Action> out;
 	auto results = db.QueryDatabase(
@@ -182,7 +187,8 @@ std::vector<ExpeditionDB::Action> LoadAllActions(Database& db)
 	);
 
 	if (!results.Success()) {
-		return out;
+		LogWarning("Failed to load expedition_template_actions: {}", results.ErrorMessage());
+		return std::nullopt;
 	}
 
 	for (auto row = results.begin(); row != results.end(); ++row) {

--- a/zone/expedition_repository.cpp
+++ b/zone/expedition_repository.cpp
@@ -6,6 +6,8 @@
 
 #include <fmt/format.h>
 
+#include <utility>
+
 namespace ExpeditionRepository {
 
 namespace {
@@ -86,7 +88,7 @@ std::optional<std::vector<ExpeditionDB::Template>> LoadAllTemplates(Database& db
 		out.push_back(std::move(e));
 	}
 
-	return out;
+	return std::move(out);
 }
 
 std::optional<std::vector<ExpeditionDB::RequestNpc>> LoadAllRequestNpcs(Database& db)
@@ -115,7 +117,7 @@ std::optional<std::vector<ExpeditionDB::RequestNpc>> LoadAllRequestNpcs(Database
 		out.push_back(std::move(e));
 	}
 
-	return out;
+	return std::move(out);
 }
 
 std::optional<std::vector<ExpeditionDB::Event>> LoadAllEvents(Database& db)
@@ -146,7 +148,7 @@ std::optional<std::vector<ExpeditionDB::Event>> LoadAllEvents(Database& db)
 		out.push_back(std::move(e));
 	}
 
-	return out;
+	return std::move(out);
 }
 
 std::optional<std::vector<ExpeditionDB::EventNpc>> LoadAllEventNpcs(Database& db)
@@ -175,7 +177,7 @@ std::optional<std::vector<ExpeditionDB::EventNpc>> LoadAllEventNpcs(Database& db
 		out.push_back(std::move(e));
 	}
 
-	return out;
+	return std::move(out);
 }
 
 std::optional<std::vector<ExpeditionDB::Action>> LoadAllActions(Database& db)
@@ -201,7 +203,7 @@ std::optional<std::vector<ExpeditionDB::Action>> LoadAllActions(Database& db)
 		out.push_back(std::move(e));
 	}
 
-	return out;
+	return std::move(out);
 }
 
 // ============================================================================

--- a/zone/expedition_repository.h
+++ b/zone/expedition_repository.h
@@ -3,6 +3,7 @@
 #include "zone/expedition_db.h"
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -17,11 +18,11 @@ namespace ExpeditionRepository {
 // responsible for any normalization (e.g. phrase / request_mode) after load.
 // ============================================================================
 
-std::vector<ExpeditionDB::Template>   LoadAllTemplates(Database& db);
-std::vector<ExpeditionDB::RequestNpc> LoadAllRequestNpcs(Database& db);
-std::vector<ExpeditionDB::Event>      LoadAllEvents(Database& db);
-std::vector<ExpeditionDB::EventNpc>   LoadAllEventNpcs(Database& db);
-std::vector<ExpeditionDB::Action>     LoadAllActions(Database& db);
+std::optional<std::vector<ExpeditionDB::Template>>   LoadAllTemplates(Database& db);
+std::optional<std::vector<ExpeditionDB::RequestNpc>> LoadAllRequestNpcs(Database& db);
+std::optional<std::vector<ExpeditionDB::Event>>      LoadAllEvents(Database& db);
+std::optional<std::vector<ExpeditionDB::EventNpc>>   LoadAllEventNpcs(Database& db);
+std::optional<std::vector<ExpeditionDB::Action>>     LoadAllActions(Database& db);
 
 // ============================================================================
 // expedition_templates

--- a/zone/expedition_repository.h
+++ b/zone/expedition_repository.h
@@ -14,7 +14,8 @@ namespace ExpeditionRepository {
 // ============================================================================
 // LOAD OPERATIONS (fetch from DB, parse rows, return typed vectors)
 //
-// Loaders return rows verbatim (no business-rule normalization). Callers are
+// Loaders return rows verbatim (no business-rule normalization), or std::nullopt
+// on query failure so callers can preserve existing cache state. Callers are
 // responsible for any normalization (e.g. phrase / request_mode) after load.
 // ============================================================================
 

--- a/zone/gm_commands/dz.cpp
+++ b/zone/gm_commands/dz.cpp
@@ -93,7 +93,7 @@ void command_dz(Client *c, const Seperator *sep)
 		if (auto dz = DynamicZone::FindDynamicZoneByID(dz_id)) {
 			std::string name = FormatName(sep->arg[3]);
 			c->Message(Chat::White, fmt::format("Setting expedition [{}] leader to [{}]", dz_id, name).c_str());
-			dz->SendWorldMakeLeaderRequest(c->CharacterID(), name);
+			dz->SendWorldMakeLeaderRequest(dz->GetLeaderID(), name);
 		}
 		else {
 			c->Message(Chat::Red, fmt::format("Failed to find expedition [{}]", dz_id).c_str());


### PR DESCRIPTION
## Summary
- honor empty dynamic-zone shutdown delay before deleting memberless DZs
- fix GM `#dz makeleader` routing through the current expedition leader authorization path
- prevent per-DZ member status mutation from leaking across multiple DZ memberships
- escape character-name lists in expedition/DZ SQL helpers
- preserve the existing expedition catalog cache when reload queries fail

## Validation
- `git diff --check`
- `cmake --build build-codex --target zone --config RelWithDebInfo`
- `cmake --build build-codex --target world --config RelWithDebInfo`
- `cmake --build build-codex --target tests --config RelWithDebInfo`
- `build-codex/bin/RelWithDebInfo/tests.exe` reported 106/106 checks passed
- `cmake --build build-codex --target ALL_BUILD --config RelWithDebInfo`
- `emu-compile` linux-test targeted deploy for `world,zone` succeeded into `C:\AkkStack\server\bin`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted bugfixes in expedition/DZ and SQL helpers; no broad auth or payment changes, and behavior is covered by existing build/tests per the PR description.
> 
> **Overview**
> This PR tightens **expedition / dynamic-zone lifecycle** behavior and a few related safety fixes.
> 
> **Empty DZ shutdown:** Memberless but not yet time-expired dynamic zones now honor `EmptyShutdownEnabled` / `EmptyShutdownDelaySeconds` before reporting `ExpiredEmpty`, instead of tearing down immediately when the zone instance has no players.
> 
> **GM `#dz makeleader`:** The world request uses the expedition’s **current leader ID** as the requester (not the GM’s character), so leader changes go through the same authorization path as normal make-leader.
> 
> **Multi-DZ membership:** `SetDynamicZoneMemberStatus` applies **Online → InDynamicZone** per DZ via a local status copy, so updating one membership no longer leaves later DZs stuck in the wrong status.
> 
> **SQL:** Character names in `IN (...)` lists for lockout and “characters with DZ” queries are **`Strings::Escape`’d** before join (expedition/event names were already escaped).
> 
> **Expedition catalog reload:** `LoadAllTemplates` / NPCs / events / actions return `std::optional` and log on query failure; `Reload` **aborts** if any load fails so the in-memory catalog is not replaced with partial/empty data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4e96d9895fd5e1112d41dbe845ce4a910ac6dfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->