### PR TITLE
[Expedition] Add expedition show action footer

### DIFF
--- a/zone/gm_commands/expedition.cpp
+++ b/zone/gm_commands/expedition.cpp
@@ -3162,7 +3162,13 @@ void HandleShow(Client* c, const Seperator* sep)
 			NeedSelection(c);
 			return;
 		}
+		auto& builder_state = ExpeditionDB::GetBuilderState(c->CharacterID());
+		const bool switching_edit_target = builder_state.edit_mode && builder_state.selected_template_id != template_data->id;
 		ExpeditionDB::SetSelectedTemplate(c->CharacterID(), template_data->id);
+		if (switching_edit_target) {
+			builder_state.edit_mode = false;
+			c->Message(Chat::Yellow, "Stopped editing because Show switched to a different expedition.");
+		}
 		ShowTemplate(c, *template_data);
 }
 

--- a/zone/gm_commands/expedition.cpp
+++ b/zone/gm_commands/expedition.cpp
@@ -3163,8 +3163,11 @@ void HandleShow(Client* c, const Seperator* sep)
 			return;
 		}
 		auto& builder_state = ExpeditionDB::GetBuilderState(c->CharacterID());
-		const bool switching_edit_target = builder_state.edit_mode && builder_state.selected_template_id != template_data->id;
-		ExpeditionDB::SetSelectedTemplate(c->CharacterID(), template_data->id);
+		const bool switching_template = builder_state.selected_template_id != template_data->id;
+		const bool switching_edit_target = builder_state.edit_mode && switching_template;
+		if (switching_template) {
+			ExpeditionDB::SetSelectedTemplate(c->CharacterID(), template_data->id);
+		}
 		if (switching_edit_target) {
 			builder_state.edit_mode = false;
 			c->Message(Chat::Yellow, "Stopped editing because Show switched to a different expedition.");

--- a/zone/gm_commands/expedition.cpp
+++ b/zone/gm_commands/expedition.cpp
@@ -1498,6 +1498,37 @@ namespace {
 		SendCardBottom(c);
 	}
 
+	void SendBuilderActionMenu(Client* c, const ExpeditionDB::Template& template_data)
+	{
+		const auto& builder_state = ExpeditionDB::GetBuilderState(c->CharacterID());
+		const bool editing_this = builder_state.edit_mode && builder_state.selected_template_id == template_data.id;
+
+		c->Message(Chat::White, "  Build:");
+		SendActionRow(c, {
+			{"#expedition config", "Configure"},
+			{fmt::format("#expedition show {}", template_data.id), "Show"},
+			template_data.enabled
+				? std::pair<std::string, std::string>{"#expedition disable", "Unpublish"}
+				: std::pair<std::string, std::string>{"#expedition publish", "Publish"}
+		});
+		c->Message(Chat::White, "  Encounters:");
+		SendActionRow(c, {
+			{"#expedition boss loot", "Target Boss"},
+			{"#expedition event group", "New Boss Group"},
+			{"#expedition event list", "Event List"}
+		});
+		c->Message(Chat::White, "  Navigate:");
+		SendActionRow(c, {
+			editing_this
+				? std::pair<std::string, std::string>{"#expedition edit off", "Stop Editing"}
+				: std::pair<std::string, std::string>{fmt::format("#expedition edit on {}", template_data.id), "Edit This"},
+			{"#expedition", "Back to List"}
+		});
+		// Rename uses a non-silent saylink: clicking pre-fills the command in your input box to edit the name.
+		c->Message(Chat::White, fmt::format("  Rename:  {}",
+			Saylink::Create("#expedition rename ", false, "[ Rename ]")).c_str());
+	}
+
 	void ShowTemplate(Client* c, const ExpeditionDB::Template& template_data)
 	{
 		SendCardTop(c, fmt::format("Expedition: {} [{}]   ({})",
@@ -1552,11 +1583,12 @@ namespace {
 		}
 
 		c->Message(Chat::White, ChatSeparator());
+		c->Message(Chat::White, "  Manage:");
 		SendActionRow(c, {
-			{fmt::format("#expedition edit on {}", template_data.id), "Edit This"},
-			{fmt::format("#expedition delete {}", template_data.id), "Delete"},
-			{"#expedition", "Back to List"}
+			{fmt::format("#expedition delete {}", template_data.id), "Delete"}
 		});
+		c->Message(Chat::White, ChatSeparator());
+		SendBuilderActionMenu(c, template_data);
 		SendCardBottom(c);
 	}
 
@@ -2020,29 +2052,7 @@ void ShowEditScreen(Client* c, const ExpeditionDB::Template& template_data)
 		}
 		c->Message(Chat::White, ChatSeparator());
 
-		// Build/publish actions on one row, navigation on the next, so the row never wraps awkwardly.
-		c->Message(Chat::White, "  Build:");
-		SendActionRow(c, {
-			{"#expedition config", "Configure"},
-			{fmt::format("#expedition show {}", template_data.id), "Show"},
-			template_data.enabled
-				? std::pair<std::string, std::string>{"#expedition disable", "Unpublish"}
-				: std::pair<std::string, std::string>{"#expedition publish", "Publish"}
-		});
-		c->Message(Chat::White, "  Encounters:");
-		SendActionRow(c, {
-			{"#expedition boss loot", "Target Boss"},
-			{"#expedition event group", "New Boss Group"},
-			{"#expedition event list", "Event List"}
-		});
-		c->Message(Chat::White, "  Navigate:");
-		SendActionRow(c, {
-			{"#expedition edit off", "Stop Editing"},
-			{"#expedition", "Back to List"}
-		});
-		// Rename uses a non-silent saylink: clicking pre-fills the command in your input box to edit the name.
-		c->Message(Chat::White, fmt::format("  Rename:  {}",
-			Saylink::Create("#expedition rename ", false, "[ Rename ]")).c_str());
+		SendBuilderActionMenu(c, template_data);
 		SendCardBottom(c);
 }
 
@@ -3152,6 +3162,7 @@ void HandleShow(Client* c, const Seperator* sep)
 			NeedSelection(c);
 			return;
 		}
+		ExpeditionDB::SetSelectedTemplate(c->CharacterID(), template_data->id);
 		ShowTemplate(c, *template_data);
 }
 


### PR DESCRIPTION
## Summary
- Share the expedition builder action menu between the edit screen and the `#expedition show` screen.
- Add the Build, Encounters, Navigate, and Rename sections to the bottom of the Show details view.
- Select the shown expedition before rendering so footer actions apply to that expedition.

## QA
- `git diff --check`
- `powershell -ExecutionPolicy Bypass -File "C:\Users\rgagn\.codex\skills\emu-compile\scripts\invoke-akkstack-eqemu-build.ps1" -BuildMode linux-test -Ref current -Targets zone -SkipSpireBuild -NoMonitor -NoOpenSpire`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> GM-only chat UI and builder state in zone/gm_commands; no player-facing gameplay or persistence logic changes beyond selection/edit-mode guards.
> 
> **Overview**
> Extracts the expedition GM **Build / Encounters / Navigate / Rename** saylink footer into **`SendBuilderActionMenu`**, shared by the edit screen and **`#expedition show`** detail view.
> 
> The **show** card now keeps **Delete** under **Manage**, then renders the same builder actions as edit mode. **Navigate** shows **Edit This** vs **Stop Editing** depending on whether edit mode targets the expedition being shown.
> 
> **`HandleShow`** updates the builder **selected template** to the one being viewed and **clears edit mode** (with a chat notice) when show switches to a different expedition while editing another.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61789a40069ef5b0d22ebe44beaff1f49d625f94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->