### PR TITLE
[CI] Build Windows release against supported Perl 5.24 (no Perl bundling)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -119,11 +119,28 @@ jobs:
           New-Item -ItemType Directory -Force -Path $cachePath | Out-Null
           "VCPKG_BINARY_SOURCES=clear;files,$cachePath,readwrite" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
+      - name: Install officially-supported Strawberry Perl (5.24)
+        shell: pwsh
+        run: |
+          $version = "5.24.4.1"
+          $url = "https://strawberryperl.com/download/$version/strawberry-perl-$version-64bit-portable.zip"
+          $zip = Join-Path $env:RUNNER_TEMP "strawberry-$version.zip"
+          $dest = "C:\Strawberry-5.24"
+          Write-Host "Installing Strawberry Perl $version (the supported EQEmu Windows Perl)"
+          Invoke-WebRequest -Uri $url -OutFile $zip
+          Expand-Archive -Path $zip -DestinationPath $dest -Force
+          "$dest\perl\site\bin" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+          "$dest\perl\bin"      | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+          $perlExe = "$dest\perl\bin\perl.exe".Replace('\', '/')
+          "PERL_524_EXE=$perlExe" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          & "$dest\perl\bin\perl.exe" -e "printf qq{Linking against Strawberry Perl %vd\n}, $^V"
+
       - name: Configure
         shell: pwsh
         run: |
           cmake -S . -B build -G Ninja `
             -DCMAKE_BUILD_TYPE=RelWithDebInfo `
+            -DPERL_EXECUTABLE="$env:PERL_524_EXE" `
             -DEQEMU_BUILD_TESTS=ON `
             -DEQEMU_BUILD_LOGIN=ON `
             -DEQEMU_BUILD_LUA=ON `

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -129,6 +129,12 @@ jobs:
           Write-Host "Installing Strawberry Perl $version (the supported EQEmu Windows Perl)"
           Invoke-WebRequest -Uri $url -OutFile $zip
           Expand-Archive -Path $zip -DestinationPath $dest -Force
+          # perl.exe's MinGW runtime (e.g. libgcc_s_seh-1.dll) can live in c\bin; copy it
+          # next to perl.exe so FindPerl can run perl during configure WITHOUT putting the
+          # MinGW toolchain (gcc/g++) on PATH, which would derail the MSVC/Ninja build.
+          foreach ($d in 'libgcc_s_seh-1.dll', 'libstdc++-6.dll', 'libwinpthread-1.dll') {
+            if (Test-Path "$dest\c\bin\$d") { Copy-Item "$dest\c\bin\$d" "$dest\perl\bin\" -Force }
+          }
           "$dest\perl\site\bin" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
           "$dest\perl\bin"      | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
           $perlExe = "$dest\perl\bin\perl.exe".Replace('\', '/')

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -292,11 +292,29 @@ jobs:
           New-Item -ItemType Directory -Force -Path $cachePath | Out-Null
           "VCPKG_BINARY_SOURCES=clear;files,$cachePath,readwrite" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
+      - name: Install officially-supported Strawberry Perl (5.24)
+        shell: pwsh
+        run: |
+          $version = "5.24.4.1"
+          $url = "https://strawberryperl.com/download/$version/strawberry-perl-$version-64bit-portable.zip"
+          $zip = Join-Path $env:RUNNER_TEMP "strawberry-$version.zip"
+          $dest = "C:\Strawberry-5.24"
+          Write-Host "Installing Strawberry Perl $version (the supported EQEmu Windows Perl)"
+          Invoke-WebRequest -Uri $url -OutFile $zip
+          Expand-Archive -Path $zip -DestinationPath $dest -Force
+          # Put 5.24 ahead of the runner's default Strawberry so FindPerl links perl524.dll.
+          "$dest\perl\site\bin" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+          "$dest\perl\bin"      | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+          $perlExe = "$dest\perl\bin\perl.exe".Replace('\', '/')
+          "PERL_524_EXE=$perlExe" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          & "$dest\perl\bin\perl.exe" -e "printf qq{Linking against Strawberry Perl %vd\n}, $^V"
+
       - name: Configure
         shell: pwsh
         run: |
           cmake -S . -B build -G Ninja `
             -DCMAKE_BUILD_TYPE=RelWithDebInfo `
+            -DPERL_EXECUTABLE="$env:PERL_524_EXE" `
             -DEQEMU_BUILD_TESTS=ON `
             -DEQEMU_BUILD_LOGIN=ON `
             -DEQEMU_BUILD_LUA=ON `

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -302,6 +302,12 @@ jobs:
           Write-Host "Installing Strawberry Perl $version (the supported EQEmu Windows Perl)"
           Invoke-WebRequest -Uri $url -OutFile $zip
           Expand-Archive -Path $zip -DestinationPath $dest -Force
+          # perl.exe's MinGW runtime (e.g. libgcc_s_seh-1.dll) can live in c\bin; copy it
+          # next to perl.exe so FindPerl can run perl during configure WITHOUT putting the
+          # MinGW toolchain (gcc/g++) on PATH, which would derail the MSVC/Ninja build.
+          foreach ($d in 'libgcc_s_seh-1.dll', 'libstdc++-6.dll', 'libwinpthread-1.dll') {
+            if (Test-Path "$dest\c\bin\$d") { Copy-Item "$dest\c\bin\$d" "$dest\perl\bin\" -Force }
+          }
           # Put 5.24 ahead of the runner's default Strawberry so FindPerl links perl524.dll.
           "$dest\perl\site\bin" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
           "$dest\perl\bin"      | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8

--- a/utils/scripts/release/package-windows.ps1
+++ b/utils/scripts/release/package-windows.ps1
@@ -345,6 +345,32 @@ function Find-RuntimeDependency {
     return $null
 }
 
+function Test-IsStrawberryPerlProvidedDll {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name
+    )
+
+    # The release links the officially-supported Strawberry Perl (5.24), which must be
+    # installed on the host -- it is the documented EQEmu Windows prerequisite. The
+    # embedded interpreter loads perl5xx.dll and its MinGW runtime from the user's
+    # Strawberry install at runtime, so these are deliberately NOT bundled. Bundling
+    # perl5xx.dll would also ship the build machine's compiled-in @INC paths (which do
+    # not exist on user machines) and break every Perl quest. This mirrors the local
+    # distribution, which ships no Perl/MinGW DLLs.
+    if ($Name -match '^perl5\d+\.dll$') {
+        return $true
+    }
+
+    $mingwRuntime = @(
+        "libgcc_s_seh-1.dll",
+        "libstdc++-6.dll",
+        "libwinpthread-1.dll"
+    )
+
+    return ($mingwRuntime -contains $Name)
+}
+
 function Copy-DynamicRuntimeDependencies {
     $dynamicRuntimeDlls = @(
         # libmariadb loads authentication and protocol plugins dynamically.
@@ -357,14 +383,6 @@ function Copy-DynamicRuntimeDependencies {
 
         # OpenSSL 3 may load this provider dynamically for legacy algorithms.
         "legacy.dll",
-
-        # The MinGW-built Strawberry perl5xx.dll depends on libstdc++-6.dll. The
-        # recursive resolver skips it whenever the build runner happens to expose a
-        # libstdc++-6.dll under a Windows system path (GitHub's windows-latest image
-        # does), so it must be force-bundled here. Without it zone.exe -- the only exe
-        # that imports perlXXX.dll -- fails to launch (STATUS_DLL_NOT_FOUND, or a
-        # STATUS_ENTRYPOINT_NOT_FOUND when a mismatched copy is found on PATH).
-        "libstdc++-6.dll",
 
         # Included to keep the release bundle aligned with the known-good package shape.
         "pkgconf-7.dll"
@@ -403,6 +421,9 @@ function Resolve-RuntimeDependencies {
         Get-ChildItem -Path $stageDir -File | Where-Object { $_.Extension -in @(".exe", ".dll") } | ForEach-Object {
             foreach ($dependency in (Get-DumpbinDependencies -Path $_.FullName)) {
                 if ($dependency -match "^(api-ms-win-|ext-ms-)") {
+                    continue
+                }
+                if (Test-IsStrawberryPerlProvidedDll -Name $dependency) {
                     continue
                 }
                 if ($systemDlls.Contains($dependency)) {
@@ -451,6 +472,9 @@ function Test-RuntimeDependencies {
             if ($dependency -match "^(api-ms-win-|ext-ms-)") {
                 continue
             }
+            if (Test-IsStrawberryPerlProvidedDll -Name $dependency) {
+                continue
+            }
             if ($systemDlls.Contains($dependency)) {
                 continue
             }
@@ -480,12 +504,9 @@ function Test-PackageContents {
         "import_client_files.exe",
         "legacy.dll",
         "libcrypto-3-x64.dll",
-        "libgcc_s_seh-1.dll",
         "libmariadb.dll",
         "libsodium.dll",
         "libssl-3-x64.dll",
-        "libstdc++-6.dll",
-        "libwinpthread-1.dll",
         "loginserver.exe",
         "lua51.dll",
         "msvcp140.dll",
@@ -494,7 +515,6 @@ function Test-PackageContents {
         "msvcp140_atomic_wait.dll",
         "msvcp140_codecvt_ids.dll",
         "mysql_clear_password.dll",
-        "perl542.dll",
         "pkgconf-7.dll",
         "pvio_shmem.dll",
         "queryserv.exe",

--- a/utils/scripts/release/package-windows.ps1
+++ b/utils/scripts/release/package-windows.ps1
@@ -348,7 +348,9 @@ function Find-RuntimeDependency {
 function Test-IsStrawberryPerlProvidedDll {
     param(
         [Parameter(Mandatory = $true)]
-        [string]$Name
+        [string]$Name,
+
+        [string]$RequiredBy
     )
 
     # The release links the officially-supported Strawberry Perl (5.24), which must be
@@ -362,13 +364,19 @@ function Test-IsStrawberryPerlProvidedDll {
         return $true
     }
 
+    # The MinGW runtime is host-provided ONLY when it is pulled in by the host's
+    # perl5xx.dll. If any other (MSVC) binary ever links it, it must still be bundled or
+    # flagged -- never silently dropped -- so gate this on the requiring file.
     $mingwRuntime = @(
         "libgcc_s_seh-1.dll",
         "libstdc++-6.dll",
         "libwinpthread-1.dll"
     )
+    if ($mingwRuntime -contains $Name) {
+        return ($RequiredBy -match '^perl5\d+\.dll$')
+    }
 
-    return ($mingwRuntime -contains $Name)
+    return $false
 }
 
 function Copy-DynamicRuntimeDependencies {
@@ -423,7 +431,7 @@ function Resolve-RuntimeDependencies {
                 if ($dependency -match "^(api-ms-win-|ext-ms-)") {
                     continue
                 }
-                if (Test-IsStrawberryPerlProvidedDll -Name $dependency) {
+                if (Test-IsStrawberryPerlProvidedDll -Name $dependency -RequiredBy $_.Name) {
                     continue
                 }
                 if ($systemDlls.Contains($dependency)) {
@@ -472,7 +480,7 @@ function Test-RuntimeDependencies {
             if ($dependency -match "^(api-ms-win-|ext-ms-)") {
                 continue
             }
-            if (Test-IsStrawberryPerlProvidedDll -Name $dependency) {
+            if (Test-IsStrawberryPerlProvidedDll -Name $dependency -RequiredBy $_.Name) {
                 continue
             }
             if ($systemDlls.Contains($dependency)) {
@@ -549,6 +557,20 @@ function Test-PackageContents {
     if ($blockedFiles.Count -gt 0) {
         $blockedNames = $blockedFiles | Sort-Object Name | ForEach-Object { $_.Name }
         throw "Release package contains non-runtime files:`n$($blockedNames -join "`n")"
+    }
+
+    # Perl and its MinGW runtime are intentionally host-provided (the user's installed
+    # Strawberry Perl 5.24). Assert they were not bundled so a future change cannot
+    # silently reintroduce bundling -- a bundled perl5xx.dll ships the build machine's
+    # @INC paths and breaks every Perl quest on user machines.
+    $hostProvidedFiles = @(Get-ChildItem -Path $stageDir -File | Where-Object {
+        $_.Name -match '^perl5\d+\.dll$' -or
+        @("libgcc_s_seh-1.dll", "libstdc++-6.dll", "libwinpthread-1.dll") -contains $_.Name
+    })
+
+    if ($hostProvidedFiles.Count -gt 0) {
+        $hostProvidedNames = $hostProvidedFiles | Sort-Object Name | ForEach-Object { $_.Name }
+        throw "Release package bundles host-provided Perl runtime (it must come from the user's installed Strawberry Perl):`n$($hostProvidedNames -join "`n")"
     }
 }
 


### PR DESCRIPTION
## What

The Windows release was unintentionally linking the `windows-latest` runner's
default Strawberry Perl (5.42) instead of the officially-supported EQEmu
Windows Perl (5.24) that local builds and users run. That version mismatch is
the root cause of the "Perl quests don't work" symptom -- a 5.42 binary cannot
use a user's 5.24 install, and a bundled 5.42 perl carries the build machine's
`@INC` paths.

This pins the Windows build to **Strawberry Perl 5.24.4.1** and stops bundling
the Perl/MinGW runtime, so the release is plain binaries + DLLs that run against
the user's installed Strawberry 5.24 (the documented prerequisite) -- matching
the local distribution.

## Changes
- `release.yaml` / `build.yaml`: install Strawberry Perl 5.24.4.1, put it first
  on `PATH`, and pass `-DPERL_EXECUTABLE` so `FindPerl` links `perl524.dll`.
- `package-windows.ps1`: exclude `perl5xx.dll` and the MinGW runtime
  (`libgcc_s_seh-1`, `libstdc++-6`, `libwinpthread-1`) from bundling and the
  dependency check; drop the libstdc++ force-bundle and the perl/MinGW entries
  from the expected-files list. Verified only `perl5xx.dll` imports the MinGW
  runtime, so nothing else is affected.

## Validation
- Local: package script syntax + exclusion logic verified; only `perl542.dll`
  imports the MinGW runtime; local 5.24 build proves master compiles against 5.24.
- This PR's CI exercises the Strawberry-5.24 install + 5.24 compile.
- The packaging step only runs in a `release.yaml` dispatch -- a draft release
  is needed to validate the final package and smoke-test on a 5.24 host.

Supersedes the libstdc++ bundle and the Perl-library bundle approach.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Windows release runtime layout and Perl linkage; wrong packaging would break zone.exe Perl quests, but CI and explicit package guards reduce that risk.
> 
> **Overview**
> Fixes Windows CI/release builds linking the runner’s default Strawberry Perl (5.42) instead of EQEmu’s supported **5.24**, which broke Perl quests when releases bundled the wrong `perl5xx.dll` or mismatched runtimes.
> 
> **CI (`build.yaml`, `release.yaml`):** Adds a step to install Strawberry **5.24.4.1** portable, copies MinGW helper DLLs next to `perl.exe` (so CMake can run Perl without putting gcc on `PATH`), prepends 5.24 to `PATH`, and passes **`-DPERL_EXECUTABLE`** so the link step targets `perl524.dll`.
> 
> **Packaging (`package-windows.ps1`):** Treats `perl5xx.dll` and MinGW runtime DLLs as **host-provided** when required by Perl—skips copy and missing-deps checks, removes the old `libstdc++-6.dll` force-bundle and expected-file entries, and **fails the package** if any of those DLLs end up in the zip so bundling cannot creep back in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 018f1fd6f388781d8fe9353ad2c1218356b81245. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->