### PR TITLE
[Feature Improvement] Improve DB expedition requester selection

### DIFF
--- a/tests/expedition_schema_test.h
+++ b/tests/expedition_schema_test.h
@@ -23,6 +23,8 @@ public:
 		TEST_ADD(ExpeditionSchemaTest::LockoutNamespaceUsesDynamicZoneName);
 		TEST_ADD(ExpeditionSchemaTest::BossOnlyFilterKeepsRequestersUnrestricted);
 		TEST_ADD(ExpeditionSchemaTest::SimpleBuilderDefaultsAreGroupReady);
+		TEST_ADD(ExpeditionSchemaTest::SharedRequesterMenuSortsExpeditions);
+		TEST_ADD(ExpeditionSchemaTest::RequesterLockoutReasonsAreStatusAware);
 	}
 
 private:
@@ -211,5 +213,57 @@ private:
 		TEST_ASSERT(std::string(ExpeditionDB::kSimpleRequestPhrase) == "expedition");
 		TEST_ASSERT(std::string(ExpeditionDB::kSimpleRequestMode) == "db_only");
 		TEST_ASSERT(std::string(ExpeditionDB::kSimpleBossEventName) == "Boss Defeated");
+	}
+
+	void SharedRequesterMenuSortsExpeditions()
+	{
+		ExpeditionDB::Template first;
+		first.id = 20;
+		first.name = "Zlandicar's Labyrinth";
+
+		ExpeditionDB::RequestNpc first_requester;
+		first_requester.id = 2;
+		first_requester.npc_type_id = 100;
+		first_requester.spawn2_id = 10;
+
+		ExpeditionDB::Template second;
+		second.id = 10;
+		second.name = "Aaryonar's Lair";
+
+		ExpeditionDB::RequestNpc second_requester;
+		second_requester.id = 1;
+		second_requester.npc_type_id = first_requester.npc_type_id;
+		second_requester.spawn2_id = first_requester.spawn2_id;
+
+		ExpeditionDB::Template fallback;
+		fallback.id = 30;
+		fallback.dz_template.name = "Cekenar's Hall";
+
+		ExpeditionDB::RequestNpc fallback_requester;
+		fallback_requester.id = 3;
+		fallback_requester.npc_type_id = first_requester.npc_type_id;
+		fallback_requester.spawn2_id = first_requester.spawn2_id;
+
+		ExpeditionDB::RequesterMatches matches = {
+			{ &first, &first_requester, 0 },
+			{ &fallback, &fallback_requester, 0 },
+			{ &second, &second_requester, 0 }
+		};
+
+		ExpeditionDB::SortRequesterMatches(matches);
+
+		TEST_ASSERT(matches.size() == 3);
+		TEST_ASSERT(matches[0].template_data == &second);
+		TEST_ASSERT(matches[1].template_data == &fallback);
+		TEST_ASSERT(matches[2].template_data == &first);
+		TEST_ASSERT(ExpeditionDB::RequesterMenuLabel(fallback) == "Cekenar's Hall");
+	}
+
+	void RequesterLockoutReasonsAreStatusAware()
+	{
+		TEST_ASSERT(ExpeditionDB::IsRequesterLockoutReason("replay_lockout"));
+		TEST_ASSERT(ExpeditionDB::IsRequesterLockoutReason("event_lockout_conflict"));
+		TEST_ASSERT(!ExpeditionDB::IsRequesterLockoutReason("player_count"));
+		TEST_ASSERT(!ExpeditionDB::IsRequesterLockoutReason("member_already_in_expedition"));
 	}
 };

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -2331,7 +2331,7 @@ void EntityList::QueueClientsGuild(const EQApplicationPacket *app, uint32 guild_
 
 void EntityList::QueueClientsGuildBankItemUpdate(GuildBankItemUpdate_Struct *gbius, uint32 guild_id)
 {
-	auto outapp = std::make_unique<EQApplicationPacket>(OP_GuildBank, sizeof(GuildBankItemUpdate_Struct));
+	auto outapp = std::make_unique<EQApplicationPacket>(OP_GuildBank, static_cast<uint32>(sizeof(GuildBankItemUpdate_Struct)));
 	auto data = reinterpret_cast<GuildBankItemUpdate_Struct *>(outapp->pBuffer);
 
 	memcpy(data, gbius, sizeof(GuildBankItemUpdate_Struct));

--- a/zone/expedition_db.cpp
+++ b/zone/expedition_db.cpp
@@ -350,7 +350,24 @@ namespace {
 			return "member lookup failed";
 		}
 
+		if (check.reason == "template_disabled") {
+			return "expedition disabled";
+		}
+
+		if (check.reason == "template_not_found") {
+			return "expedition not found";
+		}
+
 		return "request unavailable";
+	}
+
+	std::string RequestStatusLabel(const ExpeditionCheckResult& check)
+	{
+		if (check.success) {
+			return "Available";
+		}
+
+		return IsRequesterLockoutReason(check.reason) ? "Locked" : "Unavailable";
 	}
 
 	bool TryCreateTemplateRequest(Client& client, const Template& template_data)
@@ -429,7 +446,7 @@ namespace {
 		return true;
 	}
 
-	void OfferRequestMenu(Client& client, NPC& npc, const std::vector<std::pair<const Template*, const RequestNpc*>>& matches)
+	void OfferRequestMenu(Client& client, const RequesterMatches& matches)
 	{
 		if (matches.empty()) {
 			return;
@@ -443,35 +460,50 @@ namespace {
 			std::string name;
 			std::string phrase;
 			std::string button;
+			std::string status;
 			std::string note;
 		};
 		std::vector<MenuEntry> entries;
 		entries.reserve(matches.size());
-		for (const auto& [template_data, request_npc] : matches) {
+		for (const auto& match : matches) {
+			const Template* template_data = match.template_data;
+			const RequestNpc* request_npc = match.request_npc;
 			if (!template_data || !request_npc) {
 				continue;
 			}
 
 			MenuEntry entry;
-			entry.name = template_data->name;
+			entry.name = RequesterMenuLabel(*template_data);
 			if (active_expedition) {
 				if (IsMatchingExpedition(*active_expedition, *template_data)) {
+					entry.status = "Current";
 					if (active_expedition->IsCurrentZoneDz()) {
 						entry.phrase = LeaveMenuPhrase(template_data->id);
 						entry.button = "Leave Instance";
+						entry.note = "inside now";
 					}
 					else {
 						entry.phrase = EnterMenuPhrase(template_data->id);
 						entry.button = "Enter Expedition";
+						entry.note = "ready to enter";
 					}
 				}
 				else {
-					entry.note = "You are already in another expedition.";
+					entry.status = "Unavailable";
+					entry.note = "already in another expedition";
 				}
 			}
 			else {
-				entry.phrase = RequestMenuPhrase(template_data->id);
-				entry.button = "Form Expedition";
+				DynamicZone dz = BuildDynamicZone(*template_data);
+				const auto check = CheckExpeditionRequest(client, dz, true);
+				entry.status = RequestStatusLabel(check);
+				if (check.success) {
+					entry.phrase = RequestMenuPhrase(template_data->id);
+					entry.button = "Form Expedition";
+				}
+				else {
+					entry.note = RequestFailureLabel(check);
+				}
 			}
 			entries.push_back(std::move(entry));
 		}
@@ -480,19 +512,26 @@ namespace {
 			return;
 		}
 
-		const std::string title = multi ? "   Expeditions Available Here" : fmt::format("   Expedition: {}", entries.front().name);
+		const std::string title = multi ? "   Expeditions Offered Here" : fmt::format("   Expedition: {}", entries.front().name);
 		client.Message(Chat::NPCQuestSay, "%s", kManageRule);
 		client.Message(Chat::NPCQuestSay, "%s", title.c_str());
 		client.Message(Chat::NPCQuestSay, "%s", kManageRule);
 		for (const auto& entry : entries) {
-			if (!entry.note.empty()) {
-				const std::string note = multi ? fmt::format("   {} - {}", entry.name, entry.note) : fmt::format("   {}", entry.note);
-				client.Message(Chat::Yellow, "%s", note.c_str());
+			const std::string status = entry.note.empty() ? entry.status : fmt::format("{} ({})", entry.status, entry.note);
+			if (!entry.phrase.empty()) {
+				const std::string action = Saylink::Silent(entry.phrase, fmt::format("[ {} ]", entry.button));
+				const std::string line = multi ?
+					fmt::format("   {} - {} {}", entry.name, status, action) :
+					fmt::format("   {} {}", status, action);
+				client.Message(Chat::NPCQuestSay, "%s", line.c_str());
 				continue;
 			}
-			const std::string label = multi ? fmt::format("{} ({})", entry.button, entry.name) : entry.button;
-			const std::string line = fmt::format("   {}", Saylink::Silent(entry.phrase, fmt::format("[ {} ]", label)));
-			client.Message(Chat::NPCQuestSay, "%s", line.c_str());
+
+			const std::string line = multi ?
+				fmt::format("   {} - {}", entry.name, status) :
+				fmt::format("   {}", status);
+			const uint16_t chat_type = entry.status == "Locked" ? Chat::Red : Chat::Yellow;
+			client.Message(chat_type, "%s", line.c_str());
 		}
 		client.Message(Chat::NPCQuestSay, "%s", kManageRule);
 	}
@@ -1498,17 +1537,41 @@ DynamicZone* CreateExpeditionFromTemplate(Client& client, const std::string& id_
 
 bool CanCreateExpeditionFromTemplate(Client& client, const Template& template_data, bool allow_disabled)
 {
-	if (!allow_disabled && !template_data.enabled) {
-		return false;
-	}
-
-	DynamicZone dz = BuildDynamicZone(template_data);
-	return CheckExpeditionRequest(client, dz, true).success;
+	return CheckExpeditionFromTemplate(client, template_data, allow_disabled).success;
 }
 
 bool CanCreateExpeditionFromTemplate(Client& client, const Template& template_data)
 {
 	return CanCreateExpeditionFromTemplate(client, template_data, false);
+}
+
+ExpeditionCheckResult CheckExpeditionFromTemplate(Client& client, const Template& template_data, bool allow_disabled)
+{
+	ExpeditionCheckResult result;
+	if (!allow_disabled && !template_data.enabled) {
+		result.reason = "template_disabled";
+		return result;
+	}
+
+	DynamicZone dz = BuildDynamicZone(template_data);
+	return CheckExpeditionRequest(client, dz, true);
+}
+
+ExpeditionCheckResult CheckExpeditionFromTemplate(Client& client, const Template& template_data)
+{
+	return CheckExpeditionFromTemplate(client, template_data, false);
+}
+
+ExpeditionCheckResult CheckExpeditionFromTemplate(Client& client, const std::string& id_or_name)
+{
+	const Template* template_data = FindTemplate(id_or_name);
+	if (template_data) {
+		return CheckExpeditionFromTemplate(client, *template_data);
+	}
+
+	ExpeditionCheckResult result;
+	result.reason = "template_not_found";
+	return result;
 }
 
 bool HandleRequestSay(Client& client, NPC& npc, const std::string& message)
@@ -1522,8 +1585,7 @@ bool HandleRequestSay(Client& client, NPC& npc, const std::string& message)
 	const uint32_t menu_template_id = RequestMenuTemplateId(phrase);
 	const uint32_t enter_template_id = EnterMenuTemplateId(phrase);
 	const uint32_t leave_template_id = LeaveMenuTemplateId(phrase);
-	std::vector<std::pair<const Template*, const RequestNpc*>> matches;
-	std::vector<int> match_scores;
+	RequesterMatches matches;
 
 	for (const auto& [template_id, template_data] : g_templates) {
 		if (!template_data.enabled) {
@@ -1541,25 +1603,26 @@ bool HandleRequestSay(Client& client, NPC& npc, const std::string& message)
 				continue;
 			}
 
-			auto existing = std::ranges::find_if(matches, [&](const auto& match) {
-				return match.first && match.first->id == current_template_id;
+			auto existing = std::ranges::find_if(matches, [&](const RequesterMatch& match) {
+				return match.template_data && match.template_data->id == current_template_id;
 			});
 			if (existing == matches.end()) {
-				matches.push_back({ &template_data, &request_npc });
-				match_scores.push_back(specificity);
+				matches.push_back({ &template_data, &request_npc, specificity });
 			}
 			else {
-				const auto index = static_cast<size_t>(std::distance(matches.begin(), existing));
-				if (specificity > match_scores[index]) {
-					matches[index] = { &template_data, &request_npc };
-					match_scores[index] = specificity;
+				if (specificity > existing->specificity) {
+					*existing = { &template_data, &request_npc, specificity };
 				}
 			}
 		}
 	}
 
+	SortRequesterMatches(matches);
+
 	if (!is_hail) {
-		for (const auto& [template_data, request_npc] : matches) {
+		for (const auto& match : matches) {
+			const Template* template_data = match.template_data;
+			const RequestNpc* request_npc = match.request_npc;
 			if (!template_data || !request_npc) {
 				continue;
 			}
@@ -1588,17 +1651,35 @@ bool HandleRequestSay(Client& client, NPC& npc, const std::string& message)
 
 				continue;
 			}
+		}
+
+		RequesterMatches phrase_matches;
+		for (const auto& match : matches) {
+			const Template* template_data = match.template_data;
+			const RequestNpc* request_npc = match.request_npc;
+			if (!template_data || !request_npc) {
+				continue;
+			}
 
 			const std::string request_phrase = RequestPhrase(*template_data, *request_npc);
 			if (phrase == request_phrase || phrase == fmt::format("start {}", request_phrase)) {
-				TryCreateTemplateRequest(client, *template_data);
-				return false;
+				phrase_matches.push_back(match);
 			}
+		}
+
+		if (phrase_matches.size() > 1) {
+			OfferRequestMenu(client, phrase_matches);
+			return true;
+		}
+
+		if (phrase_matches.size() == 1 && phrase_matches.front().template_data) {
+			TryCreateTemplateRequest(client, *phrase_matches.front().template_data);
+			return false;
 		}
 	}
 
 	if (is_hail) {
-		OfferRequestMenu(client, npc, matches);
+		OfferRequestMenu(client, matches);
 		return false;
 	}
 

--- a/zone/expedition_db.cpp
+++ b/zone/expedition_db.cpp
@@ -1669,7 +1669,7 @@ bool HandleRequestSay(Client& client, NPC& npc, const std::string& message)
 
 		if (phrase_matches.size() > 1) {
 			OfferRequestMenu(client, phrase_matches);
-			return true;
+			return false;
 		}
 
 		if (phrase_matches.size() == 1 && phrase_matches.front().template_data) {

--- a/zone/expedition_db.h
+++ b/zone/expedition_db.h
@@ -3,6 +3,7 @@
 #include "common/repositories/dynamic_zone_templates_repository.h"
 #include "common/strings.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -14,6 +15,7 @@ class Client;
 class Database;
 class DynamicZone;
 class NPC;
+struct ExpeditionCheckResult;
 
 namespace ExpeditionDB {
 
@@ -99,6 +101,63 @@ struct Template {
 	std::vector<RequestNpc> request_npcs;
 	std::vector<Event> events;
 };
+
+struct RequesterMatch {
+	const Template* template_data = nullptr;
+	const RequestNpc* request_npc = nullptr;
+	int specificity = 0;
+};
+
+using RequesterMatches = std::vector<RequesterMatch>;
+
+inline std::string RequesterMenuLabel(const Template& template_data)
+{
+	if (!template_data.name.empty()) {
+		return template_data.name;
+	}
+
+	if (!template_data.dz_template.name.empty()) {
+		return template_data.dz_template.name;
+	}
+
+	return "Template " + std::to_string(template_data.id);
+}
+
+inline void SortRequesterMatches(RequesterMatches& matches)
+{
+	std::ranges::sort(matches, [](const RequesterMatch& lhs, const RequesterMatch& rhs) {
+		if (!lhs.template_data || !lhs.request_npc) {
+			return false;
+		}
+
+		if (!rhs.template_data || !rhs.request_npc) {
+			return true;
+		}
+
+		const std::string lhs_label = Strings::ToLower(RequesterMenuLabel(*lhs.template_data));
+		const std::string rhs_label = Strings::ToLower(RequesterMenuLabel(*rhs.template_data));
+		if (lhs_label != rhs_label) {
+			return lhs_label < rhs_label;
+		}
+
+		const std::string lhs_dz_name = Strings::ToLower(lhs.template_data->dz_template.name);
+		const std::string rhs_dz_name = Strings::ToLower(rhs.template_data->dz_template.name);
+		if (lhs_dz_name != rhs_dz_name) {
+			return lhs_dz_name < rhs_dz_name;
+		}
+
+		if (lhs.template_data->id != rhs.template_data->id) {
+			return lhs.template_data->id < rhs.template_data->id;
+		}
+
+		return lhs.request_npc->id < rhs.request_npc->id;
+	});
+}
+
+inline bool IsRequesterLockoutReason(const std::string& reason)
+{
+	return reason == "replay_lockout" || reason == "event_lockout_conflict";
+}
 
 inline bool SharesExpeditionLockoutNamespace(const Template& lhs, const Template& rhs)
 {
@@ -231,6 +290,9 @@ DynamicZone* CreateExpeditionFromTemplate(Client& client, const Template& templa
 DynamicZone* CreateExpeditionFromTemplate(Client& client, const std::string& id_or_name);
 bool CanCreateExpeditionFromTemplate(Client& client, const Template& template_data);
 bool CanCreateExpeditionFromTemplate(Client& client, const Template& template_data, bool allow_disabled);
+ExpeditionCheckResult CheckExpeditionFromTemplate(Client& client, const Template& template_data);
+ExpeditionCheckResult CheckExpeditionFromTemplate(Client& client, const Template& template_data, bool allow_disabled);
+ExpeditionCheckResult CheckExpeditionFromTemplate(Client& client, const std::string& id_or_name);
 bool HandleRequestSay(Client& client, NPC& npc, const std::string& message);
 bool HandleNpcDeath(NPC& npc, Client* killer);
 bool HandleNpcSpawn(NPC& npc);

--- a/zone/gm_commands/expedition.cpp
+++ b/zone/gm_commands/expedition.cpp
@@ -489,16 +489,24 @@ namespace {
 	void ShowRenameHelp(Client* c)
 	{
 		SendSectionHeader(c, "Rename Commands");
-		c->Message(Chat::White, "#expedition rename \"New Name\" - Rename the selected expedition.");
+		c->Message(Chat::White, "#expedition rename New Name - Rename the actively edited expedition, or the selected expedition if not editing.");
 		c->Message(Chat::White, "#expedition rename <id|name> \"New Name\" - Rename a specific expedition.");
 		c->Message(Chat::White, "#expedition set name \"New Name\" - Alias for renaming the selected expedition.");
 
+		const auto& builder_state = ExpeditionDB::GetBuilderState(c->CharacterID());
 		if (const auto* template_data = SelectedTemplate(c)) {
-			c->Message(Chat::Yellow, fmt::format("Selected expedition: [{}] id [{}].", template_data->name, template_data->id).c_str());
+			c->Message(
+				Chat::Yellow,
+				fmt::format("{} expedition: [{}] id [{}].",
+					builder_state.edit_mode ? "Actively editing" : "Selected",
+					template_data->name,
+					template_data->id
+				).c_str()
+			);
 		}
 
 		SendActionGroup(c, "Rename Examples", {
-			{"#expedition rename \"New Expedition Name\"", "Rename Selected Expedition"},
+			{"#expedition rename New Expedition Name", "Rename Active Expedition"},
 			{"#expedition set name \"New Expedition Name\"", "Rename Selected With Set"}
 		});
 	}
@@ -1699,7 +1707,7 @@ void ShowEditScreen(Client* c, const ExpeditionDB::Template& template_data)
 		});
 		// Rename uses a non-silent saylink: clicking pre-fills the command in your input box to edit the name.
 		c->Message(Chat::White, fmt::format("  Rename:  {}",
-			Saylink::Create(fmt::format("#expedition rename {} \"New Name\"", template_data.id), false, "[ Rename ]")).c_str());
+			Saylink::Create("#expedition rename ", false, "[ Rename ]")).c_str());
 		SendCardBottom(c);
 }
 
@@ -2989,9 +2997,13 @@ void HandleSet(Client* c, const Seperator* sep)
 				return;
 			}
 
-			const bool has_target = sep->arg[3][0] != '\0';
-			const auto* rename_template = has_target ? ResolveTemplate(c, sep->arg[2]) : SelectedTemplate(c);
-			const std::string new_name = has_target ? CommandTail(sep, 3) : CommandTail(sep, 2);
+			const auto& builder_state = ExpeditionDB::GetBuilderState(c->CharacterID());
+			const bool rename_active_edit = builder_state.edit_mode && builder_state.selected_template_id != 0;
+			const bool has_target = !rename_active_edit && sep->arg[3][0] != '\0';
+			const auto* rename_template = rename_active_edit ?
+				SelectedTemplate(c) :
+				(has_target ? ResolveTemplate(c, sep->arg[2]) : SelectedTemplate(c));
+			const std::string new_name = rename_active_edit || !has_target ? CommandTail(sep, 2) : CommandTail(sep, 3);
 			if (!rename_template || new_name.empty()) {
 				c->Message(Chat::Red, "Usage: #expedition rename \"New Name\" OR #expedition rename <id|name> \"New Name\"");
 				if (!rename_template) {

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -2108,6 +2108,16 @@ Lua_Expedition Lua_Client::CreateExpeditionFromExpeditionTemplate(std::string te
 	return self->CreateExpeditionFromExpeditionTemplate(template_name);
 }
 
+Lua_Expedition Lua_Client::AssignExpedition(uint32_t expedition_template_id) {
+	Lua_Safe_Call_Class(Lua_Expedition);
+	return self->CreateExpeditionFromExpeditionTemplate(expedition_template_id);
+}
+
+Lua_Expedition Lua_Client::AssignExpedition(std::string template_name) {
+	Lua_Safe_Call_Class(Lua_Expedition);
+	return self->CreateExpeditionFromExpeditionTemplate(template_name);
+}
+
 bool Lua_Client::CanCreateExpeditionFromExpeditionTemplate(uint32_t expedition_template_id) {
 	Lua_Safe_Call_Bool();
 	return self->CanCreateExpeditionFromExpeditionTemplate(expedition_template_id);
@@ -2116,6 +2126,43 @@ bool Lua_Client::CanCreateExpeditionFromExpeditionTemplate(uint32_t expedition_t
 bool Lua_Client::CanCreateExpeditionFromExpeditionTemplate(std::string template_name) {
 	Lua_Safe_Call_Bool();
 	return self->CanCreateExpeditionFromExpeditionTemplate(template_name);
+}
+
+static luabind::object Lua_Client_ExpeditionCheckResult(lua_State* L, const ExpeditionCheckResult& check)
+{
+	auto result = luabind::newtable(L);
+	result["success"] = check.success;
+	result["member_count"] = check.member_count;
+	result["min_players"] = check.min_players;
+	result["max_players"] = check.max_players;
+	result["is_raid"] = check.is_raid;
+	result["reason"] = check.reason;
+	return result;
+}
+
+luabind::object Lua_Client::CheckExpedition(lua_State* L, uint32_t expedition_template_id) {
+	if (!d_) {
+		ExpeditionCheckResult check;
+		check.reason = "invalid_client";
+		return Lua_Client_ExpeditionCheckResult(L, check);
+	}
+
+	auto self = reinterpret_cast<NativeType*>(d_);
+	return Lua_Client_ExpeditionCheckResult(
+		L,
+		ExpeditionDB::CheckExpeditionFromTemplate(*self, std::to_string(expedition_template_id))
+	);
+}
+
+luabind::object Lua_Client::CheckExpedition(lua_State* L, std::string template_name) {
+	if (!d_) {
+		ExpeditionCheckResult check;
+		check.reason = "invalid_client";
+		return Lua_Client_ExpeditionCheckResult(L, check);
+	}
+
+	auto self = reinterpret_cast<NativeType*>(d_);
+	return Lua_Client_ExpeditionCheckResult(L, ExpeditionDB::CheckExpeditionFromTemplate(*self, template_name));
 }
 
 luabind::object Lua_Client::GetExpeditionTemplate(lua_State* L, uint32_t expedition_template_id) {
@@ -3963,8 +4010,12 @@ luabind::scope lua_register_client() {
 	.def("CreateExpeditionFromTemplate", (Lua_Expedition(Lua_Client::*)(std::string))&Lua_Client::CreateExpeditionFromTemplate)
 	.def("CreateExpeditionFromExpeditionTemplate", (Lua_Expedition(Lua_Client::*)(uint32_t))&Lua_Client::CreateExpeditionFromExpeditionTemplate)
 	.def("CreateExpeditionFromExpeditionTemplate", (Lua_Expedition(Lua_Client::*)(std::string))&Lua_Client::CreateExpeditionFromExpeditionTemplate)
+	.def("AssignExpedition", (Lua_Expedition(Lua_Client::*)(uint32_t))&Lua_Client::AssignExpedition)
+	.def("AssignExpedition", (Lua_Expedition(Lua_Client::*)(std::string))&Lua_Client::AssignExpedition)
 	.def("CanCreateExpeditionFromExpeditionTemplate", (bool(Lua_Client::*)(uint32_t))&Lua_Client::CanCreateExpeditionFromExpeditionTemplate)
 	.def("CanCreateExpeditionFromExpeditionTemplate", (bool(Lua_Client::*)(std::string))&Lua_Client::CanCreateExpeditionFromExpeditionTemplate)
+	.def("CheckExpedition", (luabind::object(Lua_Client::*)(lua_State*, uint32_t))&Lua_Client::CheckExpedition)
+	.def("CheckExpedition", (luabind::object(Lua_Client::*)(lua_State*, std::string))&Lua_Client::CheckExpedition)
 	.def("GetExpeditionTemplate", (luabind::object(Lua_Client::*)(lua_State*, uint32_t))&Lua_Client::GetExpeditionTemplate)
 	.def("GetExpeditionTemplate", (luabind::object(Lua_Client::*)(lua_State*, std::string))&Lua_Client::GetExpeditionTemplate)
 	.def("CreateTaskDynamicZone", &Lua_Client::CreateTaskDynamicZone)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -625,8 +625,12 @@ public:
 	Lua_Expedition  CreateExpeditionFromTemplate(std::string template_name);
 	Lua_Expedition  CreateExpeditionFromExpeditionTemplate(uint32_t expedition_template_id);
 	Lua_Expedition  CreateExpeditionFromExpeditionTemplate(std::string template_name);
+	Lua_Expedition  AssignExpedition(uint32_t expedition_template_id);
+	Lua_Expedition  AssignExpedition(std::string template_name);
 	bool            CanCreateExpeditionFromExpeditionTemplate(uint32_t expedition_template_id);
 	bool            CanCreateExpeditionFromExpeditionTemplate(std::string template_name);
+	luabind::object CheckExpedition(lua_State* L, uint32_t expedition_template_id);
+	luabind::object CheckExpedition(lua_State* L, std::string template_name);
 	luabind::object GetExpeditionTemplate(lua_State* L, uint32_t expedition_template_id);
 	luabind::object GetExpeditionTemplate(lua_State* L, std::string template_name);
 	luabind::object CanCreateExpedition(lua_State* L, luabind::object expedition_info);

--- a/zone/lua_expedition.cpp
+++ b/zone/lua_expedition.cpp
@@ -4,6 +4,7 @@
 
 #include "common/zone_store.h"
 #include "zone/dynamic_zone.h"
+#include "zone/lua_client.h"
 
 #include "lua.hpp"
 #include "luabind/iterator_policy.hpp"
@@ -23,6 +24,16 @@ void Lua_Expedition::AddLockoutDuration(std::string event_name, int seconds) {
 void Lua_Expedition::AddLockoutDuration(std::string event_name, int seconds, bool members_only) {
 	Lua_Safe_Call_Void();
 	self->AddLockoutDuration(event_name, seconds, members_only);
+}
+
+void Lua_Expedition::AddPlayer(Lua_Client client, std::string add_name) {
+	Lua_Safe_Call_Void();
+	self->DzAddPlayer(client, add_name);
+}
+
+void Lua_Expedition::AddPlayer(Lua_Client client, std::string add_name, std::string swap_name) {
+	Lua_Safe_Call_Void();
+	self->DzAddPlayer(client, add_name, swap_name);
 }
 
 void Lua_Expedition::AddReplayLockout(uint32_t seconds) {
@@ -144,6 +155,16 @@ bool Lua_Expedition::IsLocked() {
 	return self->IsLocked();
 }
 
+void Lua_Expedition::MakeLeader(Lua_Client client, std::string leader_name) {
+	Lua_Safe_Call_Void();
+	self->DzMakeLeader(client, leader_name);
+}
+
+void Lua_Expedition::PlayerList(Lua_Client client) {
+	Lua_Safe_Call_Void();
+	self->DzPlayerList(client);
+}
+
 void Lua_Expedition::RemoveCompass() {
 	Lua_Safe_Call_Void();
 	self->SetCompass(0, 0, 0, 0, true);
@@ -152,6 +173,11 @@ void Lua_Expedition::RemoveCompass() {
 void Lua_Expedition::RemoveLockout(std::string event_name) {
 	Lua_Safe_Call_Void();
 	self->RemoveLockout(event_name);
+}
+
+void Lua_Expedition::RemovePlayer(Lua_Client client, std::string name) {
+	Lua_Safe_Call_Void();
+	self->DzRemovePlayer(client, name);
 }
 
 void Lua_Expedition::SetCompass(uint32_t zone_id, float x, float y, float z) {
@@ -268,6 +294,11 @@ void Lua_Expedition::SetZoneInLocation(float x, float y, float z, float heading)
 	self->SetZoneInLocation(x, y, z, heading, true);
 }
 
+void Lua_Expedition::SwapPlayer(Lua_Client client, std::string remove_name, std::string add_name) {
+	Lua_Safe_Call_Void();
+	self->DzSwapPlayer(client, remove_name, add_name);
+}
+
 void Lua_Expedition::UpdateLockoutDuration(std::string event_name, uint32_t duration) {
 	Lua_Safe_Call_Void();
 	self->UpdateLockoutDuration(event_name, duration);
@@ -286,6 +317,8 @@ luabind::scope lua_register_expedition() {
 	.def("AddLockout", (void(Lua_Expedition::*)(std::string, uint32_t))&Lua_Expedition::AddLockout)
 	.def("AddLockoutDuration", (void(Lua_Expedition::*)(std::string, int))&Lua_Expedition::AddLockoutDuration)
 	.def("AddLockoutDuration", (void(Lua_Expedition::*)(std::string, int, bool))&Lua_Expedition::AddLockoutDuration)
+	.def("AddPlayer", (void(Lua_Expedition::*)(Lua_Client, std::string))&Lua_Expedition::AddPlayer)
+	.def("AddPlayer", (void(Lua_Expedition::*)(Lua_Client, std::string, std::string))&Lua_Expedition::AddPlayer)
 	.def("AddReplayLockout", (void(Lua_Expedition::*)(uint32_t))&Lua_Expedition::AddReplayLockout)
 	.def("AddReplayLockoutDuration", (void(Lua_Expedition::*)(int))&Lua_Expedition::AddReplayLockoutDuration)
 	.def("AddReplayLockoutDuration", (void(Lua_Expedition::*)(int, bool))&Lua_Expedition::AddReplayLockoutDuration)
@@ -307,8 +340,11 @@ luabind::scope lua_register_expedition() {
 	.def("HasLockout", (bool(Lua_Expedition::*)(std::string))&Lua_Expedition::HasLockout)
 	.def("HasReplayLockout", (bool(Lua_Expedition::*)(void))&Lua_Expedition::HasReplayLockout)
 	.def("IsLocked", &Lua_Expedition::IsLocked)
+	.def("MakeLeader", (void(Lua_Expedition::*)(Lua_Client, std::string))&Lua_Expedition::MakeLeader)
+	.def("PlayerList", (void(Lua_Expedition::*)(Lua_Client))&Lua_Expedition::PlayerList)
 	.def("RemoveCompass", (void(Lua_Expedition::*)(void))&Lua_Expedition::RemoveCompass)
 	.def("RemoveLockout", (void(Lua_Expedition::*)(std::string))&Lua_Expedition::RemoveLockout)
+	.def("RemovePlayer", (void(Lua_Expedition::*)(Lua_Client, std::string))&Lua_Expedition::RemovePlayer)
 	.def("SetCompass", (void(Lua_Expedition::*)(uint32_t, float, float, float))&Lua_Expedition::SetCompass)
 	.def("SetCompass", (void(Lua_Expedition::*)(std::string, float, float, float))&Lua_Expedition::SetCompass)
 	.def("SetLocked", (void(Lua_Expedition::*)(bool))&Lua_Expedition::SetLocked)
@@ -323,6 +359,7 @@ luabind::scope lua_register_expedition() {
 	.def("SetSecondsRemaining", &Lua_Expedition::SetSecondsRemaining)
 	.def("SetSwitchID", &Lua_Expedition::SetSwitchID)
 	.def("SetZoneInLocation", (void(Lua_Expedition::*)(float, float, float, float))&Lua_Expedition::SetZoneInLocation)
+	.def("SwapPlayer", (void(Lua_Expedition::*)(Lua_Client, std::string, std::string))&Lua_Expedition::SwapPlayer)
 	.def("UpdateLockoutDuration", (void(Lua_Expedition::*)(std::string, uint32_t))&Lua_Expedition::UpdateLockoutDuration)
 	.def("UpdateLockoutDuration", (void(Lua_Expedition::*)(std::string, uint32_t, bool))&Lua_Expedition::UpdateLockoutDuration);
 }

--- a/zone/lua_expedition.h
+++ b/zone/lua_expedition.h
@@ -57,6 +57,8 @@ public:
 	void            AddLockout(std::string event_name, uint32_t seconds);
 	void            AddLockoutDuration(std::string event_name, int seconds);
 	void            AddLockoutDuration(std::string event_name, int seconds, bool members_only);
+	void            AddPlayer(Lua_Client client, std::string add_name);
+	void            AddPlayer(Lua_Client client, std::string add_name, std::string swap_name);
 	void            AddReplayLockout(uint32_t seconds);
 	void            AddReplayLockoutDuration(int seconds);
 	void            AddReplayLockoutDuration(int seconds, bool members_only);
@@ -77,8 +79,11 @@ public:
 	bool            HasLockout(std::string event_name);
 	bool            HasReplayLockout();
 	bool            IsLocked();
+	void            MakeLeader(Lua_Client client, std::string leader_name);
+	void            PlayerList(Lua_Client client);
 	void            RemoveCompass();
 	void            RemoveLockout(std::string event_name);
+	void            RemovePlayer(Lua_Client client, std::string name);
 	void            SetCompass(uint32_t zone_id, float x, float y, float z);
 	void            SetCompass(std::string zone_name, float x, float y, float z);
 	void            SetLocked(bool lock_expedition);
@@ -93,6 +98,7 @@ public:
 	void            SetSecondsRemaining(uint32_t seconds_remaining);
 	void            SetSwitchID(int dz_switch_id);
 	void            SetZoneInLocation(float x, float y, float z, float heading);
+	void            SwapPlayer(Lua_Client client, std::string remove_name, std::string add_name);
 	void            UpdateLockoutDuration(std::string event_name, uint32_t duration);
 	void            UpdateLockoutDuration(std::string event_name, uint32_t duration, bool members_only);
 };

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -2005,6 +2005,16 @@ DynamicZone* Perl_Client_CreateExpeditionFromExpeditionTemplate(Client* self, st
 	return self->CreateExpeditionFromExpeditionTemplate(template_name);
 }
 
+DynamicZone* Perl_Client_AssignExpedition(Client* self, uint32_t expedition_template_id)
+{
+	return self->CreateExpeditionFromExpeditionTemplate(expedition_template_id);
+}
+
+DynamicZone* Perl_Client_AssignExpedition(Client* self, std::string template_name)
+{
+	return self->CreateExpeditionFromExpeditionTemplate(template_name);
+}
+
 bool Perl_Client_CanCreateExpeditionFromExpeditionTemplate(Client* self, uint32_t expedition_template_id)
 {
 	return self->CanCreateExpeditionFromExpeditionTemplate(expedition_template_id);
@@ -2013,6 +2023,28 @@ bool Perl_Client_CanCreateExpeditionFromExpeditionTemplate(Client* self, uint32_
 bool Perl_Client_CanCreateExpeditionFromExpeditionTemplate(Client* self, std::string template_name)
 {
 	return self->CanCreateExpeditionFromExpeditionTemplate(template_name);
+}
+
+perl::reference Perl_Client_ExpeditionCheckResult(const ExpeditionCheckResult& check)
+{
+	perl::hash result;
+	result["success"] = check.success;
+	result["member_count"] = check.member_count;
+	result["min_players"] = check.min_players;
+	result["max_players"] = check.max_players;
+	result["is_raid"] = check.is_raid;
+	result["reason"] = check.reason;
+	return perl::reference(result);
+}
+
+perl::reference Perl_Client_CheckExpedition(Client* self, uint32_t expedition_template_id)
+{
+	return Perl_Client_ExpeditionCheckResult(ExpeditionDB::CheckExpeditionFromTemplate(*self, std::to_string(expedition_template_id)));
+}
+
+perl::reference Perl_Client_CheckExpedition(Client* self, std::string template_name)
+{
+	return Perl_Client_ExpeditionCheckResult(ExpeditionDB::CheckExpeditionFromTemplate(*self, template_name));
 }
 
 perl::reference Perl_Client_GetExpeditionTemplate(Client* self, uint32_t expedition_template_id)
@@ -3713,8 +3745,12 @@ void perl_register_client()
 	package.add("CreateExpeditionFromTemplate", (DynamicZone*(*)(Client*, std::string))&Perl_Client_CreateExpeditionFromTemplate);
 	package.add("CreateExpeditionFromExpeditionTemplate", (DynamicZone*(*)(Client*, uint32_t))&Perl_Client_CreateExpeditionFromExpeditionTemplate);
 	package.add("CreateExpeditionFromExpeditionTemplate", (DynamicZone*(*)(Client*, std::string))&Perl_Client_CreateExpeditionFromExpeditionTemplate);
+	package.add("AssignExpedition", (DynamicZone*(*)(Client*, uint32_t))&Perl_Client_AssignExpedition);
+	package.add("AssignExpedition", (DynamicZone*(*)(Client*, std::string))&Perl_Client_AssignExpedition);
 	package.add("CanCreateExpeditionFromExpeditionTemplate", (bool(*)(Client*, uint32_t))&Perl_Client_CanCreateExpeditionFromExpeditionTemplate);
 	package.add("CanCreateExpeditionFromExpeditionTemplate", (bool(*)(Client*, std::string))&Perl_Client_CanCreateExpeditionFromExpeditionTemplate);
+	package.add("CheckExpedition", (perl::reference(*)(Client*, uint32_t))&Perl_Client_CheckExpedition);
+	package.add("CheckExpedition", (perl::reference(*)(Client*, std::string))&Perl_Client_CheckExpedition);
 	package.add("GetExpeditionTemplate", (perl::reference(*)(Client*, uint32_t))&Perl_Client_GetExpeditionTemplate);
 	package.add("GetExpeditionTemplate", (perl::reference(*)(Client*, std::string))&Perl_Client_GetExpeditionTemplate);
 	package.add("CreateTaskDynamicZone", &Perl_Client_CreateTaskDynamicZone);

--- a/zone/perl_expedition.cpp
+++ b/zone/perl_expedition.cpp
@@ -21,6 +21,16 @@ void Perl_Expedition_AddLockoutDuration(DynamicZone* self, std::string event_nam
 	self->AddLockoutDuration(event_name, seconds, members_only);
 }
 
+void Perl_Expedition_AddPlayer(DynamicZone* self, Client* client, std::string add_name)
+{
+	self->DzAddPlayer(client, add_name);
+}
+
+void Perl_Expedition_AddPlayer(DynamicZone* self, Client* client, std::string add_name, std::string swap_name)
+{
+	self->DzAddPlayer(client, add_name, swap_name);
+}
+
 void Perl_Expedition_AddReplayLockout(DynamicZone* self, uint32_t seconds)
 {
 	self->AddLockout(DzLockout::ReplayTimer, seconds);
@@ -132,6 +142,16 @@ bool Perl_Expedition_IsLocked(DynamicZone* self)
 	return self->IsLocked();
 }
 
+void Perl_Expedition_MakeLeader(DynamicZone* self, Client* client, std::string leader_name)
+{
+	self->DzMakeLeader(client, leader_name);
+}
+
+void Perl_Expedition_PlayerList(DynamicZone* self, Client* client)
+{
+	self->DzPlayerList(client);
+}
+
 void Perl_Expedition_RemoveCompass(DynamicZone* self)
 {
 	self->SetCompass(0, 0, 0, 0, true);
@@ -140,6 +160,11 @@ void Perl_Expedition_RemoveCompass(DynamicZone* self)
 void Perl_Expedition_RemoveLockout(DynamicZone* self, std::string event_name)
 {
 	self->RemoveLockout(event_name);
+}
+
+void Perl_Expedition_RemovePlayer(DynamicZone* self, Client* client, std::string name)
+{
+	self->DzRemovePlayer(client, name);
 }
 
 void Perl_Expedition_SetCompass(DynamicZone* self, perl::scalar zone, float x, float y, float z)
@@ -233,6 +258,11 @@ void Perl_Expedition_SetZoneInLocation(DynamicZone* self, float x, float y, floa
 	self->SetZoneInLocation(x, y, z, heading, true);
 }
 
+void Perl_Expedition_SwapPlayer(DynamicZone* self, Client* client, std::string remove_name, std::string add_name)
+{
+	self->DzSwapPlayer(client, remove_name, add_name);
+}
+
 void Perl_Expedition_UpdateLockoutDuration(DynamicZone* self, std::string event_name, uint32_t seconds)
 {
 	self->UpdateLockoutDuration(event_name, seconds);
@@ -251,6 +281,8 @@ void perl_register_expedition()
 	package.add("AddLockout", &Perl_Expedition_AddLockout);
 	package.add("AddLockoutDuration", (void(*)(DynamicZone*, std::string, int))&Perl_Expedition_AddLockoutDuration);
 	package.add("AddLockoutDuration", (void(*)(DynamicZone*, std::string, int, bool))&Perl_Expedition_AddLockoutDuration);
+	package.add("AddPlayer", (void(*)(DynamicZone*, Client*, std::string))&Perl_Expedition_AddPlayer);
+	package.add("AddPlayer", (void(*)(DynamicZone*, Client*, std::string, std::string))&Perl_Expedition_AddPlayer);
 	package.add("AddReplayLockout", &Perl_Expedition_AddReplayLockout);
 	package.add("AddReplayLockoutDuration", (void(*)(DynamicZone*, int))&Perl_Expedition_AddReplayLockoutDuration);
 	package.add("AddReplayLockoutDuration", (void(*)(DynamicZone*, int, bool))&Perl_Expedition_AddReplayLockoutDuration);
@@ -272,8 +304,11 @@ void perl_register_expedition()
 	package.add("HasLockout", &Perl_Expedition_HasLockout);
 	package.add("HasReplayLockout", &Perl_Expedition_HasReplayLockout);
 	package.add("IsLocked", &Perl_Expedition_IsLocked);
+	package.add("MakeLeader", &Perl_Expedition_MakeLeader);
+	package.add("PlayerList", &Perl_Expedition_PlayerList);
 	package.add("RemoveCompass", &Perl_Expedition_RemoveCompass);
 	package.add("RemoveLockout", &Perl_Expedition_RemoveLockout);
+	package.add("RemovePlayer", &Perl_Expedition_RemovePlayer);
 	package.add("SetCompass", &Perl_Expedition_SetCompass);
 	package.add("SetLocked", (void(*)(DynamicZone*, bool))&Perl_Expedition_SetLocked);
 	package.add("SetLocked", (void(*)(DynamicZone*, bool, int))&Perl_Expedition_SetLocked);
@@ -286,6 +321,7 @@ void perl_register_expedition()
 	package.add("SetSecondsRemaining", &Perl_Expedition_SetSecondsRemaining);
 	package.add("SetSwitchID", &Perl_Expedition_SetSwitchID);
 	package.add("SetZoneInLocation", &Perl_Expedition_SetZoneInLocation);
+	package.add("SwapPlayer", &Perl_Expedition_SwapPlayer);
 	package.add("UpdateLockoutDuration", (void(*)(DynamicZone*, std::string, uint32_t))&Perl_Expedition_UpdateLockoutDuration);
 	package.add("UpdateLockoutDuration", (void(*)(DynamicZone*, std::string, uint32_t, bool))&Perl_Expedition_UpdateLockoutDuration);
 }


### PR DESCRIPTION
## Summary
- Add an organized shared-requester expedition menu when one requester NPC offers multiple DB-driven expeditions.
- Annotate requester menu rows with available, locked, unavailable, and current expedition states.
- Add Perl and Lua expedition APIs for assigning/checking DB expedition templates and managing active expedition membership.
- Improve the expedition builder rename flow so edit-mode rename commands target the active expedition and the Rename saylink prompts for the new name.

## Quest Script API Examples

```text
# Client methods: use an expedition_templates.id, name, or slug.
$client->AssignExpedition(123); / e.self:AssignExpedition(123)
$client->AssignExpedition("kael_hard"); / e.self:AssignExpedition("kael_hard")
$client->CheckExpedition(123); / e.self:CheckExpedition(123)
$client->CheckExpedition("kael_hard"); / e.self:CheckExpedition("kael_hard")

# Expedition methods: require an Expedition/DynamicZone object plus the acting client.
$expedition->AddPlayer($client, "PlayerToAdd"); / expedition:AddPlayer(client, "PlayerToAdd")
$expedition->AddPlayer($client, "PlayerToAdd", "PlayerToSwapOut"); / expedition:AddPlayer(client, "PlayerToAdd", "PlayerToSwapOut")
$expedition->RemovePlayer($client, "PlayerToRemove"); / expedition:RemovePlayer(client, "PlayerToRemove")
$expedition->SwapPlayer($client, "PlayerToRemove", "PlayerToAdd"); / expedition:SwapPlayer(client, "PlayerToRemove", "PlayerToAdd")
$expedition->MakeLeader($client, "NewLeader"); / expedition:MakeLeader(client, "NewLeader")
$expedition->PlayerList($client); / expedition:PlayerList(client)
```
## Validation
- `git diff --check`
- `cmake --build build-codex --target zone --config RelWithDebInfo`
- `cmake --build build-codex --target tests --config RelWithDebInfo`
- `build-codex\bin\RelWithDebInfo\tests.exe` - 108 tests, 100% correct
- Local AkkStack `emu-compile` linux-test target-scoped build for `zone`, deployed to `C:\AkkStack\server\bin\zone`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes player-facing expedition request flow and adds script APIs that can create or modify expeditions; core request validation is reused but menu and phrase disambiguation behavior is new.
> 
> **Overview**
> **Shared requester NPCs** now build a sorted multi-expedition menu: entries use **Available / Locked / Unavailable / Current** labels (with failure notes and red chat for lockouts), run **CheckExpeditionRequest** before offering **Form Expedition**, and ambiguous request phrases open the menu instead of failing silently. New helpers include **RequesterMatch** sorting, **RequesterMenuLabel**, **CheckExpeditionFromTemplate**, and clearer disabled/not-found failure text.
> 
> **Lua and Perl** gain **AssignExpedition** and **CheckExpedition** on clients (check returns success, counts, and reason) plus expedition **AddPlayer**, **RemovePlayer**, **SwapPlayer**, **MakeLeader**, and **PlayerList** wired to existing dynamic-zone handlers.
> 
> **GM builder** rename in edit mode targets the active expedition without requiring an id; the rename saylink prefills `#expedition rename ` only. Minor: guild bank packet size uses an explicit **uint32** cast.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2a084e2cc9d3ecdc6bf9a61de090100603295f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->