### PR TITLE
[Expeditions] Add expedition level requirements

### DIFF
--- a/common/database/database_update_manifest.h
+++ b/common/database/database_update_manifest.h
@@ -7545,6 +7545,19 @@ ADD COLUMN `max_level` INT(11) NOT NULL DEFAULT '0' AFTER `min_level`;
 ALTER TABLE `dynamic_zones`
 ADD COLUMN `min_level` INT(10) UNSIGNED NOT NULL DEFAULT 0 AFTER `max_players`,
 ADD COLUMN `max_level` INT(10) UNSIGNED NOT NULL DEFAULT 0 AFTER `min_level`;
+
+UPDATE `dynamic_zones` dz
+INNER JOIN `instance_list` il
+	ON dz.`instance_id` = il.`id`
+INNER JOIN `dynamic_zone_templates` dzt
+	ON dz.`name` = dzt.`name`
+	AND il.`zone` = dzt.`zone_id`
+	AND il.`version` = dzt.`zone_version`
+SET dz.`min_level` = dzt.`min_level`,
+	dz.`max_level` = dzt.`max_level`
+WHERE dz.`type` = 1
+	AND dz.`min_level` = 0
+	AND dz.`max_level` = 0;
 )"
 	},
 // -- template; copy/paste this when you need to create a new entry

--- a/common/database/database_update_manifest.h
+++ b/common/database/database_update_manifest.h
@@ -7522,6 +7522,31 @@ ADD COLUMN `require_bosses_dead` TINYINT(1) UNSIGNED NOT NULL DEFAULT '1' AFTER 
 )",
 		.content_schema_update = true
 	},
+	ManifestEntry{
+		.version = 9348,
+		.description = "2026_06_13_expedition_min_max_level.sql",
+		.check = "SHOW COLUMNS FROM `dynamic_zone_templates` LIKE 'min_level'",
+		.condition = "empty",
+		.match = "",
+		.sql = R"(
+ALTER TABLE `dynamic_zone_templates`
+ADD COLUMN `min_level` INT(11) NOT NULL DEFAULT '46' AFTER `max_players`,
+ADD COLUMN `max_level` INT(11) NOT NULL DEFAULT '0' AFTER `min_level`;
+)",
+		.content_schema_update = true
+	},
+	ManifestEntry{
+		.version = 9349,
+		.description = "2026_06_13_dynamic_zones_min_max_level.sql",
+		.check = "SHOW COLUMNS FROM `dynamic_zones` LIKE 'min_level'",
+		.condition = "empty",
+		.match = "",
+		.sql = R"(
+ALTER TABLE `dynamic_zones`
+ADD COLUMN `min_level` INT(10) UNSIGNED NOT NULL DEFAULT 0 AFTER `max_players`,
+ADD COLUMN `max_level` INT(10) UNSIGNED NOT NULL DEFAULT 0 AFTER `min_level`;
+)"
+	},
 // -- template; copy/paste this when you need to create a new entry
 //	ManifestEntry{
 //		.version = 9228,

--- a/common/dynamic_zone_base.cpp
+++ b/common/dynamic_zone_base.cpp
@@ -81,6 +81,8 @@ void DynamicZoneBase::LoadRepositoryResult(DynamicZonesRepository::DynamicZoneIn
 	m_leader.id          = dz_entry.leader_id;
 	m_min_players        = dz_entry.min_players;
 	m_max_players        = dz_entry.max_players;
+	m_min_level          = dz_entry.min_level;
+	m_max_level          = dz_entry.max_level;
 	m_instance_id        = dz_entry.instance_id;
 	m_type               = static_cast<DynamicZoneType>(dz_entry.type);
 	m_dz_switch_id       = dz_entry.dz_switch_id;
@@ -136,6 +138,8 @@ uint32_t DynamicZoneBase::SaveToDatabase()
 	dz.leader_id           = m_leader.id;
 	dz.min_players         = m_min_players;
 	dz.max_players         = m_max_players;
+	dz.min_level           = m_min_level;
+	dz.max_level           = m_max_level;
 	dz.instance_id         = static_cast<int32_t>(m_instance_id),
 	dz.type                = static_cast<uint8_t>(m_type);
 	dz.dz_switch_id        = m_dz_switch_id;
@@ -684,6 +688,8 @@ void DynamicZoneBase::LoadTemplate(const DynamicZoneTemplatesRepository::Dynamic
 	m_name               = dz_template.name;
 	m_min_players        = dz_template.min_players;
 	m_max_players        = dz_template.max_players;
+	m_min_level          = dz_template.min_level;
+	m_max_level          = dz_template.max_level;
 	m_duration           = std::chrono::seconds(dz_template.duration_seconds);
 	m_dz_switch_id       = dz_template.dz_switch_id;
 	m_compass.zone_id    = dz_template.compass_zone_id;

--- a/common/dynamic_zone_base.h
+++ b/common/dynamic_zone_base.h
@@ -111,6 +111,8 @@ public:
 	uint32_t GetMaxPlayers() const { return m_max_players; }
 	uint32_t GetMemberCount() const { return static_cast<uint32_t>(m_members.size()); }
 	uint32_t GetMinPlayers() const { return m_min_players; }
+	uint32_t GetMaxLevel() const { return m_max_level; }
+	uint32_t GetMinLevel() const { return m_min_level; }
 	uint32_t GetSecondsRemaining() const;
 	uint16_t GetZoneID() const { return static_cast<uint16_t>(m_zone_id); }
 	uint32_t GetZoneIndex() const { return (m_instance_id << 16) | (m_zone_id & 0xffff); }
@@ -159,6 +161,8 @@ public:
 	void SetMaxPlayers(uint32_t max_players) { m_max_players = max_players; }
 	void SetMemberStatus(uint32_t character_id, DynamicZoneMemberStatus status);
 	void SetMinPlayers(uint32_t min_players) { m_min_players = min_players; }
+	void SetMaxLevel(uint32_t max_level) { m_max_level = max_level; }
+	void SetMinLevel(uint32_t min_level) { m_min_level = min_level; }
 	void SetName(const std::string& name) { m_name = name; }
 	void SetReplayOnJoin(bool enabled, bool update_db = false);
 	void SetSafeReturn(const DynamicZoneLocation& location, bool update_db = false);
@@ -217,6 +221,8 @@ protected:
 	uint32_t m_zone_version = 0;
 	uint32_t m_min_players = 0;
 	uint32_t m_max_players = 0;
+	uint32_t m_min_level = 0;
+	uint32_t m_max_level = 0;
 	int m_dz_switch_id = 0;
 	bool m_never_expires = false;
 	bool m_has_zonein = false;
@@ -249,6 +255,8 @@ public:
 			m_zone_version,
 			m_min_players,
 			m_max_players,
+			m_min_level,
+			m_max_level,
 			m_dz_switch_id,
 			m_never_expires,
 			m_has_zonein,

--- a/common/repositories/base/base_dynamic_zone_templates_repository.h
+++ b/common/repositories/base/base_dynamic_zone_templates_repository.h
@@ -41,6 +41,8 @@ public:
 		float       zone_in_y;
 		float       zone_in_z;
 		float       zone_in_h;
+		int32_t     min_level;
+		int32_t     max_level;
 	};
 
 	static std::string PrimaryKey()
@@ -73,6 +75,8 @@ public:
 			"zone_in_y",
 			"zone_in_z",
 			"zone_in_h",
+			"min_level",
+			"max_level",
 		};
 	}
 
@@ -101,6 +105,8 @@ public:
 			"zone_in_y",
 			"zone_in_z",
 			"zone_in_h",
+			"min_level",
+			"max_level",
 		};
 	}
 
@@ -163,6 +169,8 @@ public:
 		e.zone_in_y        = 0;
 		e.zone_in_z        = 0;
 		e.zone_in_h        = 0;
+		e.min_level        = 46;
+		e.max_level        = 0;
 
 		return e;
 	}
@@ -221,6 +229,8 @@ public:
 			e.zone_in_y        = row[19] ? strtof(row[19], nullptr) : 0;
 			e.zone_in_z        = row[20] ? strtof(row[20], nullptr) : 0;
 			e.zone_in_h        = row[21] ? strtof(row[21], nullptr) : 0;
+			e.min_level        = row[22] ? static_cast<int32_t>(atoi(row[22])) : 46;
+			e.max_level        = row[23] ? static_cast<int32_t>(atoi(row[23])) : 0;
 
 			return e;
 		}
@@ -275,6 +285,8 @@ public:
 		v.push_back(columns[19] + " = " + std::to_string(e.zone_in_y));
 		v.push_back(columns[20] + " = " + std::to_string(e.zone_in_z));
 		v.push_back(columns[21] + " = " + std::to_string(e.zone_in_h));
+		v.push_back(columns[22] + " = " + std::to_string(e.min_level));
+		v.push_back(columns[23] + " = " + std::to_string(e.max_level));
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -318,6 +330,8 @@ public:
 		v.push_back(std::to_string(e.zone_in_y));
 		v.push_back(std::to_string(e.zone_in_z));
 		v.push_back(std::to_string(e.zone_in_h));
+		v.push_back(std::to_string(e.min_level));
+		v.push_back(std::to_string(e.max_level));
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -369,6 +383,8 @@ public:
 			v.push_back(std::to_string(e.zone_in_y));
 			v.push_back(std::to_string(e.zone_in_z));
 			v.push_back(std::to_string(e.zone_in_h));
+			v.push_back(std::to_string(e.min_level));
+			v.push_back(std::to_string(e.max_level));
 
 			insert_chunks.push_back("(" + Strings::Implode(",", v) + ")");
 		}
@@ -424,6 +440,8 @@ public:
 			e.zone_in_y        = row[19] ? strtof(row[19], nullptr) : 0;
 			e.zone_in_z        = row[20] ? strtof(row[20], nullptr) : 0;
 			e.zone_in_h        = row[21] ? strtof(row[21], nullptr) : 0;
+			e.min_level        = row[22] ? static_cast<int32_t>(atoi(row[22])) : 46;
+			e.max_level        = row[23] ? static_cast<int32_t>(atoi(row[23])) : 0;
 
 			all_entries.push_back(e);
 		}
@@ -470,6 +488,8 @@ public:
 			e.zone_in_y        = row[19] ? strtof(row[19], nullptr) : 0;
 			e.zone_in_z        = row[20] ? strtof(row[20], nullptr) : 0;
 			e.zone_in_h        = row[21] ? strtof(row[21], nullptr) : 0;
+			e.min_level        = row[22] ? static_cast<int32_t>(atoi(row[22])) : 46;
+			e.max_level        = row[23] ? static_cast<int32_t>(atoi(row[23])) : 0;
 
 			all_entries.push_back(e);
 		}
@@ -566,6 +586,8 @@ public:
 		v.push_back(std::to_string(e.zone_in_y));
 		v.push_back(std::to_string(e.zone_in_z));
 		v.push_back(std::to_string(e.zone_in_h));
+		v.push_back(std::to_string(e.min_level));
+		v.push_back(std::to_string(e.max_level));
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -610,6 +632,8 @@ public:
 			v.push_back(std::to_string(e.zone_in_y));
 			v.push_back(std::to_string(e.zone_in_z));
 			v.push_back(std::to_string(e.zone_in_h));
+			v.push_back(std::to_string(e.min_level));
+			v.push_back(std::to_string(e.max_level));
 
 			insert_chunks.push_back("(" + Strings::Implode(",", v) + ")");
 		}

--- a/common/repositories/base/base_dynamic_zones_repository.h
+++ b/common/repositories/base/base_dynamic_zones_repository.h
@@ -44,6 +44,8 @@ public:
 		uint8_t     has_zone_in;
 		int8_t      is_locked;
 		int8_t      add_replay;
+		uint32_t    min_level;
+		uint32_t    max_level;
 	};
 
 	static std::string PrimaryKey()
@@ -79,6 +81,8 @@ public:
 			"has_zone_in",
 			"is_locked",
 			"add_replay",
+			"min_level",
+			"max_level",
 		};
 	}
 
@@ -110,6 +114,8 @@ public:
 			"has_zone_in",
 			"is_locked",
 			"add_replay",
+			"min_level",
+			"max_level",
 		};
 	}
 
@@ -175,6 +181,8 @@ public:
 		e.has_zone_in         = 0;
 		e.is_locked           = 0;
 		e.add_replay          = 1;
+		e.min_level           = 0;
+		e.max_level           = 0;
 
 		return e;
 	}
@@ -236,6 +244,8 @@ public:
 			e.has_zone_in         = row[22] ? static_cast<uint8_t>(strtoul(row[22], nullptr, 10)) : 0;
 			e.is_locked           = row[23] ? static_cast<int8_t>(atoi(row[23])) : 0;
 			e.add_replay          = row[24] ? static_cast<int8_t>(atoi(row[24])) : 1;
+			e.min_level           = row[25] ? static_cast<uint32_t>(strtoul(row[25], nullptr, 10)) : 0;
+			e.max_level           = row[26] ? static_cast<uint32_t>(strtoul(row[26], nullptr, 10)) : 0;
 
 			return e;
 		}
@@ -293,6 +303,8 @@ public:
 		v.push_back(columns[22] + " = " + std::to_string(e.has_zone_in));
 		v.push_back(columns[23] + " = " + std::to_string(e.is_locked));
 		v.push_back(columns[24] + " = " + std::to_string(e.add_replay));
+		v.push_back(columns[25] + " = " + std::to_string(e.min_level));
+		v.push_back(columns[26] + " = " + std::to_string(e.max_level));
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -339,6 +351,8 @@ public:
 		v.push_back(std::to_string(e.has_zone_in));
 		v.push_back(std::to_string(e.is_locked));
 		v.push_back(std::to_string(e.add_replay));
+		v.push_back(std::to_string(e.min_level));
+		v.push_back(std::to_string(e.max_level));
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -393,6 +407,8 @@ public:
 			v.push_back(std::to_string(e.has_zone_in));
 			v.push_back(std::to_string(e.is_locked));
 			v.push_back(std::to_string(e.add_replay));
+			v.push_back(std::to_string(e.min_level));
+			v.push_back(std::to_string(e.max_level));
 
 			insert_chunks.push_back("(" + Strings::Implode(",", v) + ")");
 		}
@@ -451,6 +467,8 @@ public:
 			e.has_zone_in         = row[22] ? static_cast<uint8_t>(strtoul(row[22], nullptr, 10)) : 0;
 			e.is_locked           = row[23] ? static_cast<int8_t>(atoi(row[23])) : 0;
 			e.add_replay          = row[24] ? static_cast<int8_t>(atoi(row[24])) : 1;
+			e.min_level           = row[25] ? static_cast<uint32_t>(strtoul(row[25], nullptr, 10)) : 0;
+			e.max_level           = row[26] ? static_cast<uint32_t>(strtoul(row[26], nullptr, 10)) : 0;
 
 			all_entries.push_back(e);
 		}
@@ -500,6 +518,8 @@ public:
 			e.has_zone_in         = row[22] ? static_cast<uint8_t>(strtoul(row[22], nullptr, 10)) : 0;
 			e.is_locked           = row[23] ? static_cast<int8_t>(atoi(row[23])) : 0;
 			e.add_replay          = row[24] ? static_cast<int8_t>(atoi(row[24])) : 1;
+			e.min_level           = row[25] ? static_cast<uint32_t>(strtoul(row[25], nullptr, 10)) : 0;
+			e.max_level           = row[26] ? static_cast<uint32_t>(strtoul(row[26], nullptr, 10)) : 0;
 
 			all_entries.push_back(e);
 		}
@@ -599,6 +619,8 @@ public:
 		v.push_back(std::to_string(e.has_zone_in));
 		v.push_back(std::to_string(e.is_locked));
 		v.push_back(std::to_string(e.add_replay));
+		v.push_back(std::to_string(e.min_level));
+		v.push_back(std::to_string(e.max_level));
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -646,6 +668,8 @@ public:
 			v.push_back(std::to_string(e.has_zone_in));
 			v.push_back(std::to_string(e.is_locked));
 			v.push_back(std::to_string(e.add_replay));
+			v.push_back(std::to_string(e.min_level));
+			v.push_back(std::to_string(e.max_level));
 
 			insert_chunks.push_back("(" + Strings::Implode(",", v) + ")");
 		}

--- a/common/repositories/dynamic_zones_repository.h
+++ b/common/repositories/dynamic_zones_repository.h
@@ -53,6 +53,8 @@ public:
 		int      leader_id;
 		int      min_players;
 		int      max_players;
+		int      min_level;
+		int      max_level;
 		int      instance_id;
 		int      type;
 		int      dz_switch_id;
@@ -90,6 +92,8 @@ public:
 				dynamic_zones.leader_id,
 				dynamic_zones.min_players,
 				dynamic_zones.max_players,
+				dynamic_zones.min_level,
+				dynamic_zones.max_level,
 				dynamic_zones.instance_id,
 				dynamic_zones.type,
 				dynamic_zones.dz_switch_id,
@@ -131,6 +135,8 @@ public:
 		entry.leader_id           = strtol(row[col++], nullptr, 10);
 		entry.min_players         = strtol(row[col++], nullptr, 10);
 		entry.max_players         = strtol(row[col++], nullptr, 10);
+		entry.min_level           = strtol(row[col++], nullptr, 10);
+		entry.max_level           = strtol(row[col++], nullptr, 10);
 		entry.instance_id         = strtol(row[col++], nullptr, 10);
 		entry.type                = strtol(row[col++], nullptr, 10);
 		entry.dz_switch_id        = strtol(row[col++], nullptr, 10);
@@ -379,6 +385,7 @@ public:
 		uint32_t    id;
 		std::string name;
 		uint32_t    dz_id;
+		uint32_t    level;
 	};
 
 	// get character ids with possible active dz id by type
@@ -403,7 +410,8 @@ public:
 			SELECT
 				character_data.id,
 				character_data.name,
-				MAX(dynamic_zones.id)
+				MAX(dynamic_zones.id),
+				character_data.level
 			FROM character_data
 				LEFT JOIN dynamic_zone_members
 					ON character_data.id = dynamic_zone_members.character_id
@@ -426,6 +434,7 @@ public:
 				entry.id    = std::strtoul(row[0], nullptr, 10);
 				entry.name  = row[1];
 				entry.dz_id = row[2] ? std::strtoul(row[2], nullptr, 10) : 0;
+				entry.level = row[3] ? std::strtoul(row[3], nullptr, 10) : 0;
 
 				entries.push_back(std::move(entry));
 			}

--- a/common/version.h
+++ b/common/version.h
@@ -41,6 +41,6 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9347
+#define CURRENT_BINARY_DATABASE_VERSION 9349
 #define CURRENT_BINARY_BOTS_DATABASE_VERSION 9054
 #define CUSTOM_BINARY_DATABASE_VERSION 0

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -12028,6 +12028,12 @@ void Client::Handle_OP_PopupResponse(const EQApplicationPacket *app)
 		return;
 	}
 
+	// Player-facing "Form Expedition?" confirmation popup (Yes -> create).
+	if (ExpeditionRequestPopup::Owns(popup_response->popupid)) {
+		ExpeditionDB::HandleRequestConfirmPopup(*this, popup_response->popupid);
+		return;
+	}
+
 	//Get Item Details if POPUPID_REPLACE_SPELLWINDOW was used
 
 	/**

--- a/zone/dynamic_zone.cpp
+++ b/zone/dynamic_zone.cpp
@@ -396,6 +396,31 @@ bool DynamicZone::ProcessAddConflicts(Client* leader, Client* client, bool swapp
 		}
 	}
 
+	// enforce the expedition's level restrictions on the invited player; GM inviters bypass
+	// just as they do for the player-count requirement at creation time
+	const uint32_t min_level = GetMinLevel();
+	const uint32_t max_level = GetMaxLevel(); // 0 == unlimited
+	if (min_level != 0 || max_level != 0)
+	{
+		auto bypass_status = RuleI(Expedition, MinStatusToBypassPlayerCountRequirements);
+		const bool gm_bypass = leader && leader->GetGM() && leader->Admin() >= bypass_status;
+		if (!gm_bypass)
+		{
+			if (min_level != 0 && client->GetLevel() < min_level)
+			{
+				SendLeaderMessage(leader, Chat::Red, fmt::format(
+					"{} is below the minimum level of {} required for this expedition.", client->GetName(), min_level));
+				has_conflict = true;
+			}
+			else if (max_level != 0 && client->GetLevel() > max_level)
+			{
+				SendLeaderMessage(leader, Chat::Red, fmt::format(
+					"{} is above the maximum level of {} allowed for this expedition.", client->GetName(), max_level));
+				has_conflict = true;
+			}
+		}
+	}
+
 	auto invite_id = client->GetPendingDzInviteID();
 	if (invite_id)
 	{

--- a/zone/expedition_config.h
+++ b/zone/expedition_config.h
@@ -56,3 +56,13 @@ namespace ExpeditionEditPopup
 
 // Dispatches a two-button popup response for the expedition edit-mode add flow (defined in gm_commands/expedition.cpp).
 void ExpeditionEditPopupResponse(Client* client, uint32_t popup_id);
+
+// Player-facing "Form Expedition?" confirmation popup. Encodes the template id to create in the
+// low bits and uses a distinct base, so its ids never collide with ExpeditionEditPopup's.
+namespace ExpeditionRequestPopup
+{
+	inline constexpr uint32_t kBase = 0x41000000u; // distinct from ExpeditionEditPopup::kBase (0x40000000)
+	inline uint32_t Make(uint32_t template_id) { return kBase | (template_id & 0x000FFFFFu); }
+	inline bool Owns(uint32_t popup_id) { return (popup_id & 0xFFF00000u) == kBase; }
+	inline uint32_t TemplateOf(uint32_t popup_id) { return popup_id & 0x000FFFFFu; }
+}

--- a/zone/expedition_config.h
+++ b/zone/expedition_config.h
@@ -57,12 +57,13 @@ namespace ExpeditionEditPopup
 // Dispatches a two-button popup response for the expedition edit-mode add flow (defined in gm_commands/expedition.cpp).
 void ExpeditionEditPopupResponse(Client* client, uint32_t popup_id);
 
-// Player-facing "Form Expedition?" confirmation popup. Encodes the template id to create in the
-// low bits and uses a distinct base, so its ids never collide with ExpeditionEditPopup's.
+// Player-facing "Form Expedition?" confirmation popup. Template ids are tracked server-side so
+// the popup id does not need to pack database ids into a limited bit range.
 namespace ExpeditionRequestPopup
 {
 	inline constexpr uint32_t kBase = 0x41000000u; // distinct from ExpeditionEditPopup::kBase (0x40000000)
-	inline uint32_t Make(uint32_t template_id) { return kBase | (template_id & 0x000FFFFFu); }
-	inline bool Owns(uint32_t popup_id) { return (popup_id & 0xFFF00000u) == kBase; }
-	inline uint32_t TemplateOf(uint32_t popup_id) { return popup_id & 0x000FFFFFu; }
+	inline constexpr uint32_t kConfirm = kBase;
+	inline constexpr uint32_t kCancel = kBase | 1u;
+	inline bool Owns(uint32_t popup_id) { return popup_id == kConfirm || popup_id == kCancel; }
+	inline bool Accepted(uint32_t popup_id) { return popup_id == kConfirm; }
 }

--- a/zone/expedition_db.cpp
+++ b/zone/expedition_db.cpp
@@ -64,6 +64,7 @@ namespace {
 	std::unordered_map<uint32_t, Template> g_templates;
 	std::unordered_map<uint32_t, BuilderState> g_builder_states;
 	std::unordered_map<uint32_t, uint16_t> g_last_gm_target_menu_entity;
+	std::unordered_map<uint32_t, uint32_t> g_pending_request_confirmations;
 	std::unordered_map<uint32_t, std::unordered_set<std::string>> g_completed_runtime_events;
 	std::unordered_map<uint32_t, std::unordered_map<uint32_t, std::unordered_set<uint32_t>>> g_grouped_boss_progress;
 
@@ -1918,11 +1919,13 @@ ExpeditionCheckResult CheckExpeditionFromTemplate(Client& client, const std::str
 			template_data.name,
 			FormatExpeditionRequirements(template_data)
 		);
+
+		g_pending_request_confirmations[client.CharacterID()] = template_data.id;
 		client.SendFullPopup(
 			"Form Expedition?",
 			body.c_str(),
-			ExpeditionRequestPopup::Make(template_data.id), // Yes -> create
-			0,                                              // No  -> dismiss, no action
+			ExpeditionRequestPopup::kConfirm, // Yes -> create
+			ExpeditionRequestPopup::kCancel,  // No  -> dismiss and clear pending request
 			1, 0, "Yes", "No"
 		);
 	}
@@ -2041,10 +2044,21 @@ bool HandleRequestSay(Client& client, NPC& npc, const std::string& message)
 
 void HandleRequestConfirmPopup(Client& client, uint32_t popup_id)
 {
-	// Player answered "Yes" on the "Form Expedition?" confirmation popup. Look up the encoded
+	auto pending = g_pending_request_confirmations.find(client.CharacterID());
+	if (pending == g_pending_request_confirmations.end()) {
+		return;
+	}
+
+	const uint32_t template_id = pending->second;
+	g_pending_request_confirmations.erase(pending);
+
+	if (!ExpeditionRequestPopup::Accepted(popup_id)) {
+		return;
+	}
+
+	// Player answered "Yes" on the "Form Expedition?" confirmation popup. Look up the pending
 	// template and create it. TryCreateTemplateRequest re-validates (level, player count,
 	// lockouts) and messages the player on failure.
-	const uint32_t template_id = ExpeditionRequestPopup::TemplateOf(popup_id);
 	const Template* template_data = FindTemplate(template_id);
 	if (!template_data) {
 		return;

--- a/zone/expedition_db.cpp
+++ b/zone/expedition_db.cpp
@@ -9,6 +9,8 @@
 #include "zone/dynamic_zone.h"
 #include "zone/entity.h"
 #include "zone/expedition_config.h"
+#include "zone/groups.h"
+#include "zone/raids.h"
 #include "zone/event_codes.h"
 #include "zone/npc.h"
 #include "zone/quest_parser_collection.h"
@@ -50,6 +52,14 @@ std::string NpcTypeLabel(uint32_t npc_type_id)
 
 namespace {
 	constexpr const char* kManageRule = "===========================================";
+	constexpr const char* kEntryDivider = "- - - - - - - - - - - - - - - - - - - - - -";
+
+	// Roughly center text within the rule width for tidy headers.
+	std::string CenteredRuleText(const std::string& text)
+	{
+		const size_t width = std::char_traits<char>::length(kManageRule);
+		return text.size() >= width ? text : std::string((width - text.size()) / 2, ' ') + text;
+	}
 
 	std::unordered_map<uint32_t, Template> g_templates;
 	std::unordered_map<uint32_t, BuilderState> g_builder_states;
@@ -509,6 +519,66 @@ namespace {
 		return true;
 	}
 
+	// Player-facing summaries of who may form/join an expedition. The "*Text" helpers
+	// describe the configured range; the "*Met" helpers report whether the requesting
+	// player actually satisfies it (independent of GM bypass, so the menu reflects reality).
+	std::string LevelRangeText(const Template& template_data)
+	{
+		const auto& dz = template_data.dz_template;
+		if (dz.min_level > 0 && dz.max_level > 0) {
+			return fmt::format("Level {}-{}", dz.min_level, dz.max_level);
+		}
+		if (dz.min_level > 0) {
+			return fmt::format("Level {}+", dz.min_level);
+		}
+		if (dz.max_level > 0) {
+			return fmt::format("Level up to {}", dz.max_level);
+		}
+		return "Any level";
+	}
+
+	std::string PlayerRangeText(const Template& template_data)
+	{
+		const auto& dz = template_data.dz_template;
+		if (dz.max_players > 0 && dz.min_players != dz.max_players) {
+			return fmt::format("{}-{} players", dz.min_players, dz.max_players);
+		}
+		const int32_t count = dz.max_players > 0 ? dz.max_players : dz.min_players;
+		return fmt::format("{} player{}", count, count == 1 ? "" : "s");
+	}
+
+	bool LevelRequirementMet(const Template& template_data, uint32_t player_level)
+	{
+		const auto& dz = template_data.dz_template;
+		const int32_t lvl = static_cast<int32_t>(player_level);
+		return (dz.min_level == 0 || lvl >= dz.min_level) && (dz.max_level == 0 || lvl <= dz.max_level);
+	}
+
+	bool PlayerRequirementMet(const Template& template_data, uint32_t party_size)
+	{
+		// mirrors the creation rule: only the minimum gates creation (raids beyond max are truncated)
+		return static_cast<int32_t>(party_size) >= template_data.dz_template.min_players;
+	}
+
+	// Combined one-line summary used in the confirmation popup body (no color).
+	std::string FormatExpeditionRequirements(const Template& template_data)
+	{
+		return fmt::format("{}  |  {}", LevelRangeText(template_data), PlayerRangeText(template_data));
+	}
+
+	// The requesting player's prospective party size (group/raid), used to evaluate the
+	// player-count requirement for the menu coloring.
+	uint32_t RequesterPartySize(Client& client)
+	{
+		if (Raid* raid = client.GetRaid()) {
+			return raid->RaidCount();
+		}
+		if (Group* group = client.GetGroup()) {
+			return group->GroupCount();
+		}
+		return 1;
+	}
+
 	void OfferRequestMenu(Client& client, const RequesterMatches& matches)
 	{
 		if (matches.empty()) {
@@ -518,6 +588,11 @@ namespace {
 		const bool multi = matches.size() > 1;
 		DynamicZone* active_expedition = RequesterContextExpedition(client);
 
+		// Evaluated against the requesting player's real level and party size so the menu
+		// colors reflect actual eligibility, regardless of any GM player-count/level bypass.
+		const uint32_t player_level = client.GetLevel();
+		const uint32_t party_size = RequesterPartySize(client);
+
 		// Each menu entry is either a clickable action (phrase + button label) or an info note.
 		struct MenuEntry {
 			std::string name;
@@ -525,6 +600,10 @@ namespace {
 			std::string button;
 			std::string status;
 			std::string note;
+			std::string level_text;
+			std::string players_text;
+			bool level_met = false;
+			bool players_met = false;
 			bool status_block = false;
 		};
 		std::vector<MenuEntry> entries;
@@ -538,6 +617,10 @@ namespace {
 
 			MenuEntry entry;
 			entry.name = RequesterMenuLabel(*template_data);
+			entry.level_text = LevelRangeText(*template_data);
+			entry.players_text = PlayerRangeText(*template_data);
+			entry.level_met = LevelRequirementMet(*template_data, player_level);
+			entry.players_met = PlayerRequirementMet(*template_data, party_size);
 			if (active_expedition) {
 				if (IsMatchingExpedition(*active_expedition, *template_data)) {
 					entry.status = "Current";
@@ -576,30 +659,43 @@ namespace {
 			return;
 		}
 
-		const std::string title = multi ? "   Expeditions Offered Here" : fmt::format("   Expedition: {}", entries.front().name);
+		const std::string title = multi ? "Expeditions Offered Here" : fmt::format("Expedition: {}", entries.front().name);
 		client.Message(Chat::NPCQuestSay, "%s", kManageRule);
-		client.Message(Chat::NPCQuestSay, "%s", title.c_str());
+		client.Message(Chat::NPCQuestSay, "%s", CenteredRuleText(title).c_str());
 		client.Message(Chat::NPCQuestSay, "%s", kManageRule);
-		for (const auto& entry : entries) {
+
+		for (size_t i = 0; i < entries.size(); ++i) {
+			const auto& entry = entries[i];
+
 			// Status-block notes read as a sentence continuation ("Unavailable while ..."),
 			// other notes are parenthetical hints ("Locked (replay timer active)").
-			const std::string status = entry.note.empty() ? entry.status :
+			const std::string status_text = entry.note.empty() ? entry.status :
 				entry.status_block ? fmt::format("{} {}", entry.status, entry.note) :
 				fmt::format("{} ({})", entry.status, entry.note);
+
+			// Header line: "<name> - <status>" (the name is dropped in single view since it is
+			// already in the title), with the action button appended when one is offered.
+			std::string header = multi ? fmt::format("{} - {}", entry.name, status_text) : status_text;
 			if (!entry.phrase.empty()) {
-				const std::string action = Saylink::Silent(entry.phrase, fmt::format("[ {} ]", entry.button));
-				const std::string line = multi ?
-					fmt::format("   {} - {} {}", entry.name, status, action) :
-					fmt::format("   {} {}", status, action);
-				client.Message(Chat::NPCQuestSay, "%s", line.c_str());
-				continue;
+				header += "   " + Saylink::Silent(entry.phrase, fmt::format("[ {} ]", entry.button));
 			}
 
-			const std::string line = multi ?
-				fmt::format("   {} - {}", entry.name, status) :
-				fmt::format("   {}", status);
-			const uint16_t chat_type = entry.status == "Locked" ? Chat::Red : Chat::Yellow;
-			client.Message(chat_type, "%s", line.c_str());
+			// Color the whole header by availability so each block reads at a glance.
+			const uint16_t status_color =
+				entry.status == "Available" ? Chat::Green :
+				(entry.status == "Locked" || entry.status == "Unavailable") ? Chat::Red :
+				Chat::Yellow;
+			client.Message(status_color, "%s", header.c_str());
+
+			// Requirement lines, indented under the header and colored by the requesting player's
+			// real eligibility (green = meets it, red = does not; independent of any GM bypass).
+			client.Message(entry.level_met ? Chat::Green : Chat::Red, "     %s", entry.level_text.c_str());
+			client.Message(entry.players_met ? Chat::Green : Chat::Red, "     %s", entry.players_text.c_str());
+
+			// Light divider between expeditions (omitted after the last one).
+			if (multi && i + 1 < entries.size()) {
+				client.Message(Chat::Gray, "%s", kEntryDivider);
+			}
 		}
 		client.Message(Chat::NPCQuestSay, "%s", kManageRule);
 	}
@@ -856,15 +952,17 @@ uint32_t CreateTemplateFromClient(Database& db, Client& client, const std::strin
 
 	const uint32_t dz_template_id = InsertID(db, fmt::format(
 		"INSERT INTO dynamic_zone_templates "
-		"(zone_id, zone_version, name, min_players, max_players, duration_seconds, dz_switch_id, "
+		"(zone_id, zone_version, name, min_players, max_players, min_level, max_level, duration_seconds, dz_switch_id, "
 		"compass_zone_id, compass_x, compass_y, compass_z, return_zone_id, return_x, return_y, return_z, return_h, "
 		"override_zone_in, zone_in_x, zone_in_y, zone_in_z, zone_in_h) "
-		"VALUES ({}, {}, '{}', {}, {}, {}, 0, {}, {}, {}, {}, {}, {}, {}, {}, {}, 1, {}, {}, {}, {})",
+		"VALUES ({}, {}, '{}', {}, {}, {}, {}, {}, 0, {}, {}, {}, {}, {}, {}, {}, {}, {}, 1, {}, {}, {}, {})",
 		zone->GetZoneID(),
 		zone->GetInstanceVersion(),
 		escaped_name,
 		kSimpleSetupMinPlayers,
 		kSimpleSetupMaxPlayers,
+		kSimpleSetupMinLevel,
+		kSimpleSetupMaxLevel,
 		kSimpleSetupDurationSeconds,
 		zone->GetZoneID(),
 		pos.x,
@@ -921,10 +1019,10 @@ uint32_t CloneTemplate(Database& db, uint32_t source_template_id, const std::str
 	const std::string slug = fmt::format("{}_{}_{}", Slugify(name), source_template_id, static_cast<uint32_t>(std::time(nullptr)));
 	const uint32_t dz_template_id = InsertID(db, fmt::format(
 		"INSERT INTO dynamic_zone_templates "
-		"(zone_id, zone_version, name, min_players, max_players, duration_seconds, dz_switch_id, "
+		"(zone_id, zone_version, name, min_players, max_players, min_level, max_level, duration_seconds, dz_switch_id, "
 		"compass_zone_id, compass_x, compass_y, compass_z, return_zone_id, return_x, return_y, return_z, return_h, "
 		"override_zone_in, zone_in_x, zone_in_y, zone_in_z, zone_in_h) "
-		"SELECT zone_id, zone_version, '{}', min_players, max_players, duration_seconds, dz_switch_id, "
+		"SELECT zone_id, zone_version, '{}', min_players, max_players, min_level, max_level, duration_seconds, dz_switch_id, "
 		"compass_zone_id, compass_x, compass_y, compass_z, return_zone_id, return_x, return_y, return_z, return_h, "
 		"override_zone_in, zone_in_x, zone_in_y, zone_in_z, zone_in_h "
 		"FROM dynamic_zone_templates WHERE id = {}",
@@ -1074,6 +1172,18 @@ bool SetDzTemplatePlayers(Database& db, uint32_t dz_template_id, uint32_t min_pl
 		"UPDATE dynamic_zone_templates SET min_players = {}, max_players = {} WHERE id = {}",
 		min_players,
 		max_players,
+		dz_template_id
+	));
+	Reload(db);
+	return ok;
+}
+
+bool SetDzTemplateLevels(Database& db, uint32_t dz_template_id, uint32_t min_level, uint32_t max_level)
+{
+	const bool ok = QueryOK(db, fmt::format(
+		"UPDATE dynamic_zone_templates SET min_level = {}, max_level = {} WHERE id = {}",
+		min_level,
+		max_level,
 		dz_template_id
 	));
 	Reload(db);
@@ -1491,6 +1601,10 @@ ValidationResult ValidateTemplate(const Template& template_data)
 		result.errors.push_back("Player minimum and maximum are invalid.");
 	}
 
+	if (template_data.dz_template.max_level != 0 && template_data.dz_template.max_level < template_data.dz_template.min_level) {
+		result.errors.push_back("Maximum level must be zero (unlimited) or at least the minimum level.");
+	}
+
 	if (
 		template_data.request_mode != "db_only" &&
 		template_data.request_mode != "script_can_opt_in" &&
@@ -1780,6 +1894,31 @@ ExpeditionCheckResult CheckExpeditionFromTemplate(Client& client, const std::str
 	return result;
 }
 
+	// Presents a Yes/No confirmation popup before forming an expedition from the menu saylink.
+	// If the player is no longer eligible, defer to the normal path so they get the real reason.
+	void OfferRequestConfirmation(Client& client, const Template& template_data)
+	{
+		const auto check = CheckExpeditionFromTemplate(client, template_data);
+		if (!check.success) {
+			TryCreateTemplateRequest(client, template_data);
+			return;
+		}
+
+		const std::string body = fmt::format(
+			"Form the expedition \"{}\"?<br><br>{}<br><br>"
+			"This creates the instance for you and your group/raid.",
+			template_data.name,
+			FormatExpeditionRequirements(template_data)
+		);
+		client.SendFullPopup(
+			"Form Expedition?",
+			body.c_str(),
+			ExpeditionRequestPopup::Make(template_data.id), // Yes -> create
+			0,                                              // No  -> dismiss, no action
+			1, 0, "Yes", "No"
+		);
+	}
+
 bool HandleRequestSay(Client& client, NPC& npc, const std::string& message)
 {
 	if (!zone) {
@@ -1835,7 +1974,7 @@ bool HandleRequestSay(Client& client, NPC& npc, const std::string& message)
 
 			if (menu_template_id != 0) {
 				if (menu_template_id == template_data->id) {
-					TryCreateTemplateRequest(client, *template_data);
+					OfferRequestConfirmation(client, *template_data);
 					return true;
 				}
 				continue;
@@ -1890,6 +2029,20 @@ bool HandleRequestSay(Client& client, NPC& npc, const std::string& message)
 	}
 
 	return false;
+}
+
+void HandleRequestConfirmPopup(Client& client, uint32_t popup_id)
+{
+	// Player answered "Yes" on the "Form Expedition?" confirmation popup. Look up the encoded
+	// template and create it. TryCreateTemplateRequest re-validates (level, player count,
+	// lockouts) and messages the player on failure.
+	const uint32_t template_id = ExpeditionRequestPopup::TemplateOf(popup_id);
+	const Template* template_data = FindTemplate(template_id);
+	if (!template_data) {
+		return;
+	}
+
+	TryCreateTemplateRequest(client, *template_data);
 }
 
 bool HandleNpcDeath(NPC& npc, Client* killer)

--- a/zone/expedition_db.cpp
+++ b/zone/expedition_db.cpp
@@ -407,6 +407,14 @@ namespace {
 			return fmt::format("need {}-{} players", check.min_players, check.max_players);
 		}
 
+		if (check.reason == "min_level") {
+			return "below minimum level";
+		}
+
+		if (check.reason == "max_level") {
+			return "above maximum level";
+		}
+
 		if (check.reason == "no_members") {
 			return "no eligible members";
 		}
@@ -1975,7 +1983,7 @@ bool HandleRequestSay(Client& client, NPC& npc, const std::string& message)
 			if (menu_template_id != 0) {
 				if (menu_template_id == template_data->id) {
 					OfferRequestConfirmation(client, *template_data);
-					return true;
+					return false;
 				}
 				continue;
 			}

--- a/zone/expedition_db.h
+++ b/zone/expedition_db.h
@@ -21,6 +21,8 @@ namespace ExpeditionDB {
 
 inline constexpr uint32_t kSimpleSetupMinPlayers = 6;
 inline constexpr uint32_t kSimpleSetupMaxPlayers = 54;
+inline constexpr uint32_t kSimpleSetupMinLevel = 46;
+inline constexpr uint32_t kSimpleSetupMaxLevel = 0; // 0 = unlimited (no maximum)
 inline constexpr uint32_t kSimpleSetupDurationSeconds = 6 * 60 * 60;
 inline constexpr uint32_t kSimpleSetupReplaySeconds = 24 * 60 * 60;
 inline constexpr uint32_t kSimpleBossLockoutSeconds = (6 * 24 * 60 * 60) + (12 * 60 * 60);
@@ -407,6 +409,7 @@ bool SetTemplateRequestMode(Database& db, uint32_t template_id, const std::strin
 bool SetDzTemplateZone(Database& db, uint32_t dz_template_id, uint32_t zone_id, uint32_t version);
 bool SetDzTemplateDuration(Database& db, uint32_t dz_template_id, uint32_t seconds);
 bool SetDzTemplatePlayers(Database& db, uint32_t dz_template_id, uint32_t min_players, uint32_t max_players);
+bool SetDzTemplateLevels(Database& db, uint32_t dz_template_id, uint32_t min_level, uint32_t max_level);
 bool SetDzTemplateZoneIn(Database& db, uint32_t dz_template_id, float x, float y, float z, float h);
 bool SetDzTemplateSafeReturn(Database& db, uint32_t dz_template_id, uint32_t zone_id, float x, float y, float z, float h);
 bool SetDzTemplateCompass(Database& db, uint32_t dz_template_id, uint32_t zone_id, float x, float y, float z);
@@ -446,6 +449,7 @@ ExpeditionCheckResult CheckExpeditionFromTemplate(Client& client, const Template
 ExpeditionCheckResult CheckExpeditionFromTemplate(Client& client, const Template& template_data, bool allow_disabled);
 ExpeditionCheckResult CheckExpeditionFromTemplate(Client& client, const std::string& id_or_name);
 bool HandleRequestSay(Client& client, NPC& npc, const std::string& message);
+void HandleRequestConfirmPopup(Client& client, uint32_t popup_id);
 bool HandleNpcDeath(NPC& npc, Client* killer);
 bool HandleNpcSpawn(NPC& npc);
 bool IsBossSpawnBlockedByActiveLockout(uint32_t npc_type_id, uint32_t spawn2_id);

--- a/zone/expedition_request.cpp
+++ b/zone/expedition_request.cpp
@@ -141,6 +141,11 @@ bool ExpeditionRequest::CanMembersJoin(const std::vector<std::string>& member_na
 		requirements_met = IsPlayerCountValidated();
 	}
 
+	if (requirements_met)
+	{
+		requirements_met = IsLevelValidated();
+	}
+
 	return requirements_met;
 }
 
@@ -192,6 +197,7 @@ bool ExpeditionRequest::CheckMembersForConflicts(const std::vector<std::string>&
 
 		m_members.emplace_back(character.id, character.name, DynamicZoneMemberStatus::Online);
 		char_ids.push_back(character.id);
+		m_member_levels.emplace_back(character.name, character.level);
 	}
 
 	auto lockouts = CharacterExpeditionLockoutsRepository::GetLockouts(database, char_ids, m_dz->GetName());
@@ -322,6 +328,52 @@ bool ExpeditionRequest::IsPlayerCountValidated()
 
 	if (gm_bypass && !m_silent) {
 		m_requester->Message(Chat::White, "Your GM Status allows you to bypass expedition minimum and maximum player restrictions.");
+	}
+
+	return requirements_met;
+}
+
+bool ExpeditionRequest::IsLevelValidated()
+{
+	const uint32_t min_level = m_dz->GetMinLevel();
+	const uint32_t max_level = m_dz->GetMaxLevel(); // 0 == unlimited
+
+	if (min_level == 0 && max_level == 0)
+	{
+		return true; // no level restriction configured
+	}
+
+	// GMs bypass level restrictions just as they bypass the player-count requirement
+	auto bypass_status = RuleI(Expedition, MinStatusToBypassPlayerCountRequirements);
+	if (m_requester && m_requester->GetGM() && m_requester->Admin() >= bypass_status)
+	{
+		return true;
+	}
+
+	bool requirements_met = true;
+
+	for (const auto& [name, level] : m_member_levels)
+	{
+		if (min_level != 0 && level < min_level)
+		{
+			requirements_met = false;
+			m_failure_reason = "min_level";
+			if (!m_silent)
+			{
+				Client::SendCrossZoneMessage(m_leader, m_leader_name, Chat::Red, fmt::format(
+					"{} is below the minimum level of {} required for this expedition.", name, min_level));
+			}
+		}
+		else if (max_level != 0 && level > max_level)
+		{
+			requirements_met = false;
+			m_failure_reason = "max_level";
+			if (!m_silent)
+			{
+				Client::SendCrossZoneMessage(m_leader, m_leader_name, Chat::Red, fmt::format(
+					"{} is above the maximum level of {} allowed for this expedition.", name, max_level));
+			}
+		}
 	}
 
 	return requirements_met;

--- a/zone/expedition_request.cpp
+++ b/zone/expedition_request.cpp
@@ -22,6 +22,7 @@
 
 #include "common/repositories/character_expedition_lockouts_repository.h"
 #include "zone/client.h"
+#include "zone/entity.h"
 #include "zone/groups.h"
 #include "zone/raids.h"
 #include "zone/string_ids.h"
@@ -197,7 +198,14 @@ bool ExpeditionRequest::CheckMembersForConflicts(const std::vector<std::string>&
 
 		m_members.emplace_back(character.id, character.name, DynamicZoneMemberStatus::Online);
 		char_ids.push_back(character.id);
-		m_member_levels.emplace_back(character.name, character.level);
+
+		uint32_t member_level = character.level;
+		if (Client* member_client = entity_list.GetClientByCharID(character.id))
+		{
+			member_level = member_client->GetLevel();
+		}
+
+		m_member_levels.emplace_back(character.name, member_level);
 	}
 
 	auto lockouts = CharacterExpeditionLockoutsRepository::GetLockouts(database, char_ids, m_dz->GetName());

--- a/zone/expedition_request.h
+++ b/zone/expedition_request.h
@@ -25,6 +25,7 @@
 
 #include <cstdint>
 #include <string>
+#include <utility>
 #include <vector>
 
 class Client;
@@ -52,6 +53,7 @@ private:
 	bool CanGroupRequest(Group* group);
 	bool CheckMembersForConflicts(const std::vector<std::string>& member_names);
 	bool IsPlayerCountValidated();
+	bool IsLevelValidated();
 	bool SaveLeaderLockouts(const std::vector<DzLockout>& leader_lockouts);
 	void SendLeaderMemberInExpedition(const std::string& name, bool is_solo);
 	void SendLeaderMemberReplayLockout(const std::string& name, const DzLockout& lockout, bool is_solo);
@@ -68,4 +70,5 @@ private:
 	std::string m_failure_reason;
 	std::vector<DynamicZoneMember> m_members;
 	std::vector<DzLockout> m_lockouts;
+	std::vector<std::pair<std::string, uint32_t>> m_member_levels; // name + level captured during conflict scan
 };

--- a/zone/gm_commands/expedition.cpp
+++ b/zone/gm_commands/expedition.cpp
@@ -2251,21 +2251,21 @@ void ShowLevelMatrix(
 	const std::string& title,
 	const std::string& command_prefix,
 	uint32_t current,
-	bool allow_unlimited,
+	const std::string& zero_label,
 	const std::string& back_command = {},
 	const std::string& back_label = {}
 )
 {
 		SendCardTop(c, title);
-		SendInfoLine(c, "Current", (allow_unlimited && current == 0) ? "Unlimited" : fmt::format("{}", current));
+		SendInfoLine(c, "Current", (current == 0) ? zero_label : fmt::format("{}", current));
 		c->Message(Chat::White, fmt::format(
 			"  Tip: type  {} <level>  to set an exact value{}.",
 			command_prefix,
-			allow_unlimited ? " (0 = Unlimited)" : ""
+			!zero_label.empty() ? fmt::format(" (0 = {})", zero_label) : ""
 		).c_str());
-		if (allow_unlimited) {
-			c->Message(Chat::White, "  No cap:");
-			SendActionRow(c, {{command_prefix + " 0", "Unlimited"}});
+		if (!zero_label.empty()) {
+			c->Message(Chat::White, zero_label == "Unlimited" ? "  No cap:" : "  No minimum:");
+			SendActionRow(c, {{command_prefix + " 0", zero_label}});
 		}
 		c->Message(Chat::White, "  Low:");
 		SendActionRow(c, {
@@ -2583,7 +2583,7 @@ void HandleConfig(Client* c, const Seperator* sep)
 		else if (action == "minlevel") {
 			if (sep->arg[3][0] == '\0') {
 				ShowLevelMatrix(c, fmt::format("Min Level: {}", template_data->name),
-					"#expedition config minlevel", template_data->dz_template.min_level, false,
+					"#expedition config minlevel", template_data->dz_template.min_level, "Any",
 					"#expedition config", "Back to Config");
 				return;
 			}
@@ -2606,7 +2606,7 @@ void HandleConfig(Client* c, const Seperator* sep)
 		else if (action == "maxlevel") {
 			if (sep->arg[3][0] == '\0') {
 				ShowLevelMatrix(c, fmt::format("Max Level: {}", template_data->name),
-					"#expedition config maxlevel", template_data->dz_template.max_level, true,
+					"#expedition config maxlevel", template_data->dz_template.max_level, "Unlimited",
 					"#expedition config", "Back to Config");
 				return;
 			}

--- a/zone/gm_commands/expedition.cpp
+++ b/zone/gm_commands/expedition.cpp
@@ -2246,6 +2246,49 @@ void ShowCountMatrix(
 		SendCardBottom(c);
 }
 
+void ShowLevelMatrix(
+	Client* c,
+	const std::string& title,
+	const std::string& command_prefix,
+	uint32_t current,
+	bool allow_unlimited,
+	const std::string& back_command = {},
+	const std::string& back_label = {}
+)
+{
+		SendCardTop(c, title);
+		SendInfoLine(c, "Current", (allow_unlimited && current == 0) ? "Unlimited" : fmt::format("{}", current));
+		c->Message(Chat::White, fmt::format(
+			"  Tip: type  {} <level>  to set an exact value{}.",
+			command_prefix,
+			allow_unlimited ? " (0 = Unlimited)" : ""
+		).c_str());
+		if (allow_unlimited) {
+			c->Message(Chat::White, "  No cap:");
+			SendActionRow(c, {{command_prefix + " 0", "Unlimited"}});
+		}
+		c->Message(Chat::White, "  Low:");
+		SendActionRow(c, {
+			{command_prefix + " 1", "1"}, {command_prefix + " 10", "10"},
+			{command_prefix + " 20", "20"}, {command_prefix + " 30", "30"}
+		});
+		c->Message(Chat::White, "  Mid:");
+		SendActionRow(c, {
+			{command_prefix + " 40", "40"}, {command_prefix + " 46", "46"},
+			{command_prefix + " 50", "50"}, {command_prefix + " 55", "55"}
+		});
+		c->Message(Chat::White, "  High:");
+		SendActionRow(c, {
+			{command_prefix + " 60", "60"}, {command_prefix + " 65", "65"},
+			{command_prefix + " 70", "70"}, {command_prefix + " 75", "75"}
+		});
+		if (!back_command.empty() && !back_label.empty()) {
+			c->Message(Chat::White, "  Navigate:");
+			SendActionRow(c, {{back_command, back_label}});
+		}
+		SendCardBottom(c);
+}
+
 std::vector<uint32_t> ExistingZoneVersions(uint32_t zone_id)
 {
 	std::vector<uint32_t> versions;
@@ -2319,6 +2362,9 @@ void ShowConfigScreen(Client* c, const ExpeditionDB::Template& template_data)
 		SendInfoLine(c, "Duration", Duration(dz.duration_seconds));
 		SendInfoLine(c, "Replay", Duration(template_data.replay_lockout_seconds));
 		SendInfoLine(c, "Players", fmt::format("{} - {}", dz.min_players, dz.max_players));
+		SendInfoLine(c, "Level", fmt::format("{} - {}",
+			dz.min_level ? std::to_string(dz.min_level) : "Any",
+			dz.max_level ? std::to_string(dz.max_level) : "Unlimited"));
 		SendInfoLine(c, "Zone-in", dz.override_zone_in ? "set" : "NOT SET");
 		SendInfoLine(c, "Safe return", dz.return_zone_id ? "set" : "default");
 		SendInfoLine(c, "Boss-only spawns", OnOff(template_data.boss_only_spawn));
@@ -2361,6 +2407,22 @@ void ShowConfigScreen(Client* c, const ExpeditionDB::Template& template_data)
 			{"#expedition config maxplayers 24", "24"},
 			{"#expedition config maxplayers 54", "54"},
 			{"#expedition config maxplayers", "More..."}
+		});
+		c->Message(Chat::White, "  Min level (lowest level allowed to join):");
+		SendActionRow(c, {
+			{"#expedition config minlevel 1", "1"},
+			{"#expedition config minlevel 46", "46"},
+			{"#expedition config minlevel 50", "50"},
+			{"#expedition config minlevel 60", "60"},
+			{"#expedition config minlevel", "More..."}
+		});
+		c->Message(Chat::White, "  Max level (highest level allowed; Unlimited = no cap):");
+		SendActionRow(c, {
+			{"#expedition config maxlevel 0", "Unlimited"},
+			{"#expedition config maxlevel 50", "50"},
+			{"#expedition config maxlevel 60", "60"},
+			{"#expedition config maxlevel 65", "65"},
+			{"#expedition config maxlevel", "More..."}
 		});
 		c->Message(Chat::White, "  Locations (captures your current spot):");
 		SendActionRow(c, {
@@ -2516,6 +2578,53 @@ void HandleConfig(Client* c, const Seperator* sep)
 			}
 			else {
 				c->Message(Chat::Green, fmt::format("Set max players to {}.", new_max).c_str());
+			}
+		}
+		else if (action == "minlevel") {
+			if (sep->arg[3][0] == '\0') {
+				ShowLevelMatrix(c, fmt::format("Min Level: {}", template_data->name),
+					"#expedition config minlevel", template_data->dz_template.min_level, false,
+					"#expedition config", "Back to Config");
+				return;
+			}
+			if (!IsStrictUnsigned(sep->arg[3])) {
+				c->Message(Chat::Red, "Usage: #expedition config minlevel <level>");
+				return;
+			}
+			const uint32_t new_min = Strings::ToUnsignedInt(sep->arg[3]);
+			const uint32_t cur_max = template_data->dz_template.max_level;
+			// max_level 0 means unlimited; otherwise keep min <= max by raising the cap to match
+			const uint32_t new_max = (cur_max != 0 && new_min > cur_max) ? new_min : cur_max;
+			ExpeditionDB::SetDzTemplateLevels(content_db, dz_template_id, new_min, new_max);
+			if (new_max != cur_max) {
+				c->Message(Chat::Green, fmt::format("Set min level to {} (raised max to {} to stay valid).", new_min, new_max).c_str());
+			}
+			else {
+				c->Message(Chat::Green, fmt::format("Set min level to {}.", new_min).c_str());
+			}
+		}
+		else if (action == "maxlevel") {
+			if (sep->arg[3][0] == '\0') {
+				ShowLevelMatrix(c, fmt::format("Max Level: {}", template_data->name),
+					"#expedition config maxlevel", template_data->dz_template.max_level, true,
+					"#expedition config", "Back to Config");
+				return;
+			}
+			if (!IsStrictUnsigned(sep->arg[3])) {
+				c->Message(Chat::Red, "Usage: #expedition config maxlevel <level> (0 = unlimited)");
+				return;
+			}
+			const uint32_t new_max = Strings::ToUnsignedInt(sep->arg[3]); // 0 == unlimited
+			const uint32_t cur_min = template_data->dz_template.min_level;
+			// when a cap is set, keep min <= max by lowering the floor to match
+			const uint32_t new_min = (new_max != 0 && cur_min > new_max) ? new_max : cur_min;
+			ExpeditionDB::SetDzTemplateLevels(content_db, dz_template_id, new_min, new_max);
+			const std::string max_label = (new_max == 0) ? std::string("Unlimited") : std::to_string(new_max);
+			if (new_min != cur_min) {
+				c->Message(Chat::Green, fmt::format("Set max level to {} (lowered min to {} to stay valid).", max_label, new_min).c_str());
+			}
+			else {
+				c->Message(Chat::Green, fmt::format("Set max level to {}.", max_label).c_str());
 			}
 		}
 		else if (action == "size") {


### PR DESCRIPTION
## Summary

Adds persisted min/max level requirements for expedition dynamic zone templates and active dynamic zones, then enforces those requirements when expeditions are formed or players are invited.

## Details

- Adds database manifest entries for `dynamic_zone_templates.min_level/max_level` and `dynamic_zones.min_level/max_level` and bumps the binary DB version.
- Extends dynamic zone repository mappings and `DynamicZoneBase` load/save/template propagation for level bounds.
- Enforces level restrictions during expedition creation and invite conflict checks, with GM bypass matching the existing player-count bypass rule.
- Adds GM expedition config controls for min/max level and keeps invalid min/max combinations corrected.
- Improves requester menus with requirement visibility and adds a confirmation popup before forming an expedition.

## Validation

- `git diff --check`
- Local AkkStack `emu-compile` linux-test build/deploy succeeded against the same working-tree changes.
  - Latest log: `C:\AkkStack\.codex\logs\master-linux-test-20260613-130141.log`
  - Spire verified at `http://localhost:3010`
- Tests were not run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches expedition creation, invites, and DB migrations; incorrect level logic or migration backfill could block legitimate players or allow out-of-range members until fixed.
> 
> **Overview**
> Adds **min/max level** fields on expedition **dynamic zone templates** and **active dynamic zones** (schema migrations, repository wiring, and `DynamicZoneBase` load/save/template copy), with a backfill from templates onto existing expedition instances.
> 
> **Enforcement** applies when forming an expedition (`ExpeditionRequest::IsLevelValidated` using member levels from character data/clients) and when inviting players (`DynamicZone` conflict checks). GMs can bypass using the same rule as player-count bypass.
> 
> **Player/GM UX**: requester hail menus show level and player requirements with green/red eligibility; forming from a menu goes through a **“Form Expedition?”** Yes/No popup (`ExpeditionRequestPopup` + `HandleRequestConfirmPopup`). GM `#expedition config` gains **minlevel/maxlevel** (with matrices and auto-correction when min/max disagree), template validation, and simple-setup defaults (`kSimpleSetupMinLevel`).
> 
> Failure reasons **min_level** / **max_level** surface in expedition check messaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbea25f4f99c57a31897338a3208201a20f55b2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->