### PR TITLE
[Feature Improvement] Allow grouped boss chest triggers

### DIFF
--- a/tests/expedition_schema_test.h
+++ b/tests/expedition_schema_test.h
@@ -32,6 +32,7 @@ public:
 		TEST_ADD(ExpeditionSchemaTest::BaseZoneBossAvailabilityIsTemplateSpecific);
 		TEST_ADD(ExpeditionSchemaTest::BossLockoutSpawnGateUsesConfiguredBossMappings);
 		TEST_ADD(ExpeditionSchemaTest::GroupedBossRequirementMatchingSupportsDynamicBosses);
+		TEST_ADD(ExpeditionSchemaTest::GroupedBossChestTriggerDoesNotCountAsRequirement);
 		TEST_ADD(ExpeditionSchemaTest::GroupedBossAllCompletionRequiresEveryRequirement);
 		TEST_ADD(ExpeditionSchemaTest::GroupedBossValidationHelpersRequireUnambiguousBossGroup);
 	}
@@ -432,6 +433,39 @@ private:
 		TEST_ASSERT(!ExpeditionDB::GroupedBossRequirementMatchesSpawn(spawn_boss, 100, 11));
 		TEST_ASSERT(ExpeditionDB::GroupedBossRequirementMatchesSpawn(dynamic_boss, 200, 99));
 		TEST_ASSERT(!ExpeditionDB::GroupedBossRequirementMatchesSpawn(add_npc, 300, 0));
+	}
+
+	void GroupedBossChestTriggerDoesNotCountAsRequirement()
+	{
+		ExpeditionDB::Event grouped_event;
+		grouped_event.completion_mode = ExpeditionDB::kCompletionModeAllBosses;
+
+		ExpeditionDB::EventNpc first_boss;
+		first_boss.id = 1;
+		first_boss.role = "boss";
+		first_boss.npc_type_id = 100;
+		first_boss.complete_on_death = true;
+
+		ExpeditionDB::EventNpc second_boss;
+		second_boss.id = 2;
+		second_boss.role = "boss";
+		second_boss.npc_type_id = 200;
+		second_boss.complete_on_death = true;
+
+		ExpeditionDB::EventNpc chest_trigger;
+		chest_trigger.id = 3;
+		chest_trigger.role = "chest";
+		chest_trigger.npc_type_id = 300;
+		chest_trigger.complete_on_spawn = true;
+
+		grouped_event.npcs = { first_boss, second_boss, chest_trigger };
+
+		TEST_ASSERT(ExpeditionDB::IsGroupedBossChestTrigger(chest_trigger));
+		TEST_ASSERT(ExpeditionDB::GroupedBossRequirementCount(grouped_event) == 2);
+
+		std::unordered_set<uint32_t> completed;
+		completed.insert(chest_trigger.id);
+		TEST_ASSERT(!ExpeditionDB::GroupedBossRequirementsComplete(grouped_event, completed));
 	}
 
 	void GroupedBossAllCompletionRequiresEveryRequirement()

--- a/zone/expedition_db.cpp
+++ b/zone/expedition_db.cpp
@@ -771,6 +771,10 @@ namespace {
 	bool CompleteEventForNpc(DynamicZone& expedition, const Event& event_data, const EventNpc& event_npc, Client* notifier)
 	{
 		if (IsGroupedBossCompletionMode(event_data)) {
+			if (IsGroupedBossChestTrigger(event_npc)) {
+				return CompleteRuntimeEvent(expedition, event_data, RuntimeEventName(event_data, event_npc), notifier);
+			}
+
 			if (!IsGroupedBossRequirement(event_npc)) {
 				return false;
 			}
@@ -1599,12 +1603,12 @@ ValidationResult ValidateTemplate(const Template& template_data)
 				result.errors.push_back(fmt::format("Event [{}] has an NPC mapping without an NPC type.", event_data.event_name));
 			}
 
-			if (grouped_boss_event && !IsGroupedBossRequirement(event_npc)) {
-				result.errors.push_back(fmt::format("Grouped boss event [{}] has a non-boss or non-death NPC mapping [{}].", event_data.event_name, NpcTypeLabel(event_npc.npc_type_id)));
+			if (grouped_boss_event && !IsGroupedBossRequirement(event_npc) && !IsGroupedBossChestTrigger(event_npc)) {
+				result.errors.push_back(fmt::format("Grouped boss event [{}] has a non-boss/non-death mapping that is not a chest spawn trigger [{}].", event_data.event_name, NpcTypeLabel(event_npc.npc_type_id)));
 			}
 
-			if (grouped_boss_event && event_npc.complete_on_spawn) {
-				result.errors.push_back(fmt::format("Grouped boss event [{}] cannot use spawn-completion NPC mappings.", event_data.event_name));
+			if (grouped_boss_event && event_npc.complete_on_spawn && !IsGroupedBossChestTrigger(event_npc)) {
+				result.errors.push_back(fmt::format("Grouped boss event [{}] can only use spawn-completion mappings for chest triggers.", event_data.event_name));
 			}
 
 			if (event_npc.spawn2_id == 0 && !event_npc.complete_on_spawn && !grouped_boss_event) {

--- a/zone/expedition_db.h
+++ b/zone/expedition_db.h
@@ -89,6 +89,11 @@ inline bool IsBossEventNpc(const EventNpc& event_npc)
 	return Strings::EqualFold(event_npc.role, "boss");
 }
 
+inline bool IsChestEventNpc(const EventNpc& event_npc)
+{
+	return Strings::EqualFold(event_npc.role, "chest");
+}
+
 inline bool IsKnownCompletionMode(const std::string& completion_mode)
 {
 	return Strings::EqualFold(completion_mode, kCompletionModeFirst) ||
@@ -123,6 +128,11 @@ inline bool IsGroupedBossCompletionMode(const Event& event_data)
 inline bool IsGroupedBossRequirement(const EventNpc& event_npc)
 {
 	return IsBossEventNpc(event_npc) && event_npc.npc_type_id != 0 && event_npc.complete_on_death;
+}
+
+inline bool IsGroupedBossChestTrigger(const EventNpc& event_npc)
+{
+	return IsChestEventNpc(event_npc) && event_npc.npc_type_id != 0 && event_npc.complete_on_spawn && !event_npc.complete_on_death;
 }
 
 inline bool GroupedBossRequirementMatchesSpawn(const EventNpc& event_npc, uint32_t npc_type_id, uint32_t spawn2_id)

--- a/zone/gm_commands/expedition.cpp
+++ b/zone/gm_commands/expedition.cpp
@@ -3054,10 +3054,10 @@ void ApplyEditAdd(Client* c, uint32_t entity_id, const std::string& role)
 		}
 
 		if (role == "chest") {
-			// A chest must be linked to a boss event (its spawn completes that event). Auto-link when
-			// there is exactly one boss; otherwise ask which boss it belongs to.
+			// A chest must be linked to an existing event. Auto-link when there is
+			// exactly one event; otherwise ask which event it should complete.
 			if (template_data->events.empty()) {
-				c->Message(Chat::Red, "Add a boss first - a loot chest completes an existing boss event when it spawns.");
+				c->Message(Chat::Red, "Add an event first - a loot chest completes an existing event when it spawns.");
 				RefreshBuilderView(c);
 				return;
 			}
@@ -3126,7 +3126,7 @@ void HandleEdit(Client* c, const Seperator* sep)
 		// Internal: chest-link chooser callback (#expedition edit chestlink <chest_entity_id> <event_id>).
 		if (action == "chestlink") {
 			if (!IsStrictUnsigned(sep->arg[3]) || !IsStrictUnsigned(sep->arg[4])) {
-				c->Message(Chat::Red, "Pick a boss from the chest link menu.");
+				c->Message(Chat::Red, "Pick an event from the chest link menu.");
 				return;
 			}
 			ApplyChestToEvent(c, Strings::ToUnsignedInt(sep->arg[3]), Strings::ToUnsignedInt(sep->arg[4]));
@@ -3138,7 +3138,7 @@ void HandleEdit(Client* c, const Seperator* sep)
 			c->Message(Chat::White, "Toggle a guided add flow for the selected expedition.");
 			SendHelpLink(c, "#expedition edit on", "enable edit mode for the selected expedition");
 			SendHelpLink(c, "#expedition edit off", "disable edit mode");
-			c->Message(Chat::White, "While on, target any NPC to get role popups (Boss / Chest / Requester). A chest links to the boss whose event it completes.");
+			c->Message(Chat::White, "While on, target any NPC to get role popups (Boss / Chest / Requester). A chest links to the event it completes.");
 			return;
 		}
 
@@ -4659,8 +4659,8 @@ void ExpeditionEditPopupResponse(Client* c, uint32_t popup_id)
 	switch (step) {
 		case ExpeditionEditPopup::AddBoss:      ApplyEditAdd(c, entity_id, "boss"); break;
 		case ExpeditionEditPopup::AskChest:
-			// A chest can only complete an existing boss event - skip the chest question entirely
-			// when no boss exists yet and go straight to the Requester question.
+			// A chest can only complete an existing event - skip the chest question
+			// when no event exists yet and go straight to the Requester question.
 			if (template_data->events.empty()) {
 				ShowRoleQuestion(c, *template_data, *npc, entity_id, "requester");
 			}

--- a/zone/gm_commands/expedition.cpp
+++ b/zone/gm_commands/expedition.cpp
@@ -1137,6 +1137,7 @@ namespace {
 		SendSectionHeader(c, "Event Basics");
 		SendHelpLink(c, "#expedition event add \"Event Name\"", "add and select a DB event");
 		SendHelpLink(c, "#expedition event group", "create or manage a grouped boss event");
+		SendHelpLink(c, "#expedition event group chest", "link targeted chest spawn to selected grouped boss event");
 		SendHelpLink(c, "#expedition event select <id|name>", "select event for short follow-up commands");
 		SendHelpLink(c, "#expedition event list", "list events on selected expedition");
 		SendHelpLink(c, "#expedition event rename", "show event rename commands");
@@ -1211,10 +1212,36 @@ namespace {
 		}
 
 		c->Message(Chat::White, ChatSeparator());
+		SendInfoLine(c, "Chest Triggers", fmt::format("{} target(s)", std::ranges::count_if(event_data->npcs, ExpeditionDB::IsGroupedBossChestTrigger)));
+		uint32_t chest_index = 0;
+		for (const auto& event_npc : event_data->npcs) {
+			if (!ExpeditionDB::IsGroupedBossChestTrigger(event_npc)) {
+				continue;
+			}
+
+			const std::string mapping_type = event_npc.spawn2_id == 0 ? "dynamic npc-type" : "spawn-specific";
+			c->Message(Chat::White, fmt::format(
+				"   {:>2}. {}   ({})",
+				++chest_index,
+				NpcMappingLabel(event_npc.npc_type_id, event_npc.spawn2_id),
+				mapping_type
+			).c_str());
+		}
+
+		if (chest_index == 0) {
+			c->Message(Chat::Gray, "   (target a chest and click Add Target Chest)");
+		}
+
+		c->Message(Chat::White, ChatSeparator());
 		c->Message(Chat::White, "  Boss Targets:");
 		SendActionRow(c, {
 			{"#expedition event group add", "Add Target Boss"},
 			{"#expedition event group remove", "Remove Target Boss"}
+		});
+		c->Message(Chat::White, "  Chest Trigger:");
+		SendActionRow(c, {
+			{"#expedition event group chest", "Add Target Chest"},
+			{"#expedition event group removechest", "Remove Target Chest"}
 		});
 		c->Message(Chat::White, "  Completion Policy:");
 		SendActionRow(c, {
@@ -2927,8 +2954,8 @@ void ShowRoleQuestion(Client* c, const ExpeditionDB::Template& template_data, NP
 		c->SendFullPopup(title.c_str(), body.c_str(), yes_id, no_id, 1, 0, "Yes", "No");
 }
 
-// Links a loot chest to a specific boss event: its spawn completes that event (and fires that
-// boss's lockout), with loot protection. Used for both the single-boss auto-link and the chooser.
+// Links a loot chest to a specific event: its spawn completes that event (and fires that
+// event's lockout), with loot protection. Used for both the auto-link and the chooser.
 void ApplyChestToEvent(Client* c, uint32_t entity_id, uint32_t event_id)
 {
 		const auto* template_data = RequireSelectedTemplate(c);
@@ -2949,7 +2976,7 @@ void ApplyChestToEvent(Client* c, uint32_t entity_id, uint32_t event_id)
 			}
 		}
 		if (!event_data) {
-			c->Message(Chat::Red, "That boss event no longer exists - re-target the chest to link it.");
+			c->Message(Chat::Red, "That event no longer exists - re-target the chest to link it.");
 			return;
 		}
 
@@ -2966,19 +2993,19 @@ void ApplyChestToEvent(Client* c, uint32_t entity_id, uint32_t event_id)
 		}
 		ExpeditionDB::SetSelectedEvent(c->CharacterID(), event_id);
 		c->Message(Chat::Green, fmt::format(
-			"Saved: loot chest [{}] is linked to [{}] - its spawn now completes that boss's event and fires its lockout (loot protected).",
+			"Saved: loot chest [{}] is linked to [{}] - its spawn now completes that event and fires its lockout (loot protected).",
 			NpcLabel(*npc), event_name).c_str());
 		if (const auto* refreshed = ExpeditionDB::FindTemplate(template_id)) {
 			ShowEditScreen(c, *refreshed);
 		}
 }
 
-// When an expedition has more than one boss, ask which boss's event this chest should complete.
+// When an expedition has more than one event, ask which event this chest should complete.
 void ShowChestLinkChooser(Client* c, const ExpeditionDB::Template& template_data, NPC& npc, uint32_t entity_id)
 {
 		SendEditBanner(c, template_data);
-		SendCardTop(c, "Link Loot Chest To Boss");
-		c->Message(Chat::White, fmt::format("  Which boss should [{}] be linked to? Its spawn will complete that boss's event and trigger its lockout.",
+		SendCardTop(c, "Link Loot Chest To Event");
+		c->Message(Chat::White, fmt::format("  Which event should [{}] be linked to? Its spawn will complete that event and trigger its lockout.",
 			NpcLabel(npc)).c_str());
 		c->Message(Chat::White, ChatSeparator());
 		for (const auto& event_data : template_data.events) {
@@ -3819,6 +3846,43 @@ void HandleEventGroup(Client* c, const Seperator* sep, const ExpeditionDB::Templ
 			return;
 		}
 
+		if (sub_action == "chest") {
+			NPC* npc = RequireTargetNpc(c, "Target a chest NPC, then click Add Target Chest again.");
+			if (!npc) {
+				ShowGroupedBossEventCard(c, event_data);
+				return;
+			}
+
+			const uint32_t npc_type_id = npc->GetNPCTypeID();
+			const uint32_t spawn2_id = npc->GetSpawnPointID();
+			const auto* mapped_npc = FindEventNpc(*event_data, *npc);
+			if (mapped_npc && ExpeditionDB::IsGroupedBossChestTrigger(*mapped_npc)) {
+				c->Message(Chat::Yellow, fmt::format("Target [{}] is already a chest trigger for grouped event [{}].", NpcLabel(*npc), selected_event_name).c_str());
+				ShowGroupedBossEventCard(c, event_data);
+				return;
+			}
+
+			if (
+				!ExpeditionDB::SetEventNpc(content_db, selected_event_id, npc_type_id, spawn2_id, "chest") ||
+				!ExpeditionDB::SetEventNpcCompleteOnDeath(content_db, selected_event_id, npc_type_id, spawn2_id, false) ||
+				!ExpeditionDB::SetEventNpcCompleteOnSpawn(content_db, selected_event_id, npc_type_id, spawn2_id, true) ||
+				!ExpeditionDB::SetEventNpcLoot(content_db, selected_event_id, npc_type_id, spawn2_id, true)
+			) {
+				c->Message(Chat::Red, fmt::format("Failed to add target chest trigger to grouped event [{}].", selected_event_name).c_str());
+				return;
+			}
+
+			c->Message(Chat::Green, fmt::format(
+				"Saved: chest [{}] now completes grouped event [{}] on spawn.",
+				NpcLabel(*npc),
+				selected_event_name
+			).c_str());
+			if (const auto* refreshed_event = ExpeditionDB::FindEvent(selected_event_id)) {
+				ShowGroupedBossEventCard(c, refreshed_event);
+			}
+			return;
+		}
+
 		if (sub_action == "remove") {
 			NPC* npc = RequireTargetNpc(c, "Target a grouped boss, then click Remove Target Boss again.");
 			if (!npc) {
@@ -3849,7 +3913,37 @@ void HandleEventGroup(Client* c, const Seperator* sep, const ExpeditionDB::Templ
 			return;
 		}
 
-		c->Message(Chat::Red, "Usage: #expedition event group new|mode|add|remove");
+		if (sub_action == "removechest") {
+			NPC* npc = RequireTargetNpc(c, "Target a grouped chest trigger, then click Remove Target Chest again.");
+			if (!npc) {
+				ShowGroupedBossEventCard(c, event_data);
+				return;
+			}
+
+			const auto* mapped_npc = FindEventNpc(*event_data, *npc);
+			if (!mapped_npc || !ExpeditionDB::IsGroupedBossChestTrigger(*mapped_npc)) {
+				c->Message(Chat::Yellow, "Target is not a chest trigger for the selected grouped boss event.");
+				ShowGroupedBossEventCard(c, event_data);
+				return;
+			}
+
+			if (!ExpeditionDB::DeleteEventNpcMapping(content_db, selected_event_id, mapped_npc->npc_type_id, mapped_npc->spawn2_id)) {
+				c->Message(Chat::Red, fmt::format("Failed to remove target chest trigger from grouped event [{}].", selected_event_name).c_str());
+				return;
+			}
+
+			c->Message(Chat::Green, fmt::format(
+				"Saved: removed chest trigger [{}] from grouped event [{}].",
+				NpcLabel(*npc),
+				selected_event_name
+			).c_str());
+			if (const auto* refreshed_event = ExpeditionDB::FindEvent(selected_event_id)) {
+				ShowGroupedBossEventCard(c, refreshed_event);
+			}
+			return;
+		}
+
+		c->Message(Chat::Red, "Usage: #expedition event group new|mode|add|remove|chest|removechest");
 		ShowGroupedBossEventCard(c, event_data);
 }
 

--- a/zone/gm_commands/expedition.cpp
+++ b/zone/gm_commands/expedition.cpp
@@ -3818,6 +3818,11 @@ void HandleEventGroup(Client* c, const Seperator* sep, const ExpeditionDB::Templ
 				ShowGroupedBossEventCard(c, event_data);
 				return;
 			}
+			if (mapped_npc && ExpeditionDB::IsGroupedBossChestTrigger(*mapped_npc)) {
+				c->Message(Chat::Yellow, fmt::format("Target [{}] is already a chest trigger for grouped event [{}]. Remove the chest trigger before adding it as a boss.", NpcLabel(*npc), selected_event_name).c_str());
+				ShowGroupedBossEventCard(c, event_data);
+				return;
+			}
 
 			const bool ambiguous_dynamic = std::ranges::any_of(event_data->npcs, [&](const ExpeditionDB::EventNpc& event_npc) {
 				return ExpeditionDB::IsGroupedBossRequirement(event_npc) &&
@@ -3858,6 +3863,11 @@ void HandleEventGroup(Client* c, const Seperator* sep, const ExpeditionDB::Templ
 			const auto* mapped_npc = FindEventNpc(*event_data, *npc);
 			if (mapped_npc && ExpeditionDB::IsGroupedBossChestTrigger(*mapped_npc)) {
 				c->Message(Chat::Yellow, fmt::format("Target [{}] is already a chest trigger for grouped event [{}].", NpcLabel(*npc), selected_event_name).c_str());
+				ShowGroupedBossEventCard(c, event_data);
+				return;
+			}
+			if (mapped_npc && ExpeditionDB::IsGroupedBossRequirement(*mapped_npc)) {
+				c->Message(Chat::Yellow, fmt::format("Target [{}] is already a boss for grouped event [{}]. Remove the boss before adding it as a chest trigger.", NpcLabel(*npc), selected_event_name).c_str());
 				ShowGroupedBossEventCard(c, event_data);
 				return;
 			}


### PR DESCRIPTION
## Summary
- Allow grouped boss events to include chest spawn triggers without counting those chests as boss requirements.
- Add grouped-event UI/actions for `#expedition event group chest` and `#expedition event group removechest`.
- Allow grouped chest triggers to complete the shared runtime event on spawn while keeping all/any boss requirement tracking separate.
- Prevent grouped boss/chest add actions from overwriting an existing mapping of the other role; require explicit removal first.
- Update chest-link wording and add test coverage for grouped chest triggers.

## Validation
- `git diff --check`
- `cmake --build build-codex --target zone --config RelWithDebInfo`
- `cmake --build build-codex --target tests --config RelWithDebInfo`
- `./build-codex/bin/RelWithDebInfo/tests.exe` (117/117 correct)