### PR TITLE
[Feature Improvement] Add DB expedition boss availability guards & other improvements

### DIFF
--- a/common/database/database_update_manifest.h
+++ b/common/database/database_update_manifest.h
@@ -7454,6 +7454,7 @@ CREATE TABLE IF NOT EXISTS `expedition_template_events` (
 	`lock_on_failure` TINYINT(1) UNSIGNED NOT NULL DEFAULT '0',
 	`loot_protected` TINYINT(1) UNSIGNED NOT NULL DEFAULT '0',
 	`sort_order` INT(11) NOT NULL DEFAULT '0',
+	`completion_mode` VARCHAR(32) NOT NULL DEFAULT 'first_completion',
 	PRIMARY KEY (`id`),
 	KEY `idx_expedition_events_template` (`expedition_template_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
@@ -7493,6 +7494,18 @@ CREATE TABLE IF NOT EXISTS `expedition_template_actions` (
 		.sql = R"(
 ALTER TABLE `expedition_templates`
 ADD COLUMN `boss_only_spawn` TINYINT(1) UNSIGNED NOT NULL DEFAULT '0' AFTER `silent`;
+)",
+		.content_schema_update = true
+	},
+	ManifestEntry{
+		.version = 9346,
+		.description = "2026_06_08_expedition_event_completion_mode.sql",
+		.check = "SHOW COLUMNS FROM `expedition_template_events` LIKE 'completion_mode'",
+		.condition = "empty",
+		.match = "",
+		.sql = R"(
+ALTER TABLE `expedition_template_events`
+ADD COLUMN `completion_mode` VARCHAR(32) NOT NULL DEFAULT 'first_completion' AFTER `sort_order`;
 )",
 		.content_schema_update = true
 	},

--- a/common/version.h
+++ b/common/version.h
@@ -41,6 +41,6 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9345
+#define CURRENT_BINARY_DATABASE_VERSION 9346
 #define CURRENT_BINARY_BOTS_DATABASE_VERSION 9054
 #define CUSTOM_BINARY_DATABASE_VERSION 0

--- a/tests/expedition_schema_test.h
+++ b/tests/expedition_schema_test.h
@@ -25,6 +25,9 @@ public:
 		TEST_ADD(ExpeditionSchemaTest::SimpleBuilderDefaultsAreGroupReady);
 		TEST_ADD(ExpeditionSchemaTest::SharedRequesterMenuSortsExpeditions);
 		TEST_ADD(ExpeditionSchemaTest::RequesterLockoutReasonsAreStatusAware);
+		TEST_ADD(ExpeditionSchemaTest::BaseZoneBossSpawnedReasonUsesFormattedUnavailableMessage);
+		TEST_ADD(ExpeditionSchemaTest::BaseZoneBossAvailabilityIsTemplateSpecific);
+		TEST_ADD(ExpeditionSchemaTest::BossLockoutSpawnGateUsesConfiguredBossMappings);
 	}
 
 private:
@@ -265,5 +268,94 @@ private:
 		TEST_ASSERT(ExpeditionDB::IsRequesterLockoutReason("event_lockout_conflict"));
 		TEST_ASSERT(!ExpeditionDB::IsRequesterLockoutReason("player_count"));
 		TEST_ASSERT(!ExpeditionDB::IsRequesterLockoutReason("member_already_in_expedition"));
+	}
+
+	void BaseZoneBossSpawnedReasonUsesFormattedUnavailableMessage()
+	{
+		TEST_ASSERT(ExpeditionDB::IsBaseZoneBossSpawnedReason(ExpeditionDB::kBaseZoneBossSpawnedReason));
+		TEST_ASSERT(ExpeditionDB::IsRequesterStatusBlockReason(ExpeditionDB::kBaseZoneBossSpawnedReason));
+		TEST_ASSERT(!ExpeditionDB::IsRequesterStatusBlockReason("replay_lockout"));
+		TEST_ASSERT(std::string(ExpeditionDB::kBaseZoneBossUnavailableStatus) == "Unavailable");
+		TEST_ASSERT(std::string(ExpeditionDB::kBaseZoneBossUnavailableNote) == "while associated bosses are spawned in the base zone.");
+		TEST_ASSERT(std::string(ExpeditionDB::kBaseZoneBossUnavailableMessage) == "Unavailable while associated bosses are spawned in the base zone.");
+		TEST_ASSERT(std::string(ExpeditionDB::kBaseZoneBossUnavailableFailure) == "unavailable while associated bosses are spawned in the base zone");
+	}
+
+	void BaseZoneBossAvailabilityIsTemplateSpecific()
+	{
+		ExpeditionDB::Template first_template;
+		ExpeditionDB::Event first_event;
+		ExpeditionDB::EventNpc first_boss;
+		first_boss.role = "boss";
+		first_boss.npc_type_id = 100;
+		first_boss.spawn2_id = 10;
+		first_event.npcs.push_back(first_boss);
+		first_template.events.push_back(first_event);
+
+		ExpeditionDB::Template second_template;
+		ExpeditionDB::Event second_event;
+		ExpeditionDB::EventNpc second_boss;
+		second_boss.role = "boss";
+		second_boss.npc_type_id = 200;
+		second_boss.spawn2_id = 20;
+		second_event.npcs.push_back(second_boss);
+		second_template.events.push_back(second_event);
+
+		ExpeditionDB::Template non_boss_template;
+		ExpeditionDB::Event non_boss_event;
+		ExpeditionDB::EventNpc add_npc;
+		add_npc.role = "add";
+		add_npc.npc_type_id = first_boss.npc_type_id;
+		add_npc.spawn2_id = first_boss.spawn2_id;
+		non_boss_event.npcs.push_back(add_npc);
+		non_boss_template.events.push_back(non_boss_event);
+
+		ExpeditionDB::Template wildcard_template;
+		ExpeditionDB::Event wildcard_event;
+		ExpeditionDB::EventNpc wildcard_boss;
+		wildcard_boss.role = "boss";
+		wildcard_boss.npc_type_id = 300;
+		wildcard_boss.spawn2_id = 0;
+		wildcard_event.npcs.push_back(wildcard_boss);
+		wildcard_template.events.push_back(wildcard_event);
+
+		TEST_ASSERT(ExpeditionDB::TemplateHasBaseZoneAvailabilityBossForSpawn(first_template, 100, 10));
+		TEST_ASSERT(!ExpeditionDB::TemplateHasBaseZoneAvailabilityBossForSpawn(first_template, 100, 11));
+		TEST_ASSERT(!ExpeditionDB::TemplateHasBaseZoneAvailabilityBossForSpawn(second_template, 100, 10));
+		TEST_ASSERT(!ExpeditionDB::TemplateHasBaseZoneAvailabilityBossForSpawn(non_boss_template, 100, 10));
+		TEST_ASSERT(ExpeditionDB::TemplateHasBaseZoneAvailabilityBossForSpawn(wildcard_template, 300, 99));
+		TEST_ASSERT(!ExpeditionDB::TemplateHasBaseZoneAvailabilityBossForSpawn(wildcard_template, 301, 99));
+	}
+
+	void BossLockoutSpawnGateUsesConfiguredBossMappings()
+	{
+		TEST_ASSERT(ExpeditionDB::kBossLockoutSpawnRetryMilliseconds == 60000);
+
+		ExpeditionDB::EventNpc boss_npc;
+		boss_npc.role = "boss";
+		boss_npc.npc_type_id = 100;
+		boss_npc.spawn2_id = 10;
+
+		ExpeditionDB::EventNpc wildcard_boss_npc;
+		wildcard_boss_npc.role = "boss";
+		wildcard_boss_npc.npc_type_id = 200;
+		wildcard_boss_npc.spawn2_id = 0;
+
+		ExpeditionDB::EventNpc non_boss_npc;
+		non_boss_npc.role = "add";
+		non_boss_npc.npc_type_id = boss_npc.npc_type_id;
+		non_boss_npc.spawn2_id = boss_npc.spawn2_id;
+
+		ExpeditionDB::EventNpc unset_boss_npc;
+		unset_boss_npc.role = "boss";
+		unset_boss_npc.npc_type_id = 0;
+		unset_boss_npc.spawn2_id = boss_npc.spawn2_id;
+
+		TEST_ASSERT(ExpeditionDB::BossEventNpcMatchesSpawn(boss_npc, 100, 10));
+		TEST_ASSERT(!ExpeditionDB::BossEventNpcMatchesSpawn(boss_npc, 100, 11));
+		TEST_ASSERT(!ExpeditionDB::BossEventNpcMatchesSpawn(boss_npc, 101, 10));
+		TEST_ASSERT(ExpeditionDB::BossEventNpcMatchesSpawn(wildcard_boss_npc, 200, 99));
+		TEST_ASSERT(!ExpeditionDB::BossEventNpcMatchesSpawn(non_boss_npc, 100, 10));
+		TEST_ASSERT(!ExpeditionDB::BossEventNpcMatchesSpawn(unset_boss_npc, 0, 10));
 	}
 };

--- a/tests/expedition_schema_test.h
+++ b/tests/expedition_schema_test.h
@@ -7,6 +7,7 @@
 #include "zone/expedition_db.h"
 
 #include <algorithm>
+#include <unordered_set>
 
 extern std::vector<ManifestEntry> manifest_entries;
 
@@ -17,8 +18,10 @@ public:
 		TEST_ADD(ExpeditionSchemaTest::ContentSchemaIncludesExpeditionAuthoringTables);
 		TEST_ADD(ExpeditionSchemaTest::CreationMigrationHasFinalSchema);
 		TEST_ADD(ExpeditionSchemaTest::BossOnlyMigrationUpdatesExistingTemplates);
+		TEST_ADD(ExpeditionSchemaTest::EventCompletionModeMigrationUpdatesExistingEvents);
 		TEST_ADD(ExpeditionSchemaTest::BinaryDatabaseVersionIncludesExpeditionMigrations);
 		TEST_ADD(ExpeditionSchemaTest::BossOnlyDefaultsAreOff);
+		TEST_ADD(ExpeditionSchemaTest::EventCompletionModeDefaultsToFirstCompletion);
 		TEST_ADD(ExpeditionSchemaTest::BossEventNpcRemovalDeletesEvent);
 		TEST_ADD(ExpeditionSchemaTest::LockoutNamespaceUsesDynamicZoneName);
 		TEST_ADD(ExpeditionSchemaTest::BossOnlyFilterKeepsRequestersUnrestricted);
@@ -28,6 +31,9 @@ public:
 		TEST_ADD(ExpeditionSchemaTest::BaseZoneBossSpawnedReasonUsesFormattedUnavailableMessage);
 		TEST_ADD(ExpeditionSchemaTest::BaseZoneBossAvailabilityIsTemplateSpecific);
 		TEST_ADD(ExpeditionSchemaTest::BossLockoutSpawnGateUsesConfiguredBossMappings);
+		TEST_ADD(ExpeditionSchemaTest::GroupedBossRequirementMatchingSupportsDynamicBosses);
+		TEST_ADD(ExpeditionSchemaTest::GroupedBossAllCompletionRequiresEveryRequirement);
+		TEST_ADD(ExpeditionSchemaTest::GroupedBossValidationHelpersRequireUnambiguousBossGroup);
 	}
 
 private:
@@ -63,6 +69,8 @@ private:
 		TEST_ASSERT(entry->sql.find("db_only") != std::string::npos);
 		TEST_ASSERT(entry->sql.find("zone_version") != std::string::npos);
 		TEST_ASSERT(entry->sql.find("complete_on_spawn") != std::string::npos);
+		TEST_ASSERT(entry->sql.find("completion_mode") != std::string::npos);
+		TEST_ASSERT(entry->sql.find("first_completion") != std::string::npos);
 		TEST_ASSERT(entry->sql.find("idx_expedition_request_lookup") != std::string::npos);
 
 		// The redundant follow-up migrations were consolidated away.
@@ -87,9 +95,24 @@ private:
 		TEST_ASSERT(entry->sql.find("DEFAULT '0'") != std::string::npos);
 	}
 
+	void EventCompletionModeMigrationUpdatesExistingEvents()
+	{
+		auto entry = std::find_if(manifest_entries.begin(), manifest_entries.end(), [](const ManifestEntry& e) {
+			return e.version == 9346 && e.description == "2026_06_08_expedition_event_completion_mode.sql";
+		});
+
+		TEST_ASSERT(entry != manifest_entries.end());
+		TEST_ASSERT(entry->content_schema_update);
+		TEST_ASSERT(entry->check == "SHOW COLUMNS FROM `expedition_template_events` LIKE 'completion_mode'");
+		TEST_ASSERT(entry->condition == "empty");
+		TEST_ASSERT(entry->sql.find("ALTER TABLE `expedition_template_events`") != std::string::npos);
+		TEST_ASSERT(entry->sql.find("completion_mode") != std::string::npos);
+		TEST_ASSERT(entry->sql.find("DEFAULT 'first_completion'") != std::string::npos);
+	}
+
 	void BinaryDatabaseVersionIncludesExpeditionMigrations()
 	{
-		TEST_ASSERT(CURRENT_BINARY_DATABASE_VERSION >= 9345);
+		TEST_ASSERT(CURRENT_BINARY_DATABASE_VERSION >= 9346);
 	}
 
 	void BossOnlyDefaultsAreOff()
@@ -103,6 +126,16 @@ private:
 		TEST_ASSERT(filter.unrestricted_spawn2_ids.empty());
 		TEST_ASSERT(filter.AllowsSpawn2(1));
 		TEST_ASSERT(filter.AllowedNPCTypeIDs(1) == nullptr);
+	}
+
+	void EventCompletionModeDefaultsToFirstCompletion()
+	{
+		ExpeditionDB::Event event_data;
+		TEST_ASSERT(event_data.completion_mode == ExpeditionDB::kCompletionModeFirst);
+		TEST_ASSERT(!ExpeditionDB::IsGroupedBossCompletionMode(event_data));
+		TEST_ASSERT(ExpeditionDB::NormalizeCompletionMode("all") == ExpeditionDB::kCompletionModeAllBosses);
+		TEST_ASSERT(ExpeditionDB::NormalizeCompletionMode("any") == ExpeditionDB::kCompletionModeAnyBoss);
+		TEST_ASSERT(ExpeditionDB::NormalizeCompletionMode("unexpected") == ExpeditionDB::kCompletionModeFirst);
 	}
 
 	void BossEventNpcRemovalDeletesEvent()
@@ -122,6 +155,13 @@ private:
 		ExpeditionDB::EventNpc chest_npc;
 		chest_npc.role = "chest";
 		TEST_ASSERT(!ExpeditionDB::EventNpcRemovalDeletesEvent(chest_npc));
+
+		ExpeditionDB::Event single_boss_event;
+		TEST_ASSERT(ExpeditionDB::EventNpcRemovalDeletesEvent(single_boss_event, boss_npc));
+
+		ExpeditionDB::Event grouped_boss_event;
+		grouped_boss_event.completion_mode = ExpeditionDB::kCompletionModeAllBosses;
+		TEST_ASSERT(!ExpeditionDB::EventNpcRemovalDeletesEvent(grouped_boss_event, boss_npc));
 	}
 
 	void LockoutNamespaceUsesDynamicZoneName()
@@ -357,5 +397,98 @@ private:
 		TEST_ASSERT(ExpeditionDB::BossEventNpcMatchesSpawn(wildcard_boss_npc, 200, 99));
 		TEST_ASSERT(!ExpeditionDB::BossEventNpcMatchesSpawn(non_boss_npc, 100, 10));
 		TEST_ASSERT(!ExpeditionDB::BossEventNpcMatchesSpawn(unset_boss_npc, 0, 10));
+	}
+
+	void GroupedBossRequirementMatchingSupportsDynamicBosses()
+	{
+		ExpeditionDB::Event grouped_event;
+		grouped_event.completion_mode = ExpeditionDB::kCompletionModeAllBosses;
+
+		ExpeditionDB::EventNpc spawn_boss;
+		spawn_boss.id = 1;
+		spawn_boss.role = "boss";
+		spawn_boss.npc_type_id = 100;
+		spawn_boss.spawn2_id = 10;
+		spawn_boss.complete_on_death = true;
+
+		ExpeditionDB::EventNpc dynamic_boss;
+		dynamic_boss.id = 2;
+		dynamic_boss.role = "boss";
+		dynamic_boss.npc_type_id = 200;
+		dynamic_boss.spawn2_id = 0;
+		dynamic_boss.complete_on_death = true;
+
+		ExpeditionDB::EventNpc add_npc;
+		add_npc.id = 3;
+		add_npc.role = "add";
+		add_npc.npc_type_id = 300;
+		add_npc.complete_on_death = true;
+
+		grouped_event.npcs = { spawn_boss, dynamic_boss, add_npc };
+
+		TEST_ASSERT(ExpeditionDB::IsGroupedBossCompletionMode(grouped_event));
+		TEST_ASSERT(ExpeditionDB::GroupedBossRequirementCount(grouped_event) == 2);
+		TEST_ASSERT(ExpeditionDB::GroupedBossRequirementMatchesSpawn(spawn_boss, 100, 10));
+		TEST_ASSERT(!ExpeditionDB::GroupedBossRequirementMatchesSpawn(spawn_boss, 100, 11));
+		TEST_ASSERT(ExpeditionDB::GroupedBossRequirementMatchesSpawn(dynamic_boss, 200, 99));
+		TEST_ASSERT(!ExpeditionDB::GroupedBossRequirementMatchesSpawn(add_npc, 300, 0));
+	}
+
+	void GroupedBossAllCompletionRequiresEveryRequirement()
+	{
+		ExpeditionDB::Event grouped_event;
+		grouped_event.completion_mode = ExpeditionDB::kCompletionModeAllBosses;
+
+		ExpeditionDB::EventNpc first_boss;
+		first_boss.id = 10;
+		first_boss.role = "boss";
+		first_boss.npc_type_id = 100;
+		first_boss.complete_on_death = true;
+
+		ExpeditionDB::EventNpc second_boss;
+		second_boss.id = 20;
+		second_boss.role = "boss";
+		second_boss.npc_type_id = 200;
+		second_boss.complete_on_death = true;
+
+		grouped_event.npcs = { first_boss, second_boss };
+
+		std::unordered_set<uint32_t> completed;
+		TEST_ASSERT(!ExpeditionDB::GroupedBossRequirementsComplete(grouped_event, completed));
+		completed.insert(first_boss.id);
+		TEST_ASSERT(!ExpeditionDB::GroupedBossRequirementsComplete(grouped_event, completed));
+		completed.insert(second_boss.id);
+		TEST_ASSERT(ExpeditionDB::GroupedBossRequirementsComplete(grouped_event, completed));
+	}
+
+	void GroupedBossValidationHelpersRequireUnambiguousBossGroup()
+	{
+		ExpeditionDB::Event grouped_event;
+		grouped_event.event_name = ExpeditionDB::kSimpleBossEventName;
+		grouped_event.completion_mode = ExpeditionDB::kCompletionModeAllBosses;
+
+		ExpeditionDB::EventNpc dynamic_boss;
+		dynamic_boss.id = 1;
+		dynamic_boss.role = "boss";
+		dynamic_boss.npc_type_id = 100;
+		dynamic_boss.spawn2_id = 0;
+		dynamic_boss.complete_on_death = true;
+
+		ExpeditionDB::EventNpc spawn_boss;
+		spawn_boss.id = 2;
+		spawn_boss.role = "boss";
+		spawn_boss.npc_type_id = 100;
+		spawn_boss.spawn2_id = 10;
+		spawn_boss.complete_on_death = true;
+
+		grouped_event.npcs = { dynamic_boss, spawn_boss };
+
+		TEST_ASSERT(ExpeditionDB::IsGroupedBossCompletionMode(grouped_event));
+		TEST_ASSERT(Strings::EqualFold(grouped_event.event_name, ExpeditionDB::kSimpleBossEventName));
+		TEST_ASSERT(ExpeditionDB::GroupedBossHasAmbiguousDynamicRequirement(grouped_event));
+
+		spawn_boss.npc_type_id = 200;
+		grouped_event.npcs = { dynamic_boss, spawn_boss };
+		TEST_ASSERT(!ExpeditionDB::GroupedBossHasAmbiguousDynamicRequirement(grouped_event));
 	}
 };

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -1212,6 +1212,30 @@ bool EntityList::IsMobSpawnedByNpcTypeID(uint32 get_id)
 	return false;
 }
 
+bool EntityList::IsActiveNPCSpawnedByNpcTypeID(uint32 npc_type_id, uint32 spawn_point_id)
+{
+	if (npc_type_id == 0 || npc_list.empty()) {
+		return false;
+	}
+
+	for (const auto& npc_entry : npc_list) {
+		NPC* npc = npc_entry.second;
+		if (!npc || npc->GetNPCTypeID() != npc_type_id) {
+			continue;
+		}
+
+		if (spawn_point_id != 0 && npc->GetSpawnPointID() != spawn_point_id) {
+			continue;
+		}
+
+		if (npc->GetID() != 0 && !npc->GetDepop()) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 bool EntityList::IsNPCSpawned(std::vector<uint32> npc_ids)
 {
 	return CountSpawnedNPCs(npc_ids) != 0;

--- a/zone/entity.h
+++ b/zone/entity.h
@@ -166,6 +166,7 @@ public:
 	}
 	NPC *GetNPCByNPCTypeID(uint32 npc_id);
 	NPC *GetNPCBySpawnID(uint32 spawn_id);
+	bool IsActiveNPCSpawnedByNpcTypeID(uint32 npc_type_id, uint32 spawn_point_id = 0);
 	inline Merc *GetMercByID(uint16 id)
 	{
 		auto it = merc_list.find(id);

--- a/zone/expedition_db.cpp
+++ b/zone/expedition_db.cpp
@@ -55,6 +55,7 @@ namespace {
 	std::unordered_map<uint32_t, BuilderState> g_builder_states;
 	std::unordered_map<uint32_t, uint16_t> g_last_gm_target_menu_entity;
 	std::unordered_map<uint32_t, std::unordered_set<std::string>> g_completed_runtime_events;
+	std::unordered_map<uint32_t, std::unordered_map<uint32_t, std::unordered_set<uint32_t>>> g_grouped_boss_progress;
 
 	uint32_t UInt(const char* value)
 	{
@@ -610,6 +611,10 @@ namespace {
 
 	std::string RuntimeEventName(const Event& event_data, const EventNpc& event_npc)
 	{
+		if (IsGroupedBossCompletionMode(event_data)) {
+			return event_data.event_name;
+		}
+
 		if (Strings::EqualFold(event_data.event_name, kSimpleBossEventName)) {
 			return BossEventName(event_npc);
 		}
@@ -642,6 +647,17 @@ namespace {
 	bool TryMarkRuntimeEventComplete(DynamicZone& expedition, const std::string& runtime_event_name)
 	{
 		return g_completed_runtime_events[expedition.GetID()].insert(runtime_event_name).second;
+	}
+
+	bool TryMarkGroupedBossRequirementComplete(DynamicZone& expedition, const Event& event_data, const EventNpc& event_npc)
+	{
+		if (!IsGroupedBossRequirement(event_npc) || event_npc.id == 0) {
+			return false;
+		}
+
+		auto& completed_event_npc_ids = g_grouped_boss_progress[expedition.GetID()][event_data.id];
+		completed_event_npc_ids.insert(event_npc.id);
+		return GroupedBossRequirementsComplete(event_data, completed_event_npc_ids);
 	}
 
 	std::pair<std::string, uint32_t> ParseLockoutActionValue(const std::string& value, const std::string& default_event_name)
@@ -729,9 +745,8 @@ namespace {
 		}
 	}
 
-	bool CompleteEventForNpc(DynamicZone& expedition, const Event& event_data, const EventNpc& event_npc, Client* notifier)
+	bool CompleteRuntimeEvent(DynamicZone& expedition, const Event& event_data, const std::string& runtime_event_name, Client* notifier)
 	{
-		const std::string runtime_event_name = RuntimeEventName(event_data, event_npc);
 		if (HasCurrentExpeditionLockout(expedition, runtime_event_name) || !TryMarkRuntimeEventComplete(expedition, runtime_event_name)) {
 			return false;
 		}
@@ -751,6 +766,24 @@ namespace {
 		}
 
 		return true;
+	}
+
+	bool CompleteEventForNpc(DynamicZone& expedition, const Event& event_data, const EventNpc& event_npc, Client* notifier)
+	{
+		if (IsGroupedBossCompletionMode(event_data)) {
+			if (!IsGroupedBossRequirement(event_npc)) {
+				return false;
+			}
+
+			if (
+				Strings::EqualFold(event_data.completion_mode, kCompletionModeAllBosses) &&
+				!TryMarkGroupedBossRequirementComplete(expedition, event_data, event_npc)
+			) {
+				return false;
+			}
+		}
+
+		return CompleteRuntimeEvent(expedition, event_data, RuntimeEventName(event_data, event_npc), notifier);
 	}
 }
 
@@ -916,7 +949,8 @@ uint32_t CloneTemplate(Database& db, uint32_t source_template_id, const std::str
 			event_data.lock_on_success,
 			event_data.lock_on_failure,
 			event_data.loot_protected,
-			event_data.sort_order
+			event_data.sort_order,
+			event_data.completion_mode
 		);
 
 		if (!event_id) {
@@ -1107,9 +1141,9 @@ bool DeleteRequestNpc(Database& db, uint32_t template_id, uint32_t zone_id, int3
 	return ok;
 }
 
-uint32_t AddEvent(Database& db, uint32_t template_id, const std::string& event_name)
+uint32_t AddEvent(Database& db, uint32_t template_id, const std::string& event_name, const std::string& completion_mode)
 {
-	const uint32_t id = ExpeditionRepository::InsertEvent(db, template_id, event_name, 0, 0, true, false, false, 0);
+	const uint32_t id = ExpeditionRepository::InsertEvent(db, template_id, event_name, 0, 0, true, false, false, 0, completion_mode);
 	Reload(db);
 	return id;
 }
@@ -1128,6 +1162,17 @@ bool SetEventName(Database& db, uint32_t event_id, const std::string& event_name
 	}
 
 	const bool ok = ExpeditionRepository::UpdateEventName(db, event_id, event_name);
+	Reload(db);
+	return ok;
+}
+
+bool SetEventCompletionMode(Database& db, uint32_t event_id, const std::string& completion_mode)
+{
+	if (!IsKnownCompletionMode(completion_mode) && !Strings::EqualFold(completion_mode, "all") && !Strings::EqualFold(completion_mode, "any")) {
+		return false;
+	}
+
+	const bool ok = ExpeditionRepository::UpdateEventCompletionMode(db, event_id, completion_mode);
 	Reload(db);
 	return ok;
 }
@@ -1208,7 +1253,10 @@ bool DeleteEventNpc(Database& db, uint32_t event_id, uint32_t npc_type_id, uint3
 {
 	bool delete_event = false;
 	auto results = db.QueryDatabase(fmt::format(
-		"SELECT role FROM expedition_template_event_npcs WHERE event_id = {} AND npc_type_id = {} AND spawn2_id = {}",
+		"SELECT n.role, e.completion_mode "
+		"FROM expedition_template_event_npcs n "
+		"INNER JOIN expedition_template_events e ON e.id = n.event_id "
+		"WHERE n.event_id = {} AND n.npc_type_id = {} AND n.spawn2_id = {}",
 		event_id,
 		npc_type_id,
 		spawn2_id
@@ -1220,7 +1268,8 @@ bool DeleteEventNpc(Database& db, uint32_t event_id, uint32_t npc_type_id, uint3
 	for (auto row = results.begin(); row != results.end(); ++row) {
 		EventNpc event_npc;
 		event_npc.role = row[0] ? row[0] : "";
-		if (EventNpcRemovalDeletesEvent(event_npc)) {
+		const std::string completion_mode = row[1] ? row[1] : "";
+		if (EventNpcRemovalDeletesEvent(event_npc) && !IsGroupedBossCompletionMode(completion_mode)) {
 			delete_event = true;
 			break;
 		}
@@ -1229,6 +1278,13 @@ bool DeleteEventNpc(Database& db, uint32_t event_id, uint32_t npc_type_id, uint3
 	const bool ok = delete_event ?
 		ExpeditionRepository::DeleteEvent(db, event_id) :
 		ExpeditionRepository::DeleteEventNpc(db, event_id, npc_type_id, spawn2_id);
+	Reload(db);
+	return ok;
+}
+
+bool DeleteEventNpcMapping(Database& db, uint32_t event_id, uint32_t npc_type_id, uint32_t spawn2_id)
+{
+	const bool ok = ExpeditionRepository::DeleteEventNpc(db, event_id, npc_type_id, spawn2_id);
 	Reload(db);
 	return ok;
 }
@@ -1293,6 +1349,7 @@ void Reload(Database& db)
 	}
 
 	for (auto event_data : *event_rows) {
+		event_data.completion_mode = NormalizeCompletionMode(event_data.completion_mode);
 		auto it = templates.find(event_data.expedition_template_id);
 		if (it != templates.end()) {
 			it->second.events.push_back(event_data);
@@ -1509,8 +1566,23 @@ ValidationResult ValidateTemplate(const Template& template_data)
 
 	size_t event_index = 0;
 	for (const auto& event_data : template_data.events) {
+		if (!IsKnownCompletionMode(event_data.completion_mode)) {
+			result.errors.push_back(fmt::format("Event [{}] has an unknown completion mode [{}].", event_data.event_name, event_data.completion_mode));
+		}
+
 		if (event_data.event_name.empty()) {
 			result.errors.push_back("Event is missing a name.");
+		}
+
+		const bool grouped_boss_event = IsGroupedBossCompletionMode(event_data);
+		if (grouped_boss_event) {
+			if (Strings::EqualFold(event_data.event_name, kSimpleBossEventName)) {
+				result.errors.push_back("Grouped boss events require a custom event name.");
+			}
+
+			if (GroupedBossRequirementCount(event_data) < 2) {
+				result.errors.push_back(fmt::format("Grouped boss event [{}] requires at least two boss targets.", event_data.event_name));
+			}
 		}
 
 		if (event_data.lockout_seconds == 0 && event_data.lock_on_success) {
@@ -1527,7 +1599,15 @@ ValidationResult ValidateTemplate(const Template& template_data)
 				result.errors.push_back(fmt::format("Event [{}] has an NPC mapping without an NPC type.", event_data.event_name));
 			}
 
-			if (event_npc.spawn2_id == 0 && !event_npc.complete_on_spawn) {
+			if (grouped_boss_event && !IsGroupedBossRequirement(event_npc)) {
+				result.errors.push_back(fmt::format("Grouped boss event [{}] has a non-boss or non-death NPC mapping [{}].", event_data.event_name, NpcTypeLabel(event_npc.npc_type_id)));
+			}
+
+			if (grouped_boss_event && event_npc.complete_on_spawn) {
+				result.errors.push_back(fmt::format("Grouped boss event [{}] cannot use spawn-completion NPC mappings.", event_data.event_name));
+			}
+
+			if (event_npc.spawn2_id == 0 && !event_npc.complete_on_spawn && !grouped_boss_event) {
 				result.warnings.push_back(fmt::format("Event [{}] maps NPC [{}] without a spawn-specific id.", event_data.event_name, NpcTypeLabel(event_npc.npc_type_id)));
 			}
 
@@ -1537,6 +1617,13 @@ ValidationResult ValidateTemplate(const Template& template_data)
 			) {
 				result.warnings.push_back(fmt::format("Event NPC [{}] already has a death quest script; verify DB event actions do not duplicate scripted behavior.", NpcTypeLabel(event_npc.npc_type_id)));
 			}
+		}
+
+		if (grouped_boss_event && GroupedBossHasAmbiguousDynamicRequirement(event_data)) {
+			result.errors.push_back(fmt::format(
+				"Grouped boss event [{}] has an ambiguous dynamic boss NPC; a no-spawn-point boss cannot share its NPC type with another grouped boss in the same event.",
+				event_data.event_name
+			));
 		}
 
 		std::unordered_set<std::string> runtime_names;
@@ -1845,6 +1932,16 @@ bool HandleNpcSpawn(NPC& npc)
 				continue;
 			}
 
+			if (
+				IsGroupedBossCompletionMode(event_data) &&
+				BossEventNpcMatchesSpawn(event_npc, npc.GetNPCTypeID(), npc.GetSpawnPointID()) &&
+				HasCurrentExpeditionLockout(*expedition, RuntimeEventName(event_data, event_npc))
+			) {
+				npc.Depop(false);
+				handled = true;
+				continue;
+			}
+
 			ApplyLootEventForNpc(*expedition, event_data, event_npc, npc);
 			if (event_npc.complete_on_spawn) {
 				handled = CompleteEventForNpc(*expedition, event_data, event_npc, nullptr) || handled;
@@ -2062,7 +2159,7 @@ void MaybeShowGmTargetMenu(Client& client, NPC& npc)
 				SendManageRow(client, {
 					{fmt::format("#expedition event loot {}", loot_protected ? "off" : "on"), loot_protected ? "Loot Protection: Off" : "Loot Protection: On"},
 					{"#expedition event lockout", "Set Lockout..."},
-					{"#expedition event npc remove confirm", EventNpcRemovalDeletesEvent(event_npc) ? "Remove Boss/Event" : "Remove from Expedition"}
+					{"#expedition event npc remove confirm", EventNpcRemovalDeletesEvent(event_data, event_npc) ? "Remove Boss/Event" : "Remove from Expedition"}
 				});
 				SendManageRow(client, {
 					{fmt::format("#expedition event completeondeath {}", event_npc.complete_on_death ? "off" : "on"), event_npc.complete_on_death ? "Death Trigger Off" : "Death Trigger On"},
@@ -2120,6 +2217,7 @@ void ClearRuntimeEventState(uint32_t dz_id)
 {
 	if (dz_id != 0) {
 		g_completed_runtime_events.erase(dz_id);
+		g_grouped_boss_progress.erase(dz_id);
 	}
 }
 

--- a/zone/expedition_db.cpp
+++ b/zone/expedition_db.cpp
@@ -324,8 +324,62 @@ namespace {
 			expedition.GetZoneVersion() == dz.GetZoneVersion();
 	}
 
+	DynamicZone* CurrentInstanceExpedition()
+	{
+		DynamicZone* expedition = zone ? zone->GetDynamicZone() : nullptr;
+		if (!expedition || !expedition->IsExpedition() || !expedition->IsCurrentZoneDz()) {
+			return nullptr;
+		}
+
+		return expedition;
+	}
+
+	DynamicZone* RequesterContextExpedition(Client& client)
+	{
+		if (DynamicZone* expedition = CurrentInstanceExpedition()) {
+			return expedition;
+		}
+
+		return client.GetExpedition();
+	}
+
+	bool IsCurrentBaseZoneForTemplate(const Template& template_data)
+	{
+		if (!zone || zone->GetInstanceID() != 0) {
+			return false;
+		}
+
+		return template_data.dz_template.zone_id > 0 &&
+			zone->GetZoneID() == static_cast<uint32_t>(template_data.dz_template.zone_id);
+	}
+
+	bool HasActiveBaseZoneBoss(const Template& template_data)
+	{
+		if (!IsCurrentBaseZoneForTemplate(template_data)) {
+			return false;
+		}
+
+		for (const auto& event_data : template_data.events) {
+			for (const auto& event_npc : event_data.npcs) {
+				if (!IsBaseZoneAvailabilityBoss(event_npc)) {
+					continue;
+				}
+
+				if (entity_list.IsActiveNPCSpawnedByNpcTypeID(event_npc.npc_type_id, event_npc.spawn2_id)) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
 	std::string RequestFailureLabel(const ExpeditionCheckResult& check)
 	{
+		if (IsBaseZoneBossSpawnedReason(check.reason)) {
+			return kBaseZoneBossUnavailableFailure;
+		}
+
 		if (check.reason == "member_already_in_expedition") {
 			return "already in an expedition";
 		}
@@ -361,6 +415,15 @@ namespace {
 		return "request unavailable";
 	}
 
+	std::string RequestMenuNoteLabel(const ExpeditionCheckResult& check)
+	{
+		if (IsBaseZoneBossSpawnedReason(check.reason)) {
+			return kBaseZoneBossUnavailableNote;
+		}
+
+		return RequestFailureLabel(check);
+	}
+
 	std::string RequestStatusLabel(const ExpeditionCheckResult& check)
 	{
 		if (check.success) {
@@ -372,8 +435,7 @@ namespace {
 
 	bool TryCreateTemplateRequest(Client& client, const Template& template_data)
 	{
-		DynamicZone dz = BuildDynamicZone(template_data);
-		const auto check = CheckExpeditionRequest(client, dz, true);
+		const auto check = CheckExpeditionFromTemplate(client, template_data);
 		if (!check.success) {
 			if (!template_data.silent) {
 				client.Message(Chat::Red, fmt::format("Cannot create expedition: {}.", RequestFailureLabel(check)).c_str());
@@ -419,7 +481,7 @@ namespace {
 
 	bool TryLeaveTemplateRequest(Client& client, const Template& template_data)
 	{
-		DynamicZone* expedition = client.GetExpedition();
+		DynamicZone* expedition = RequesterContextExpedition(client);
 		if (!expedition) {
 			client.Message(Chat::Red, "No active expedition.");
 			return true;
@@ -453,7 +515,7 @@ namespace {
 		}
 
 		const bool multi = matches.size() > 1;
-		DynamicZone* active_expedition = client.GetExpedition();
+		DynamicZone* active_expedition = RequesterContextExpedition(client);
 
 		// Each menu entry is either a clickable action (phrase + button label) or an info note.
 		struct MenuEntry {
@@ -462,6 +524,7 @@ namespace {
 			std::string button;
 			std::string status;
 			std::string note;
+			bool status_block = false;
 		};
 		std::vector<MenuEntry> entries;
 		entries.reserve(matches.size());
@@ -494,15 +557,15 @@ namespace {
 				}
 			}
 			else {
-				DynamicZone dz = BuildDynamicZone(*template_data);
-				const auto check = CheckExpeditionRequest(client, dz, true);
+				const auto check = CheckExpeditionFromTemplate(client, *template_data);
 				entry.status = RequestStatusLabel(check);
 				if (check.success) {
 					entry.phrase = RequestMenuPhrase(template_data->id);
 					entry.button = "Form Expedition";
 				}
 				else {
-					entry.note = RequestFailureLabel(check);
+					entry.note = RequestMenuNoteLabel(check);
+					entry.status_block = IsRequesterStatusBlockReason(check.reason);
 				}
 			}
 			entries.push_back(std::move(entry));
@@ -517,7 +580,7 @@ namespace {
 		client.Message(Chat::NPCQuestSay, "%s", title.c_str());
 		client.Message(Chat::NPCQuestSay, "%s", kManageRule);
 		for (const auto& entry : entries) {
-			const std::string status = entry.note.empty() ? entry.status : fmt::format("{} ({})", entry.status, entry.note);
+			const std::string status = (entry.note.empty() || entry.status_block) ? entry.status : fmt::format("{} ({})", entry.status, entry.note);
 			if (!entry.phrase.empty()) {
 				const std::string action = Saylink::Silent(entry.phrase, fmt::format("[ {} ]", entry.button));
 				const std::string line = multi ?
@@ -532,6 +595,9 @@ namespace {
 				fmt::format("   {}", status);
 			const uint16_t chat_type = entry.status == "Locked" ? Chat::Red : Chat::Yellow;
 			client.Message(chat_type, "%s", line.c_str());
+			if (entry.status_block && !entry.note.empty()) {
+				client.Message(chat_type, "      %s", entry.note.c_str());
+			}
 		}
 		client.Message(Chat::NPCQuestSay, "%s", kManageRule);
 	}
@@ -686,6 +752,37 @@ namespace {
 
 		return true;
 	}
+}
+
+bool IsBossSpawnBlockedByActiveLockout(uint32_t npc_type_id, uint32_t spawn2_id)
+{
+	if (!zone || npc_type_id == 0) {
+		return false;
+	}
+
+	DynamicZone* expedition = zone->GetDynamicZone();
+	if (!expedition || !expedition->IsExpedition() || !expedition->IsCurrentZoneDz()) {
+		return false;
+	}
+
+	const Template* template_data = FindTemplateByDz(*expedition);
+	if (!template_data) {
+		return false;
+	}
+
+	for (const auto& event_data : template_data->events) {
+		for (const auto& event_npc : event_data.npcs) {
+			if (!BossEventNpcMatchesSpawn(event_npc, npc_type_id, spawn2_id)) {
+				continue;
+			}
+
+			if (HasCurrentExpeditionLockout(*expedition, RuntimeEventName(event_data, event_npc))) {
+				return true;
+			}
+		}
+	}
+
+	return false;
 }
 
 std::string ValidationResult::StatusName() const
@@ -1504,6 +1601,10 @@ DynamicZone* CreateExpeditionFromTemplate(Client& client, const Template& templa
 		return nullptr;
 	}
 
+	if (HasActiveBaseZoneBoss(template_data)) {
+		return nullptr;
+	}
+
 	DynamicZone dz = BuildDynamicZone(template_data);
 	ExpeditionCreationOptions options;
 	options.silent = template_data.silent;
@@ -1550,6 +1651,11 @@ ExpeditionCheckResult CheckExpeditionFromTemplate(Client& client, const Template
 	ExpeditionCheckResult result;
 	if (!allow_disabled && !template_data.enabled) {
 		result.reason = "template_disabled";
+		return result;
+	}
+
+	if (HasActiveBaseZoneBoss(template_data)) {
+		result.reason = kBaseZoneBossSpawnedReason;
 		return result;
 	}
 

--- a/zone/expedition_db.h
+++ b/zone/expedition_db.h
@@ -29,6 +29,9 @@ inline constexpr const char* kSimpleRequestPhrase = "expedition";
 inline constexpr const char* kRequesterLastName = "Expeditions";
 inline constexpr const char* kSimpleRequestMode = "db_only";
 inline constexpr const char* kSimpleBossEventName = "Boss Defeated";
+inline constexpr const char* kCompletionModeFirst = "first_completion";
+inline constexpr const char* kCompletionModeAllBosses = "all_bosses";
+inline constexpr const char* kCompletionModeAnyBoss = "any_boss";
 inline constexpr const char* kBaseZoneBossSpawnedReason = "base_zone_boss_spawned";
 inline constexpr const char* kBaseZoneBossUnavailableStatus = "Unavailable";
 inline constexpr const char* kBaseZoneBossUnavailableNote = "while associated bosses are spawned in the base zone.";
@@ -70,6 +73,7 @@ struct Event {
 	uint32_t id = 0;
 	uint32_t expedition_template_id = 0;
 	std::string event_name;
+	std::string completion_mode = kCompletionModeFirst;
 	uint32_t lockout_seconds = 0;
 	uint32_t replay_lockout_seconds = 0;
 	bool lock_on_success = true;
@@ -83,6 +87,87 @@ struct Event {
 inline bool IsBossEventNpc(const EventNpc& event_npc)
 {
 	return Strings::EqualFold(event_npc.role, "boss");
+}
+
+inline bool IsKnownCompletionMode(const std::string& completion_mode)
+{
+	return Strings::EqualFold(completion_mode, kCompletionModeFirst) ||
+		Strings::EqualFold(completion_mode, kCompletionModeAllBosses) ||
+		Strings::EqualFold(completion_mode, kCompletionModeAnyBoss);
+}
+
+inline std::string NormalizeCompletionMode(const std::string& completion_mode)
+{
+	if (Strings::EqualFold(completion_mode, kCompletionModeAllBosses) || Strings::EqualFold(completion_mode, "all")) {
+		return kCompletionModeAllBosses;
+	}
+
+	if (Strings::EqualFold(completion_mode, kCompletionModeAnyBoss) || Strings::EqualFold(completion_mode, "any")) {
+		return kCompletionModeAnyBoss;
+	}
+
+	return kCompletionModeFirst;
+}
+
+inline bool IsGroupedBossCompletionMode(const std::string& completion_mode)
+{
+	return Strings::EqualFold(completion_mode, kCompletionModeAllBosses) ||
+		Strings::EqualFold(completion_mode, kCompletionModeAnyBoss);
+}
+
+inline bool IsGroupedBossCompletionMode(const Event& event_data)
+{
+	return IsGroupedBossCompletionMode(event_data.completion_mode);
+}
+
+inline bool IsGroupedBossRequirement(const EventNpc& event_npc)
+{
+	return IsBossEventNpc(event_npc) && event_npc.npc_type_id != 0 && event_npc.complete_on_death;
+}
+
+inline bool GroupedBossRequirementMatchesSpawn(const EventNpc& event_npc, uint32_t npc_type_id, uint32_t spawn2_id)
+{
+	if (!IsGroupedBossRequirement(event_npc) || event_npc.npc_type_id != npc_type_id) {
+		return false;
+	}
+
+	return event_npc.spawn2_id == 0 || event_npc.spawn2_id == spawn2_id;
+}
+
+inline uint32_t GroupedBossRequirementCount(const Event& event_data)
+{
+	return static_cast<uint32_t>(std::ranges::count_if(event_data.npcs, IsGroupedBossRequirement));
+}
+
+inline bool GroupedBossRequirementsComplete(const Event& event_data, const std::unordered_set<uint32_t>& completed_event_npc_ids)
+{
+	for (const auto& event_npc : event_data.npcs) {
+		if (IsGroupedBossRequirement(event_npc) && !completed_event_npc_ids.contains(event_npc.id)) {
+			return false;
+		}
+	}
+
+	return GroupedBossRequirementCount(event_data) > 0;
+}
+
+inline bool GroupedBossHasAmbiguousDynamicRequirement(const Event& event_data)
+{
+	std::unordered_map<uint32_t, uint32_t> requirement_count_by_npc_type;
+	std::unordered_set<uint32_t> dynamic_requirement_npc_types;
+	for (const auto& event_npc : event_data.npcs) {
+		if (!IsGroupedBossRequirement(event_npc)) {
+			continue;
+		}
+
+		requirement_count_by_npc_type[event_npc.npc_type_id]++;
+		if (event_npc.spawn2_id == 0) {
+			dynamic_requirement_npc_types.insert(event_npc.npc_type_id);
+		}
+	}
+
+	return std::ranges::any_of(dynamic_requirement_npc_types, [&](uint32_t npc_type_id) {
+		return requirement_count_by_npc_type[npc_type_id] > 1;
+	});
 }
 
 inline bool IsBaseZoneAvailabilityBoss(const EventNpc& event_npc)
@@ -107,6 +192,11 @@ inline bool BaseZoneAvailabilityBossMatchesSpawn(const EventNpc& event_npc, uint
 inline bool EventNpcRemovalDeletesEvent(const EventNpc& event_npc)
 {
 	return IsBossEventNpc(event_npc);
+}
+
+inline bool EventNpcRemovalDeletesEvent(const Event& event_data, const EventNpc& event_npc)
+{
+	return EventNpcRemovalDeletesEvent(event_npc) && !IsGroupedBossCompletionMode(event_data);
 }
 
 struct Template {
@@ -311,9 +401,10 @@ bool SetDzTemplateCompass(Database& db, uint32_t dz_template_id, uint32_t zone_i
 bool SetDzTemplateSwitchID(Database& db, uint32_t dz_template_id, uint32_t switch_id);
 uint32_t UpsertRequestNpc(Database& db, uint32_t template_id, uint32_t zone_id, uint32_t npc_type_id, uint32_t spawn2_id, const std::string& phrase, int32_t zone_version = -1);
 bool DeleteRequestNpc(Database& db, uint32_t template_id, uint32_t zone_id, int32_t zone_version, uint32_t npc_type_id, uint32_t spawn2_id);
-uint32_t AddEvent(Database& db, uint32_t template_id, const std::string& event_name);
+uint32_t AddEvent(Database& db, uint32_t template_id, const std::string& event_name, const std::string& completion_mode = kCompletionModeFirst);
 bool DeleteEvent(Database& db, uint32_t event_id);
 bool SetEventName(Database& db, uint32_t event_id, const std::string& event_name);
+bool SetEventCompletionMode(Database& db, uint32_t event_id, const std::string& completion_mode);
 bool SetEventLockout(Database& db, uint32_t event_id, uint32_t seconds);
 bool SetEventReplay(Database& db, uint32_t event_id, uint32_t seconds);
 bool SetEventNpc(Database& db, uint32_t event_id, uint32_t npc_type_id, uint32_t spawn2_id, const std::string& role);
@@ -321,6 +412,7 @@ bool SetEventNpcLoot(Database& db, uint32_t event_id, uint32_t npc_type_id, uint
 bool SetEventNpcCompleteOnDeath(Database& db, uint32_t event_id, uint32_t npc_type_id, uint32_t spawn2_id, bool enabled);
 bool SetEventNpcCompleteOnSpawn(Database& db, uint32_t event_id, uint32_t npc_type_id, uint32_t spawn2_id, bool enabled);
 bool DeleteEventNpc(Database& db, uint32_t event_id, uint32_t npc_type_id, uint32_t spawn2_id);
+bool DeleteEventNpcMapping(Database& db, uint32_t event_id, uint32_t npc_type_id, uint32_t spawn2_id);
 uint32_t AddAction(Database& db, uint32_t event_id, const std::string& action_type, const std::string& action_value);
 bool ClearActions(Database& db, uint32_t event_id);
 

--- a/zone/expedition_db.h
+++ b/zone/expedition_db.h
@@ -29,6 +29,12 @@ inline constexpr const char* kSimpleRequestPhrase = "expedition";
 inline constexpr const char* kRequesterLastName = "Expeditions";
 inline constexpr const char* kSimpleRequestMode = "db_only";
 inline constexpr const char* kSimpleBossEventName = "Boss Defeated";
+inline constexpr const char* kBaseZoneBossSpawnedReason = "base_zone_boss_spawned";
+inline constexpr const char* kBaseZoneBossUnavailableStatus = "Unavailable";
+inline constexpr const char* kBaseZoneBossUnavailableNote = "while associated bosses are spawned in the base zone.";
+inline constexpr const char* kBaseZoneBossUnavailableMessage = "Unavailable while associated bosses are spawned in the base zone.";
+inline constexpr const char* kBaseZoneBossUnavailableFailure = "unavailable while associated bosses are spawned in the base zone";
+inline constexpr uint32_t kBossLockoutSpawnRetryMilliseconds = 60000;
 
 struct RequestNpc {
 	uint32_t id = 0;
@@ -77,6 +83,25 @@ struct Event {
 inline bool IsBossEventNpc(const EventNpc& event_npc)
 {
 	return Strings::EqualFold(event_npc.role, "boss");
+}
+
+inline bool IsBaseZoneAvailabilityBoss(const EventNpc& event_npc)
+{
+	return IsBossEventNpc(event_npc) && event_npc.npc_type_id != 0;
+}
+
+inline bool BossEventNpcMatchesSpawn(const EventNpc& event_npc, uint32_t npc_type_id, uint32_t spawn2_id)
+{
+	if (!IsBaseZoneAvailabilityBoss(event_npc) || event_npc.npc_type_id != npc_type_id) {
+		return false;
+	}
+
+	return event_npc.spawn2_id == 0 || event_npc.spawn2_id == spawn2_id;
+}
+
+inline bool BaseZoneAvailabilityBossMatchesSpawn(const EventNpc& event_npc, uint32_t npc_type_id, uint32_t spawn2_id)
+{
+	return BossEventNpcMatchesSpawn(event_npc, npc_type_id, spawn2_id);
 }
 
 inline bool EventNpcRemovalDeletesEvent(const EventNpc& event_npc)
@@ -159,9 +184,32 @@ inline bool IsRequesterLockoutReason(const std::string& reason)
 	return reason == "replay_lockout" || reason == "event_lockout_conflict";
 }
 
+inline bool IsBaseZoneBossSpawnedReason(const std::string& reason)
+{
+	return reason == kBaseZoneBossSpawnedReason;
+}
+
+inline bool IsRequesterStatusBlockReason(const std::string& reason)
+{
+	return IsBaseZoneBossSpawnedReason(reason);
+}
+
 inline bool SharesExpeditionLockoutNamespace(const Template& lhs, const Template& rhs)
 {
 	return Strings::EqualFold(lhs.dz_template.name, rhs.dz_template.name);
+}
+
+inline bool TemplateHasBaseZoneAvailabilityBossForSpawn(const Template& template_data, uint32_t npc_type_id, uint32_t spawn2_id)
+{
+	for (const auto& event_data : template_data.events) {
+		for (const auto& event_npc : event_data.npcs) {
+			if (BaseZoneAvailabilityBossMatchesSpawn(event_npc, npc_type_id, spawn2_id)) {
+				return true;
+			}
+		}
+	}
+
+	return false;
 }
 
 struct ValidationResult {
@@ -296,6 +344,7 @@ ExpeditionCheckResult CheckExpeditionFromTemplate(Client& client, const std::str
 bool HandleRequestSay(Client& client, NPC& npc, const std::string& message);
 bool HandleNpcDeath(NPC& npc, Client* killer);
 bool HandleNpcSpawn(NPC& npc);
+bool IsBossSpawnBlockedByActiveLockout(uint32_t npc_type_id, uint32_t spawn2_id);
 BossOnlySpawnFilter GetBossOnlySpawnFilter(DynamicZone* expedition);
 // Stamps the "Expeditions" surname on configured requester NPCs (and clears a stale one when an
 // NPC is no longer a requester). Safe to call for any NPC spawn in any zone.

--- a/zone/expedition_repository.cpp
+++ b/zone/expedition_repository.cpp
@@ -125,7 +125,7 @@ std::optional<std::vector<ExpeditionDB::Event>> LoadAllEvents(Database& db)
 	std::vector<ExpeditionDB::Event> out;
 	auto results = db.QueryDatabase(
 		"SELECT id, expedition_template_id, event_name, lockout_seconds, replay_lockout_seconds, "
-		"lock_on_success, lock_on_failure, loot_protected, sort_order "
+		"lock_on_success, lock_on_failure, loot_protected, sort_order, completion_mode "
 		"FROM expedition_template_events ORDER BY expedition_template_id, sort_order, id"
 	);
 
@@ -145,6 +145,7 @@ std::optional<std::vector<ExpeditionDB::Event>> LoadAllEvents(Database& db)
 		e.lock_on_failure = Truthy(row[6]);
 		e.loot_protected = Truthy(row[7]);
 		e.sort_order = Int(row[8]);
+		e.completion_mode = ExpeditionDB::NormalizeCompletionMode(Text(row[9]));
 		out.push_back(std::move(e));
 	}
 
@@ -405,12 +406,13 @@ uint32_t InsertEvent(
 	bool lock_on_success,
 	bool lock_on_failure,
 	bool loot_protected,
-	int32_t sort_order)
+	int32_t sort_order,
+	const std::string& completion_mode)
 {
 	return InsertID(db, fmt::format(
 		"INSERT INTO expedition_template_events "
-		"(expedition_template_id, event_name, lockout_seconds, replay_lockout_seconds, lock_on_success, lock_on_failure, loot_protected, sort_order) "
-		"VALUES ({}, '{}', {}, {}, {}, {}, {}, {})",
+		"(expedition_template_id, event_name, lockout_seconds, replay_lockout_seconds, lock_on_success, lock_on_failure, loot_protected, sort_order, completion_mode) "
+		"VALUES ({}, '{}', {}, {}, {}, {}, {}, {}, '{}')",
 		template_id,
 		Escape(event_name),
 		lockout_seconds,
@@ -418,7 +420,8 @@ uint32_t InsertEvent(
 		lock_on_success ? 1 : 0,
 		lock_on_failure ? 1 : 0,
 		loot_protected ? 1 : 0,
-		sort_order
+		sort_order,
+		Escape(ExpeditionDB::NormalizeCompletionMode(completion_mode))
 	));
 }
 
@@ -427,6 +430,15 @@ bool UpdateEventName(Database& db, uint32_t event_id, const std::string& event_n
 	return QueryOK(db, fmt::format(
 		"UPDATE expedition_template_events SET event_name = '{}' WHERE id = {}",
 		Escape(event_name),
+		event_id
+	));
+}
+
+bool UpdateEventCompletionMode(Database& db, uint32_t event_id, const std::string& completion_mode)
+{
+	return QueryOK(db, fmt::format(
+		"UPDATE expedition_template_events SET completion_mode = '{}' WHERE id = {}",
+		Escape(ExpeditionDB::NormalizeCompletionMode(completion_mode)),
 		event_id
 	));
 }

--- a/zone/expedition_repository.h
+++ b/zone/expedition_repository.h
@@ -91,10 +91,12 @@ uint32_t InsertEvent(
 	bool lock_on_success,
 	bool lock_on_failure,
 	bool loot_protected,
-	int32_t sort_order
+	int32_t sort_order,
+	const std::string& completion_mode = ExpeditionDB::kCompletionModeFirst
 );
 
 bool UpdateEventName(Database& db, uint32_t event_id, const std::string& event_name);
+bool UpdateEventCompletionMode(Database& db, uint32_t event_id, const std::string& completion_mode);
 bool UpdateEventLockout(Database& db, uint32_t event_id, uint32_t seconds);
 bool UpdateEventReplay(Database& db, uint32_t event_id, uint32_t seconds);
 bool DeleteEvent(Database& db, uint32_t event_id);

--- a/zone/gm_commands/expedition.cpp
+++ b/zone/gm_commands/expedition.cpp
@@ -605,15 +605,52 @@ namespace {
 		return zone_id ? fmt::format("{} ({})", ZoneLongName(zone_id), ZoneName(zone_id, true)) : "unset";
 	}
 
-	// Same, with an explicit version suffix: "Nagafen's Lair (soldungb) v0".
+	std::string ExpeditionVersionOptionLabel(uint32_t zone_version)
+	{
+		switch (zone_version) {
+		case 0:
+			return "0 base zone";
+		case 1:
+			return "1 Normal Raids";
+		case 2:
+			return "2 Ancient Raids";
+		case 3:
+			return "3 Hard Mode Raids";
+		case 4:
+			return "4 Challenge Normal";
+		case 5:
+			return "5 Challenge Hard";
+		default:
+			return fmt::format("v{}", zone_version);
+		}
+	}
+
+	std::string ExpeditionVersionDisplay(int32_t zone_version)
+	{
+		if (zone_version == -1) {
+			return "v*";
+		}
+
+		if (zone_version < 0) {
+			return fmt::format("v{}", zone_version);
+		}
+
+		return ExpeditionVersionOptionLabel(static_cast<uint32_t>(zone_version));
+	}
+
+	bool IsExpeditionVersionOption(uint32_t zone_version)
+	{
+		return zone_version <= 5;
+	}
+
+	// Same, with an explicit version suffix: "Nagafen's Lair (soldungb) 0 base zone".
 	std::string ZoneVersionLabel(uint32_t zone_id, int32_t zone_version)
 	{
 		if (!zone_id) {
 			return "unset";
 		}
-		return zone_version == -1 ?
-			fmt::format("{} v*", ZoneLabel(zone_id)) :
-			fmt::format("{} v{}", ZoneLabel(zone_id), zone_version);
+
+		return fmt::format("{} {}", ZoneLabel(zone_id), ExpeditionVersionDisplay(zone_version));
 	}
 
 	std::string NpcMappingLabel(uint32_t npc_type_id, uint32_t spawn2_id)
@@ -1781,8 +1818,12 @@ std::vector<uint32_t> ExistingZoneVersions(uint32_t zone_id)
 	return versions;
 }
 
-bool ZoneVersionExists(uint32_t zone_id, uint32_t zone_version)
+bool IsSelectableZoneVersion(uint32_t zone_id, uint32_t zone_version)
 {
+	if (IsExpeditionVersionOption(zone_version)) {
+		return true;
+	}
+
 	const auto versions = ExistingZoneVersions(zone_id);
 	return std::ranges::find(versions, zone_version) != versions.end();
 }
@@ -1806,33 +1847,18 @@ void ShowVersionScreen(Client* c, const ExpeditionDB::Template& template_data)
 		return;
 	}
 
-	c->Message(Chat::White, fmt::format("  Current Version: {}", dz.zone_version).c_str());
-
-	const auto versions = ExistingZoneVersions(dz.zone_id);
-	if (versions.empty()) {
-		c->Message(Chat::Yellow, fmt::format(
-			"  No loaded zone versions were found for {}. Use #expedition set zone <zone|id> [version].",
-			ZoneLabel(dz.zone_id)
-		).c_str());
-	}
-	else {
-		std::string line = "  Zone Versions: ";
-		for (size_t i = 0; i < versions.size(); ++i) {
-			if (i != 0) {
-				line += " ";
-			}
-
-			const auto version = versions[i];
-			const bool is_current = static_cast<int32_t>(version) == dz.zone_version;
-			const std::string label = is_current ?
-				fmt::format("[{}]", version) :
-				fmt::format("{}", version);
-
-			line += Saylink::Silent(fmt::format("#expedition config version {}", version), label);
-		}
-
-		c->Message(Chat::White, line.c_str());
-	}
+	c->Message(Chat::White, fmt::format("  Current Version: {}", ExpeditionVersionDisplay(dz.zone_version)).c_str());
+	c->Message(Chat::White, "  Zone Versions:");
+	SendActionRow(c, {
+		{"#expedition config version 0", ExpeditionVersionOptionLabel(0)},
+		{"#expedition config version 1", ExpeditionVersionOptionLabel(1)},
+		{"#expedition config version 2", ExpeditionVersionOptionLabel(2)}
+	});
+	SendActionRow(c, {
+		{"#expedition config version 3", ExpeditionVersionOptionLabel(3)},
+		{"#expedition config version 4", ExpeditionVersionOptionLabel(4)},
+		{"#expedition config version 5", ExpeditionVersionOptionLabel(5)}
+	});
 
 	SendActionRow(c, {{"#expedition config", "Back to Config"}});
 	SendCardBottom(c);
@@ -1974,10 +2000,10 @@ void HandleConfig(Client* c, const Seperator* sep)
 			}
 
 			const uint32_t version = Strings::ToUnsignedInt(sep->arg[3]);
-			if (!ZoneVersionExists(dz.zone_id, version)) {
+			if (!IsSelectableZoneVersion(dz.zone_id, version)) {
 				c->Message(Chat::Red, fmt::format(
-					"Zone version [{}] does not exist for {}.",
-					version,
+					"Zone version [{}] is not available for {}.",
+					ExpeditionVersionOptionLabel(version),
 					ZoneLabel(dz.zone_id)
 				).c_str());
 				ShowVersionScreen(c, *template_data);
@@ -1985,7 +2011,7 @@ void HandleConfig(Client* c, const Seperator* sep)
 			}
 
 			ExpeditionDB::SetDzTemplateZone(content_db, dz_template_id, dz.zone_id, version);
-			c->Message(Chat::Green, fmt::format("Set zone version to [{}].", version).c_str());
+			c->Message(Chat::Green, fmt::format("Set zone version to [{}].", ExpeditionVersionOptionLabel(version)).c_str());
 			if (const auto* refreshed = ExpeditionDB::FindTemplate(template_id)) {
 				ShowVersionScreen(c, *refreshed);
 			}

--- a/zone/gm_commands/expedition.cpp
+++ b/zone/gm_commands/expedition.cpp
@@ -299,6 +299,32 @@ namespace {
 		return "DB automatic request handling";
 	}
 
+	std::string CompletionModeLabel(const std::string& completion_mode)
+	{
+		if (Strings::EqualFold(completion_mode, ExpeditionDB::kCompletionModeAllBosses)) {
+			return "All grouped bosses";
+		}
+
+		if (Strings::EqualFold(completion_mode, ExpeditionDB::kCompletionModeAnyBoss)) {
+			return "Any grouped boss";
+		}
+
+		return "First completion";
+	}
+
+	std::string GroupCompletionModeFromArg(const char* value)
+	{
+		if (Strings::EqualFold(value, "all") || Strings::EqualFold(value, ExpeditionDB::kCompletionModeAllBosses)) {
+			return ExpeditionDB::kCompletionModeAllBosses;
+		}
+
+		if (Strings::EqualFold(value, "any") || Strings::EqualFold(value, ExpeditionDB::kCompletionModeAnyBoss)) {
+			return ExpeditionDB::kCompletionModeAnyBoss;
+		}
+
+		return {};
+	}
+
 	std::string StatusLabel(const ExpeditionDB::ValidationResult& validation)
 	{
 		if (!validation.errors.empty()) {
@@ -696,6 +722,11 @@ namespace {
 	{
 		std::vector<std::string> names;
 		for (const auto& event_data : template_data.events) {
+			if (ExpeditionDB::IsGroupedBossCompletionMode(event_data)) {
+				names.push_back(fmt::format("{} ({}, {} bosses)", event_data.event_name, CompletionModeLabel(event_data.completion_mode), ExpeditionDB::GroupedBossRequirementCount(event_data)));
+				continue;
+			}
+
 			if (IsBossCompletionEvent(event_data)) {
 				for (const auto& event_npc : event_data.npcs) {
 					if (event_npc.npc_type_id != 0 && event_npc.complete_on_death) {
@@ -853,6 +884,7 @@ namespace {
 				{
 					{"#expedition boss 6h", "Use Target Boss"},
 					{"#expedition boss 6h loot", "Use Target Boss With Loot"},
+					{"#expedition event group", "New Boss Group"},
 					{"#expedition event list", "List Events"}
 				}
 			};
@@ -1058,6 +1090,7 @@ namespace {
 
 		SendSectionHeader(c, "Event Basics");
 		SendHelpLink(c, "#expedition event add \"Event Name\"", "add and select a DB event");
+		SendHelpLink(c, "#expedition event group", "create or manage a grouped boss event");
 		SendHelpLink(c, "#expedition event select <id|name>", "select event for short follow-up commands");
 		SendHelpLink(c, "#expedition event list", "list events on selected expedition");
 		SendHelpLink(c, "#expedition event rename", "show event rename commands");
@@ -1081,6 +1114,7 @@ namespace {
 
 		SendActionGroup(c, "Event Actions", {
 			{"#expedition event add \"Boss Defeated\"", "Add Boss Event"},
+			{"#expedition event group", "New Boss Group"},
 			{"#expedition event list", "List Events"},
 			{"#expedition event npc", "Add Target as Event NPC"},
 			{"#expedition event lockout 6h", "6h Lockout"},
@@ -1089,6 +1123,66 @@ namespace {
 		if (const auto* template_data = SelectedTemplate(c)) {
 			RefreshBuilderView(c);
 		}
+	}
+
+	void ShowGroupedBossEventCard(Client* c, const ExpeditionDB::Event* event_data)
+	{
+		SendCardTop(c, event_data ? fmt::format("Boss Group: {} [{}]", event_data->event_name, event_data->id) : "New Boss Group");
+		if (!event_data) {
+			c->Message(Chat::White, "  Create a shared boss event with a custom lockout name.");
+			c->Message(Chat::White, "  Click a policy, finish the command with an event name, then target bosses and add them to the group.");
+			c->Message(Chat::White, fmt::format("  {}   {}",
+				Saylink::Create("#expedition event group new all ", false, "[ Require All Bosses ]"),
+				Saylink::Create("#expedition event group new any ", false, "[ Any Boss Completes ]")).c_str());
+			SendActionRow(c, {{"#expedition event list", "Back to Events"}});
+			SendCardBottom(c);
+			return;
+		}
+
+		SendInfoLine(c, "Policy", CompletionModeLabel(event_data->completion_mode));
+		SendInfoLine(c, "Lockout", Duration(event_data->lockout_seconds));
+		SendInfoLine(c, "Replay", Duration(event_data->replay_lockout_seconds));
+		SendInfoLine(c, "Bosses", fmt::format("{} target(s)", ExpeditionDB::GroupedBossRequirementCount(*event_data)));
+		c->Message(Chat::White, ChatSeparator());
+
+		uint32_t boss_index = 0;
+		for (const auto& event_npc : event_data->npcs) {
+			if (!ExpeditionDB::IsGroupedBossRequirement(event_npc)) {
+				continue;
+			}
+
+			const std::string mapping_type = event_npc.spawn2_id == 0 ? "dynamic npc-type" : "spawn-specific";
+			c->Message(Chat::White, fmt::format(
+				"   {:>2}. {}   ({})",
+				++boss_index,
+				NpcMappingLabel(event_npc.npc_type_id, event_npc.spawn2_id),
+				mapping_type
+			).c_str());
+		}
+
+		if (boss_index == 0) {
+			c->Message(Chat::Gray, "   (target a boss and click Add Target Boss)");
+		}
+
+		c->Message(Chat::White, ChatSeparator());
+		c->Message(Chat::White, "  Boss Targets:");
+		SendActionRow(c, {
+			{"#expedition event group add", "Add Target Boss"},
+			{"#expedition event group remove", "Remove Target Boss"}
+		});
+		c->Message(Chat::White, "  Completion Policy:");
+		SendActionRow(c, {
+			{"#expedition event group mode all", "Require All Bosses"},
+			{"#expedition event group mode any", "Any Boss Completes"}
+		});
+		c->Message(Chat::White, "  Event Settings:");
+		SendActionRow(c, {
+			{fmt::format("#expedition event rename {} \"{}\"", event_data->id, event_data->event_name), "Rename"},
+			{"#expedition event lockout", "Lockout..."},
+			{"#expedition event replay 2h", "Replay 2h"},
+			{fmt::format("#expedition event remove {}", event_data->id), "Delete Event"}
+		});
+		SendCardBottom(c);
 	}
 
 	void ShowTestHelp(Client* c)
@@ -1245,8 +1339,8 @@ namespace {
 		}
 		uint32_t roster_index = 0;
 		for (const auto& event_data : template_data.events) {
-			c->Message(Chat::LightBlue, fmt::format("  Event: {}   -   lockout {}",
-				event_data.event_name, Duration(event_data.lockout_seconds)).c_str());
+			c->Message(Chat::LightBlue, fmt::format("  Event: {}   -   {}   -   lockout {}",
+				event_data.event_name, CompletionModeLabel(event_data.completion_mode), Duration(event_data.lockout_seconds)).c_str());
 			bool any_npc = false;
 			for (const auto& event_npc : event_data.npcs) {
 				if (Strings::EqualFold(event_npc.role, "chest") || event_npc.complete_on_spawn) {
@@ -1331,8 +1425,9 @@ namespace {
 
 		for (const auto& event_data : template_data.events) {
 			c->Message(Chat::White, fmt::format(
-				"Event [{}] lockout [{}] replay [{}] npcs [{}] actions [{}]",
+				"Event [{}] mode [{}] lockout [{}] replay [{}] npcs [{}] actions [{}]",
 				event_data.event_name,
+				CompletionModeLabel(event_data.completion_mode),
 				Duration(event_data.lockout_seconds),
 				Duration(event_data.replay_lockout_seconds),
 				event_data.npcs.size(),
@@ -1736,6 +1831,12 @@ void ShowEditScreen(Client* c, const ExpeditionDB::Template& template_data)
 			template_data.enabled
 				? std::pair<std::string, std::string>{"#expedition disable", "Unpublish"}
 				: std::pair<std::string, std::string>{"#expedition publish", "Publish"}
+		});
+		c->Message(Chat::White, "  Encounters:");
+		SendActionRow(c, {
+			{"#expedition boss 6h loot", "Target Boss"},
+			{"#expedition event group", "New Boss Group"},
+			{"#expedition event list", "Event List"}
 		});
 		c->Message(Chat::White, "  Navigate:");
 		SendActionRow(c, {
@@ -3245,6 +3346,167 @@ void HandleSet(Client* c, const Seperator* sep)
 		RefreshBuilderView(c);
 }
 
+void HandleEventGroup(Client* c, const Seperator* sep, const ExpeditionDB::Template& template_data)
+{
+		const std::string sub_action = Strings::ToLower(sep->arg[3]);
+		if (sub_action.empty() || sub_action == "help") {
+			const auto* selected_event = SelectedEvent(c, template_data);
+			ShowGroupedBossEventCard(c, selected_event && ExpeditionDB::IsGroupedBossCompletionMode(*selected_event) ? selected_event : nullptr);
+			return;
+		}
+
+		if (sub_action == "new") {
+			const std::string completion_mode = GroupCompletionModeFromArg(sep->arg[4]);
+			const std::string event_name = CommandTail(sep, 5);
+			if (completion_mode.empty() || event_name.empty()) {
+				c->Message(Chat::Red, "Usage: #expedition event group new all|any \"Custom Event Name\"");
+				ShowGroupedBossEventCard(c, nullptr);
+				return;
+			}
+
+			if (Strings::EqualFold(event_name, ExpeditionDB::kSimpleBossEventName)) {
+				c->Message(Chat::Red, "Grouped boss events require a custom event name.");
+				ShowGroupedBossEventCard(c, nullptr);
+				return;
+			}
+
+			const uint32_t event_id = ExpeditionDB::AddEvent(content_db, template_data.id, event_name, completion_mode);
+			if (!event_id) {
+				c->Message(Chat::Red, "Failed to create grouped boss event.");
+				return;
+			}
+
+			ExpeditionDB::SetSelectedEvent(c->CharacterID(), event_id);
+			if (
+				!ExpeditionDB::SetEventLockout(content_db, event_id, ExpeditionDB::kSimpleBossLockoutSeconds) ||
+				!ExpeditionDB::SetEventReplay(content_db, event_id, ExpeditionDB::kSimpleBossReplaySeconds)
+			) {
+				c->Message(Chat::Red, fmt::format("Created event [{}], but failed to apply default timing.", event_name).c_str());
+				return;
+			}
+
+			c->Message(Chat::Green, fmt::format(
+				"Saved: grouped boss event [{}] uses policy [{}]. Target bosses and click Add Target Boss.",
+				event_name,
+				CompletionModeLabel(completion_mode)
+			).c_str());
+			if (const auto* refreshed_event = ExpeditionDB::FindEvent(event_id)) {
+				ShowGroupedBossEventCard(c, refreshed_event);
+			}
+			return;
+		}
+
+		const auto* event_data = RequireSelectedEvent(c, template_data);
+		if (!event_data) {
+			return;
+		}
+
+		if (!ExpeditionDB::IsGroupedBossCompletionMode(*event_data)) {
+			c->Message(Chat::Red, "Select or create a grouped boss event first.");
+			ShowGroupedBossEventCard(c, nullptr);
+			return;
+		}
+
+		const uint32_t selected_event_id = event_data->id;
+		const std::string selected_event_name = event_data->event_name;
+
+		if (sub_action == "mode") {
+			const std::string completion_mode = GroupCompletionModeFromArg(sep->arg[4]);
+			if (completion_mode.empty()) {
+				c->Message(Chat::Red, "Usage: #expedition event group mode all|any");
+				ShowGroupedBossEventCard(c, event_data);
+				return;
+			}
+
+			if (!ExpeditionDB::SetEventCompletionMode(content_db, selected_event_id, completion_mode)) {
+				c->Message(Chat::Red, fmt::format("Failed to set grouped boss policy for event [{}].", selected_event_name).c_str());
+				return;
+			}
+
+			c->Message(Chat::Green, fmt::format("Saved: grouped boss event [{}] policy is now [{}].", selected_event_name, CompletionModeLabel(completion_mode)).c_str());
+			if (const auto* refreshed_event = ExpeditionDB::FindEvent(selected_event_id)) {
+				ShowGroupedBossEventCard(c, refreshed_event);
+			}
+			return;
+		}
+
+		if (sub_action == "add") {
+			NPC* npc = RequireTargetNpc(c, "Target a boss NPC, then click Add Target Boss again.");
+			if (!npc) {
+				ShowGroupedBossEventCard(c, event_data);
+				return;
+			}
+
+			const uint32_t npc_type_id = npc->GetNPCTypeID();
+			const uint32_t spawn2_id = npc->GetSpawnPointID();
+			const auto* mapped_npc = FindEventNpc(*event_data, *npc);
+			if (mapped_npc && ExpeditionDB::IsGroupedBossRequirement(*mapped_npc)) {
+				c->Message(Chat::Yellow, fmt::format("Target [{}] is already part of grouped event [{}].", NpcLabel(*npc), selected_event_name).c_str());
+				ShowGroupedBossEventCard(c, event_data);
+				return;
+			}
+
+			const bool ambiguous_dynamic = std::ranges::any_of(event_data->npcs, [&](const ExpeditionDB::EventNpc& event_npc) {
+				return ExpeditionDB::IsGroupedBossRequirement(event_npc) &&
+					event_npc.npc_type_id == npc_type_id &&
+					(event_npc.spawn2_id == 0 || spawn2_id == 0);
+			});
+			if (ambiguous_dynamic) {
+				c->Message(Chat::Red, "A dynamic grouped boss without a spawn point cannot share its NPC type with another boss in the same group.");
+				ShowGroupedBossEventCard(c, event_data);
+				return;
+			}
+
+			if (!ExpeditionDB::SetEventNpc(content_db, selected_event_id, npc_type_id, spawn2_id, "boss")) {
+				c->Message(Chat::Red, fmt::format("Failed to add target boss to grouped event [{}].", selected_event_name).c_str());
+				return;
+			}
+
+			c->Message(Chat::Green, fmt::format(
+				"Saved: added boss [{}] to grouped event [{}].",
+				NpcLabel(*npc),
+				selected_event_name
+			).c_str());
+			if (const auto* refreshed_event = ExpeditionDB::FindEvent(selected_event_id)) {
+				ShowGroupedBossEventCard(c, refreshed_event);
+			}
+			return;
+		}
+
+		if (sub_action == "remove") {
+			NPC* npc = RequireTargetNpc(c, "Target a grouped boss, then click Remove Target Boss again.");
+			if (!npc) {
+				ShowGroupedBossEventCard(c, event_data);
+				return;
+			}
+
+			const auto* mapped_npc = FindEventNpc(*event_data, *npc);
+			if (!mapped_npc || !ExpeditionDB::IsGroupedBossRequirement(*mapped_npc)) {
+				c->Message(Chat::Yellow, "Target is not part of the selected grouped boss event.");
+				ShowGroupedBossEventCard(c, event_data);
+				return;
+			}
+
+			if (!ExpeditionDB::DeleteEventNpcMapping(content_db, selected_event_id, mapped_npc->npc_type_id, mapped_npc->spawn2_id)) {
+				c->Message(Chat::Red, fmt::format("Failed to remove target boss from grouped event [{}].", selected_event_name).c_str());
+				return;
+			}
+
+			c->Message(Chat::Green, fmt::format(
+				"Saved: removed boss [{}] from grouped event [{}].",
+				NpcLabel(*npc),
+				selected_event_name
+			).c_str());
+			if (const auto* refreshed_event = ExpeditionDB::FindEvent(selected_event_id)) {
+				ShowGroupedBossEventCard(c, refreshed_event);
+			}
+			return;
+		}
+
+		c->Message(Chat::Red, "Usage: #expedition event group new|mode|add|remove");
+		ShowGroupedBossEventCard(c, event_data);
+}
+
 void HandleEvent(Client* c, const Seperator* sep)
 {
 		const std::string action = Strings::ToLower(sep->arg[2]);
@@ -3259,6 +3521,10 @@ void HandleEvent(Client* c, const Seperator* sep)
 		const auto* template_data = SelectedTemplate(c);
 		if (!template_data) {
 			NeedSelection(c);
+			return;
+		}
+		if (action == "group") {
+			HandleEventGroup(c, sep, *template_data);
 			return;
 		}
 		if (action == "add") {
@@ -3300,9 +3566,13 @@ void HandleEvent(Client* c, const Seperator* sep)
 			for (const auto& event_data : template_data->events) {
 				c->Message(Chat::White, ChatSeparator());
 				SendInfoLine(c, "Event", fmt::format("{} [{}]", event_data.event_name, event_data.id));
+				SendInfoLine(c, "Mode", CompletionModeLabel(event_data.completion_mode));
 				SendInfoLine(c, "Timing", fmt::format("lockout {} | replay {}", Duration(event_data.lockout_seconds), Duration(event_data.replay_lockout_seconds)));
 				SendInfoLine(c, "Mappings", fmt::format("NPCs {} | actions {}", event_data.npcs.size(), event_data.actions.size()));
 				SendHelpLink(c, fmt::format("#expedition event select {}", event_data.id), "select event");
+				if (ExpeditionDB::IsGroupedBossCompletionMode(event_data)) {
+					SendHelpLink(c, "#expedition event group", "manage boss group");
+				}
 				SendHelpLink(c, "#expedition event rename", "show rename commands");
 				SendHelpLink(c, fmt::format("#expedition event remove {}", event_data.id), "review delete");
 			}
@@ -3462,7 +3732,7 @@ void HandleEvent(Client* c, const Seperator* sep)
 						c->Message(Chat::Yellow, "Target is not mapped to the selected event.");
 						return;
 					}
-					const bool removes_event = ExpeditionDB::EventNpcRemovalDeletesEvent(*mapped_npc);
+					const bool removes_event = ExpeditionDB::EventNpcRemovalDeletesEvent(*event_data, *mapped_npc);
 					if (!ExpeditionDB::DeleteEventNpc(content_db, selected_event_id, mapped_npc->npc_type_id, mapped_npc->spawn2_id)) {
 						c->Message(Chat::Red, fmt::format("Failed to remove target NPC mapping for event [{}].", selected_event_name).c_str());
 						return;

--- a/zone/spawn2.cpp
+++ b/zone/spawn2.cpp
@@ -222,6 +222,17 @@ bool Spawn2::Process() {
 			return (true);
 		}
 
+		if (ExpeditionDB::IsBossSpawnBlockedByActiveLockout(npcid, spawn2_id)) {
+			LogSpawns(
+				"Spawn2 [{}]: NPC type [{}] blocked by active expedition boss lockout, retrying in [{}] ms",
+				spawn2_id,
+				npcid,
+				ExpeditionDB::kBossLockoutSpawnRetryMilliseconds
+			);
+			timer.Start(ExpeditionDB::kBossLockoutSpawnRetryMilliseconds);
+			return true;
+		}
+
 		//try to find our NPC type.
 		const NPCType *tmp = content_db.LoadNPCTypesData(npcid);
 		if (tmp == nullptr) {


### PR DESCRIPTION
## Summary
- Mark DB expedition offers unavailable when associated base-zone bosses are actively spawned.
- Prevent mapped DB expedition bosses from respawning while the current expedition instance has an active matching boss/event lockout.
- Add flexible grouped boss expedition events with custom DB event names, not expedition/template names, and `all_bosses` / `any_boss` completion policies.
- Improve DB expedition builder UX, including cleaner unavailable status formatting and labeled known raid/base zone versions.

## Key Changes
- Adds the `base_zone_boss_spawned` request reason and displays: `Unavailable while associated bosses are spawned in the base zone.`
- Formats long unavailable reasons as a two-line status block instead of a parenthesized row, while keeping short states like `Available`, `Locked`, and `Current` compact.
- Adds schema version `9346` with `expedition_template_events.completion_mode`, defaulting existing events to `first_completion`.
- Preserves existing single-event behavior for `first_completion`; grouped behavior is opt-in through the new boss group flow.
- Grouped boss custom naming writes to `expedition_template_events.event_name`; it does not change the expedition/template name.
- Supports grouped event completion modes:
  - `all_bosses`: every mapped boss must die before the shared custom event lockout fires.
  - `any_boss`: the first mapped boss death fires the shared custom event lockout once.
- Tracks `all_bosses` progress in memory by expedition instance and event NPC row.
- Supports spawn-specific bosses with `npc_type_id + spawn2_id` and script-spawned/dynamic bosses without spawn points by `npc_type_id`.
- Blocks grouped boss respawns after the grouped event lockout exists, scoped to the same expedition instance.
- Adds guided builder commands and UI for grouped events, including `#expedition event group new all|any`, mode switching, add/remove target boss, event rename, lockout/replay, and delete controls.

## Scope and Performance
- Base-zone availability checks use active NPC lookup data and only apply to the offering NPC/template context.
- Respawn blocking remains scoped to the current expedition UUID/template; base zones and unrelated expedition instances are not affected.
- Spawn2-based lockout protection defers blocked boss spawn attempts for 60 seconds instead of constructing and immediately depopping NPCs.
- Dynamic no-spawn boss depop fallback is limited to grouped-boss completion modes with an active matching lockout.
- Grouped boss progress is in memory only and clears with the expedition runtime event state.

## Validation
- `git diff --check`
- `cmake --build build-codex --target tests --config RelWithDebInfo`
- `./build-codex/bin/RelWithDebInfo/tests.exe` completed 116/116 tests
- `cmake --build build-codex --target zone --config RelWithDebInfo`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes expedition request eligibility, event completion, and spawn2 timing in live zones; mistakes could block requests or alter boss respawn behavior, though logic is scoped to current expedition instances and template mappings.
> 
> **Overview**
> Adds **`completion_mode`** on DB expedition template events (schema **9346**) and runtime support for **grouped boss events** (`all_bosses` / `any_boss`) with per-boss progress, validation, and GM **`#expedition event group`** authoring.
> 
> **Base-zone availability:** expedition offers and creation are blocked when template-mapped bosses are **actively spawned** in the matching base zone (new `EntityList::IsActiveNPCSpawnedByNpcTypeID`), with clearer requester menu status text.
> 
> **In-instance lockouts:** mapped boss spawns are **deferred 60s** in `spawn2` when the current expedition already has the boss/event lockout; grouped events with lockouts can **depop** bosses on spawn instead of completing.
> 
> Request checks use **`CheckExpeditionFromTemplate`** / instance-aware requester context; zone version picker in GM config uses **labeled raid/base versions (0-5)** instead of only DB-discovered versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77d61cdc1dd51c66039962fd41b0cb0c93a87d0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->