### PR TITLE
[Expeditions] Make base zone boss-dead requirement toggleable per expedition

### DIFF
--- a/common/database/database_update_manifest.h
+++ b/common/database/database_update_manifest.h
@@ -7419,6 +7419,7 @@ CREATE TABLE IF NOT EXISTS `expedition_templates` (
 	`replay_on_join` TINYINT(1) UNSIGNED NOT NULL DEFAULT '1',
 	`silent` TINYINT(1) UNSIGNED NOT NULL DEFAULT '0',
 	`boss_only_spawn` TINYINT(1) UNSIGNED NOT NULL DEFAULT '0',
+	`require_bosses_dead` TINYINT(1) UNSIGNED NOT NULL DEFAULT '1',
 	`request_phrase` VARCHAR(64) NOT NULL DEFAULT 'expedition',
 	`request_mode` VARCHAR(32) NOT NULL DEFAULT 'db_only',
 	`notes` TEXT NULL,
@@ -7506,6 +7507,18 @@ ADD COLUMN `boss_only_spawn` TINYINT(1) UNSIGNED NOT NULL DEFAULT '0' AFTER `sil
 		.sql = R"(
 ALTER TABLE `expedition_template_events`
 ADD COLUMN `completion_mode` VARCHAR(32) NOT NULL DEFAULT 'first_completion' AFTER `sort_order`;
+)",
+		.content_schema_update = true
+	},
+	ManifestEntry{
+		.version = 9347,
+		.description = "2026_06_12_expedition_require_bosses_dead.sql",
+		.check = "SHOW COLUMNS FROM `expedition_templates` LIKE 'require_bosses_dead'",
+		.condition = "empty",
+		.match = "",
+		.sql = R"(
+ALTER TABLE `expedition_templates`
+ADD COLUMN `require_bosses_dead` TINYINT(1) UNSIGNED NOT NULL DEFAULT '1' AFTER `boss_only_spawn`;
 )",
 		.content_schema_update = true
 	},

--- a/common/version.h
+++ b/common/version.h
@@ -41,6 +41,6 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9346
+#define CURRENT_BINARY_DATABASE_VERSION 9347
 #define CURRENT_BINARY_BOTS_DATABASE_VERSION 9054
 #define CUSTOM_BINARY_DATABASE_VERSION 0

--- a/tests/expedition_schema_test.h
+++ b/tests/expedition_schema_test.h
@@ -19,8 +19,10 @@ public:
 		TEST_ADD(ExpeditionSchemaTest::CreationMigrationHasFinalSchema);
 		TEST_ADD(ExpeditionSchemaTest::BossOnlyMigrationUpdatesExistingTemplates);
 		TEST_ADD(ExpeditionSchemaTest::EventCompletionModeMigrationUpdatesExistingEvents);
+		TEST_ADD(ExpeditionSchemaTest::RequireBossesDeadMigrationUpdatesExistingTemplates);
 		TEST_ADD(ExpeditionSchemaTest::BinaryDatabaseVersionIncludesExpeditionMigrations);
 		TEST_ADD(ExpeditionSchemaTest::BossOnlyDefaultsAreOff);
+		TEST_ADD(ExpeditionSchemaTest::RequireBossesDeadDefaultsOn);
 		TEST_ADD(ExpeditionSchemaTest::EventCompletionModeDefaultsToFirstCompletion);
 		TEST_ADD(ExpeditionSchemaTest::BossEventNpcRemovalDeletesEvent);
 		TEST_ADD(ExpeditionSchemaTest::LockoutNamespaceUsesDynamicZoneName);
@@ -67,6 +69,7 @@ private:
 		TEST_ASSERT(entry->condition == "empty");
 		TEST_ASSERT(entry->sql.find("request_mode") != std::string::npos);
 		TEST_ASSERT(entry->sql.find("boss_only_spawn") != std::string::npos);
+		TEST_ASSERT(entry->sql.find("require_bosses_dead") != std::string::npos);
 		TEST_ASSERT(entry->sql.find("db_only") != std::string::npos);
 		TEST_ASSERT(entry->sql.find("zone_version") != std::string::npos);
 		TEST_ASSERT(entry->sql.find("complete_on_spawn") != std::string::npos);
@@ -111,9 +114,24 @@ private:
 		TEST_ASSERT(entry->sql.find("DEFAULT 'first_completion'") != std::string::npos);
 	}
 
+	void RequireBossesDeadMigrationUpdatesExistingTemplates()
+	{
+		auto entry = std::find_if(manifest_entries.begin(), manifest_entries.end(), [](const ManifestEntry& e) {
+			return e.version == 9347 && e.description == "2026_06_12_expedition_require_bosses_dead.sql";
+		});
+
+		TEST_ASSERT(entry != manifest_entries.end());
+		TEST_ASSERT(entry->content_schema_update);
+		TEST_ASSERT(entry->check == "SHOW COLUMNS FROM `expedition_templates` LIKE 'require_bosses_dead'");
+		TEST_ASSERT(entry->condition == "empty");
+		TEST_ASSERT(entry->sql.find("ALTER TABLE `expedition_templates`") != std::string::npos);
+		TEST_ASSERT(entry->sql.find("require_bosses_dead") != std::string::npos);
+		TEST_ASSERT(entry->sql.find("DEFAULT '1'") != std::string::npos);
+	}
+
 	void BinaryDatabaseVersionIncludesExpeditionMigrations()
 	{
-		TEST_ASSERT(CURRENT_BINARY_DATABASE_VERSION >= 9346);
+		TEST_ASSERT(CURRENT_BINARY_DATABASE_VERSION >= 9347);
 	}
 
 	void BossOnlyDefaultsAreOff()
@@ -127,6 +145,12 @@ private:
 		TEST_ASSERT(filter.unrestricted_spawn2_ids.empty());
 		TEST_ASSERT(filter.AllowsSpawn2(1));
 		TEST_ASSERT(filter.AllowedNPCTypeIDs(1) == nullptr);
+	}
+
+	void RequireBossesDeadDefaultsOn()
+	{
+		ExpeditionDB::Template template_data;
+		TEST_ASSERT(template_data.require_bosses_dead);
 	}
 
 	void EventCompletionModeDefaultsToFirstCompletion()

--- a/zone/expedition_db.cpp
+++ b/zone/expedition_db.cpp
@@ -356,7 +356,7 @@ namespace {
 
 	bool HasActiveBaseZoneBoss(const Template& template_data)
 	{
-		if (!IsCurrentBaseZoneForTemplate(template_data)) {
+		if (!template_data.require_bosses_dead || !IsCurrentBaseZoneForTemplate(template_data)) {
 			return false;
 		}
 
@@ -581,7 +581,11 @@ namespace {
 		client.Message(Chat::NPCQuestSay, "%s", title.c_str());
 		client.Message(Chat::NPCQuestSay, "%s", kManageRule);
 		for (const auto& entry : entries) {
-			const std::string status = (entry.note.empty() || entry.status_block) ? entry.status : fmt::format("{} ({})", entry.status, entry.note);
+			// Status-block notes read as a sentence continuation ("Unavailable while ..."),
+			// other notes are parenthetical hints ("Locked (replay timer active)").
+			const std::string status = entry.note.empty() ? entry.status :
+				entry.status_block ? fmt::format("{} {}", entry.status, entry.note) :
+				fmt::format("{} ({})", entry.status, entry.note);
 			if (!entry.phrase.empty()) {
 				const std::string action = Saylink::Silent(entry.phrase, fmt::format("[ {} ]", entry.button));
 				const std::string line = multi ?
@@ -596,9 +600,6 @@ namespace {
 				fmt::format("   {}", status);
 			const uint16_t chat_type = entry.status == "Locked" ? Chat::Red : Chat::Yellow;
 			client.Message(chat_type, "%s", line.c_str());
-			if (entry.status_block && !entry.note.empty()) {
-				client.Message(chat_type, "      %s", entry.note.c_str());
-			}
 		}
 		client.Message(Chat::NPCQuestSay, "%s", kManageRule);
 	}
@@ -894,6 +895,7 @@ uint32_t CreateTemplateFromClient(Database& db, Client& client, const std::strin
 		true,
 		false,
 		false,
+		true,
 		kSimpleRequestPhrase,
 		kSimpleRequestMode,
 		""
@@ -1025,6 +1027,13 @@ bool SetTemplateSilent(Database& db, uint32_t template_id, bool silent)
 bool SetTemplateBossOnlySpawn(Database& db, uint32_t template_id, bool enabled)
 {
 	const bool ok = ExpeditionRepository::UpdateTemplateBossOnlySpawn(db, template_id, enabled);
+	Reload(db);
+	return ok;
+}
+
+bool SetTemplateRequireBossesDead(Database& db, uint32_t template_id, bool enabled)
+{
+	const bool ok = ExpeditionRepository::UpdateTemplateRequireBossesDead(db, template_id, enabled);
 	Reload(db);
 	return ok;
 }

--- a/zone/expedition_db.h
+++ b/zone/expedition_db.h
@@ -219,6 +219,7 @@ struct Template {
 	bool replay_on_join = true;
 	bool silent = false;
 	bool boss_only_spawn = false;
+	bool require_bosses_dead = true;
 	std::string request_phrase = "expedition";
 	std::string request_mode = "db_only";
 	std::string notes;
@@ -401,6 +402,7 @@ bool SetTemplateEnabled(Database& db, uint32_t template_id, bool enabled);
 bool SetTemplateReplay(Database& db, uint32_t template_id, uint32_t seconds);
 bool SetTemplateSilent(Database& db, uint32_t template_id, bool silent);
 bool SetTemplateBossOnlySpawn(Database& db, uint32_t template_id, bool enabled);
+bool SetTemplateRequireBossesDead(Database& db, uint32_t template_id, bool enabled);
 bool SetTemplateRequestMode(Database& db, uint32_t template_id, const std::string& request_mode);
 bool SetDzTemplateZone(Database& db, uint32_t dz_template_id, uint32_t zone_id, uint32_t version);
 bool SetDzTemplateDuration(Database& db, uint32_t dz_template_id, uint32_t seconds);

--- a/zone/expedition_repository.cpp
+++ b/zone/expedition_repository.cpp
@@ -62,7 +62,7 @@ std::optional<std::vector<ExpeditionDB::Template>> LoadAllTemplates(Database& db
 {
 	std::vector<ExpeditionDB::Template> out;
 	auto results = db.QueryDatabase(
-		"SELECT id, dz_template_id, name, slug, enabled, replay_lockout_seconds, replay_on_join, silent, boss_only_spawn, request_phrase, request_mode, notes "
+		"SELECT id, dz_template_id, name, slug, enabled, replay_lockout_seconds, replay_on_join, silent, boss_only_spawn, require_bosses_dead, request_phrase, request_mode, notes "
 		"FROM expedition_templates"
 	);
 
@@ -82,9 +82,10 @@ std::optional<std::vector<ExpeditionDB::Template>> LoadAllTemplates(Database& db
 		e.replay_on_join = Truthy(row[6]);
 		e.silent = Truthy(row[7]);
 		e.boss_only_spawn = Truthy(row[8]);
-		e.request_phrase = Text(row[9]);
-		e.request_mode = Text(row[10]);
-		e.notes = Text(row[11]);
+		e.require_bosses_dead = Truthy(row[9]);
+		e.request_phrase = Text(row[10]);
+		e.request_mode = Text(row[11]);
+		e.notes = Text(row[12]);
 		out.push_back(std::move(e));
 	}
 
@@ -221,14 +222,15 @@ uint32_t InsertTemplate(
 	bool replay_on_join,
 	bool silent,
 	bool boss_only_spawn,
+	bool require_bosses_dead,
 	const std::string& request_phrase,
 	const std::string& request_mode,
 	const std::string& notes)
 {
 	return InsertID(db, fmt::format(
 		"INSERT INTO expedition_templates "
-		"(dz_template_id, name, slug, enabled, replay_lockout_seconds, replay_on_join, silent, boss_only_spawn, request_phrase, request_mode, notes) "
-		"VALUES ({}, '{}', '{}', {}, {}, {}, {}, {}, '{}', '{}', '{}')",
+		"(dz_template_id, name, slug, enabled, replay_lockout_seconds, replay_on_join, silent, boss_only_spawn, require_bosses_dead, request_phrase, request_mode, notes) "
+		"VALUES ({}, '{}', '{}', {}, {}, {}, {}, {}, {}, '{}', '{}', '{}')",
 		dz_template_id,
 		Escape(name),
 		Escape(slug),
@@ -237,6 +239,7 @@ uint32_t InsertTemplate(
 		replay_on_join ? 1 : 0,
 		silent ? 1 : 0,
 		boss_only_spawn ? 1 : 0,
+		require_bosses_dead ? 1 : 0,
 		Escape(request_phrase),
 		Escape(request_mode),
 		Escape(notes)
@@ -252,8 +255,8 @@ uint32_t InsertTemplateFrom(
 {
 	return InsertID(db, fmt::format(
 		"INSERT INTO expedition_templates "
-		"(dz_template_id, name, slug, enabled, replay_lockout_seconds, replay_on_join, silent, boss_only_spawn, request_phrase, request_mode, notes) "
-		"SELECT {}, '{}', '{}', 0, replay_lockout_seconds, replay_on_join, silent, boss_only_spawn, request_phrase, request_mode, notes "
+		"(dz_template_id, name, slug, enabled, replay_lockout_seconds, replay_on_join, silent, boss_only_spawn, require_bosses_dead, request_phrase, request_mode, notes) "
+		"SELECT {}, '{}', '{}', 0, replay_lockout_seconds, replay_on_join, silent, boss_only_spawn, require_bosses_dead, request_phrase, request_mode, notes "
 		"FROM expedition_templates WHERE id = {}",
 		dz_template_id,
 		Escape(name),
@@ -290,6 +293,11 @@ bool UpdateTemplateSilent(Database& db, uint32_t template_id, bool silent)
 bool UpdateTemplateBossOnlySpawn(Database& db, uint32_t template_id, bool enabled)
 {
 	return QueryOK(db, fmt::format("UPDATE expedition_templates SET boss_only_spawn = {} WHERE id = {}", enabled ? 1 : 0, template_id));
+}
+
+bool UpdateTemplateRequireBossesDead(Database& db, uint32_t template_id, bool enabled)
+{
+	return QueryOK(db, fmt::format("UPDATE expedition_templates SET require_bosses_dead = {} WHERE id = {}", enabled ? 1 : 0, template_id));
 }
 
 bool UpdateTemplateRequestMode(Database& db, uint32_t template_id, const std::string& request_mode)

--- a/zone/expedition_repository.h
+++ b/zone/expedition_repository.h
@@ -39,6 +39,7 @@ uint32_t InsertTemplate(
 	bool replay_on_join,
 	bool silent,
 	bool boss_only_spawn,
+	bool require_bosses_dead,
 	const std::string& request_phrase,
 	const std::string& request_mode,
 	const std::string& notes
@@ -57,6 +58,7 @@ bool UpdateTemplateEnabled(Database& db, uint32_t template_id, bool enabled);
 bool UpdateTemplateReplay(Database& db, uint32_t template_id, uint32_t seconds);
 bool UpdateTemplateSilent(Database& db, uint32_t template_id, bool silent);
 bool UpdateTemplateBossOnlySpawn(Database& db, uint32_t template_id, bool enabled);
+bool UpdateTemplateRequireBossesDead(Database& db, uint32_t template_id, bool enabled);
 bool UpdateTemplateRequestMode(Database& db, uint32_t template_id, const std::string& request_mode);
 bool DeleteTemplate(Database& db, uint32_t template_id);
 

--- a/zone/gm_commands/expedition.cpp
+++ b/zone/gm_commands/expedition.cpp
@@ -1150,6 +1150,7 @@ namespace {
 		SendHelpLink(c, "#expedition set requestmode db_only|script_can_opt_in|script_only", "choose DB/script request handling");
 		SendHelpLink(c, "#expedition set silent on|off", "toggle normal create/failure messages");
 		SendHelpLink(c, "#expedition set bossonly on|off", "toggle spawning only mapped boss NPCs in expedition instances");
+		SendHelpLink(c, "#expedition set bossesdead on|off", "toggle requiring base zone bosses to be dead before creation");
 		SendHelpLink(c, "#expedition set switchid target|<id>", "set dynamic-zone switch entity id");
 
 		SendActionGroup(c, "Common Setup Actions", {
@@ -1617,6 +1618,7 @@ namespace {
 		SendInfoLine(c, "Replay", Duration(template_data.replay_lockout_seconds));
 		SendInfoLine(c, "Requests", template_data.request_mode);
 		SendInfoLine(c, "Boss-only spawns", OnOff(template_data.boss_only_spawn));
+		SendInfoLine(c, "Require bosses dead", OnOff(template_data.require_bosses_dead));
 		c->Message(Chat::White, ChatSeparator());
 
 		c->Message(Chat::Yellow, "Bosses & Chests:");
@@ -1697,6 +1699,7 @@ namespace {
 			OnOff(template_data.silent)
 		).c_str());
 		c->Message(Chat::White, fmt::format("Boss-only spawns: {}", OnOff(template_data.boss_only_spawn)).c_str());
+		c->Message(Chat::White, fmt::format("Require bosses dead: {}", OnOff(template_data.require_bosses_dead)).c_str());
 		c->Message(Chat::White, fmt::format(
 			"Zone-in: {}",
 			Location(template_data.dz_template.zone_id, template_data.dz_template.zone_in_x, template_data.dz_template.zone_in_y, template_data.dz_template.zone_in_z, template_data.dz_template.zone_in_h)
@@ -2319,6 +2322,7 @@ void ShowConfigScreen(Client* c, const ExpeditionDB::Template& template_data)
 		SendInfoLine(c, "Zone-in", dz.override_zone_in ? "set" : "NOT SET");
 		SendInfoLine(c, "Safe return", dz.return_zone_id ? "set" : "default");
 		SendInfoLine(c, "Boss-only spawns", OnOff(template_data.boss_only_spawn));
+		SendInfoLine(c, "Require bosses dead", OnOff(template_data.require_bosses_dead));
 		c->Message(Chat::White, ChatSeparator());
 
 		c->Message(Chat::White, "  Destination:");
@@ -2368,6 +2372,11 @@ void ShowConfigScreen(Client* c, const ExpeditionDB::Template& template_data)
 		SendActionRow(c, {
 			{"#expedition config bossonly on", "Bosses Only"},
 			{"#expedition config bossonly off", "Normal Spawns"}
+		});
+		c->Message(Chat::White, "  Availability (block creation while bosses are up in the base zone):");
+		SendActionRow(c, {
+			{"#expedition config bossesdead on", "Require Bosses Dead"},
+			{"#expedition config bossesdead off", "Ignore Base Zone Bosses"}
 		});
 		c->Message(Chat::White, ChatSeparator());
 		SendActionRow(c, {
@@ -2543,6 +2552,15 @@ void HandleConfig(Client* c, const Seperator* sep)
 			}
 			ExpeditionDB::SetTemplateBossOnlySpawn(content_db, template_id, enabled);
 			c->Message(Chat::Green, fmt::format("Set boss-only spawns to [{}].", OnOff(enabled)).c_str());
+		}
+		else if (action == "bossesdead" || action == "bosses_dead") {
+			bool enabled = false;
+			if (!ParseOnOffArg(sep->arg[3], enabled)) {
+				c->Message(Chat::Red, "Usage: #expedition config bossesdead on|off");
+				return;
+			}
+			ExpeditionDB::SetTemplateRequireBossesDead(content_db, template_id, enabled);
+			c->Message(Chat::Green, fmt::format("Set require bosses dead to [{}].", OnOff(enabled)).c_str());
 		}
 		else {
 			ShowConfigScreen(c, *template_data);
@@ -3850,6 +3868,15 @@ void HandleSet(Client* c, const Seperator* sep)
 			}
 			ExpeditionDB::SetTemplateBossOnlySpawn(content_db, template_data->id, enabled);
 			c->Message(Chat::Green, fmt::format("Set boss-only spawns to [{}].", OnOff(enabled)).c_str());
+		}
+		else if (field == "bossesdead" || field == "bosses_dead") {
+			bool enabled = false;
+			if (!ParseOnOffArg(sep->arg[3], enabled)) {
+				c->Message(Chat::Red, "Usage: #expedition set bossesdead on|off");
+				return;
+			}
+			ExpeditionDB::SetTemplateRequireBossesDead(content_db, template_data->id, enabled);
+			c->Message(Chat::Green, fmt::format("Set require bosses dead to [{}].", OnOff(enabled)).c_str());
 		}
 		else if (field == "requestmode") {
 			if (!IsRequestModeArg(sep->arg[3])) {


### PR DESCRIPTION
## Summary
- Adds a per-expedition `require_bosses_dead` setting (default **on**, preserving current behavior) controlling whether all associated bosses must be dead in the base zone before the expedition can be created.
- Exposes the toggle in the expedition config menu under a new **Availability** row (`[ Require Bosses Dead ] [ Ignore Base Zone Bosses ]`), plus `#expedition config bossesdead on|off` and `#expedition set bossesdead on|off`; the value is shown on the Configure/Show/Preview cards and in set-help.
- Fixes the requester menu message so it renders on a single line: `Unavailable while associated bosses are spawned in the base zone.` (previously the status and reason were printed awkwardly on two lines).

## Database
- New column `expedition_templates.require_bosses_dead` TINYINT(1) NOT NULL DEFAULT 1 (migration 9347, also included in the fresh-install 9344 schema); binary database version bumped to 9347.

## Implementation notes
- `HasActiveBaseZoneBoss()` short-circuits when the template has the requirement disabled, covering both the creation path and the requester-menu availability check with one gate.
- Repository load/insert/clone and the `SetTemplateRequireBossesDead` setter mirror the existing `boss_only_spawn` plumbing.

## Testing
- `ExpeditionSchemaTest` extended (creation migration includes the column, new 9347 migration entry test, default-on test): full unit test suite passes 119/119 (100%).
- Verified in-game on the local server: toggle appears in `#expedition config`, and the unavailable message renders on one line.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is opt-out per template with default preserving existing boss-dead gating; schema migration is additive with tests.
> 
> **Overview**
> Adds a per-expedition **`require_bosses_dead`** flag (DB default **on**) so operators can allow creation even when mapped bosses are still up in the base zone. **`HasActiveBaseZoneBoss()`** now returns false when the flag is off, so both creation blocking and requester-menu availability use the same gate.
> 
> Wires the setting through template load/insert/clone, **`SetTemplateRequireBossesDead`**, and GM tooling (`#expedition config/set bossesdead on|off`, config **Availability** row, show/preview cards). Migration **9347** and the fresh-install schema add the column; binary DB version bumps to **9347**.
> 
> Also fixes requester menu copy: **status-block** notes append on one line with the status (e.g. `Unavailable while …`) instead of a second indented line; other notes stay parenthetical.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a0c380f48ef9e7f6f4d1d5f4154d6fec397f824. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->