### PR TITLE
[Bug Fix] Fix monk regular kick double hit

### DIFF
--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -27,9 +27,28 @@
 #include "zone/npc.h"
 #include "zone/string_ids.h"
 
+#include <algorithm>
+#include <array>
 #include <cstring>
 
 extern double frame_time;
+
+namespace {
+
+constexpr std::array<EQ::skills::SkillType, 5> MonkSpecialAttackSkills = {
+	EQ::skills::SkillFlyingKick,
+	EQ::skills::SkillDragonPunch,
+	EQ::skills::SkillEagleStrike,
+	EQ::skills::SkillTigerClaw,
+	EQ::skills::SkillRoundKick
+};
+
+bool IsMonkSpecialAttack(EQ::skills::SkillType skill)
+{
+	return std::find(MonkSpecialAttackSkills.begin(), MonkSpecialAttackSkills.end(), skill) != MonkSpecialAttackSkills.end();
+}
+
+} // namespace
 
 int Mob::GetBaseSkillDamage(EQ::skills::SkillType skill, Mob *target)
 {
@@ -498,14 +517,9 @@ void Client::OPCombatAbility(const CombatAbility_Struct *ca_atk)
 	}
 
 	const uint8 class_id = GetClass();
-	const bool is_kick = ca_atk->m_skill == EQ::skills::SkillKick;
-	const bool is_monk_special_attack = (
-		ca_atk->m_skill == EQ::skills::SkillFlyingKick ||
-		ca_atk->m_skill == EQ::skills::SkillDragonPunch ||
-		ca_atk->m_skill == EQ::skills::SkillEagleStrike ||
-		ca_atk->m_skill == EQ::skills::SkillTigerClaw ||
-		ca_atk->m_skill == EQ::skills::SkillRoundKick
-	);
+	const auto skill = static_cast<EQ::skills::SkillType>(ca_atk->m_skill);
+	const bool is_kick = skill == EQ::skills::SkillKick;
+	const bool is_monk_special_attack = IsMonkSpecialAttack(skill);
 
 	// Warrior, Ranger, Monk, Beastlord, and Berserker can kick always
 	const uint32 allowed_kick_classes = RuleI(Combat, ExtraAllowedKickClassesBitmask);
@@ -544,9 +558,9 @@ void Client::OPCombatAbility(const CombatAbility_Struct *ca_atk)
 		}
 	}
 
-	const bool can_use_monk_double_special_attack = is_monk_special_attack || (is_kick && found_skill);
+	const bool can_process_monk_ability = is_monk_special_attack || (is_kick && found_skill);
 
-	if (class_id == Class::Monk && can_use_monk_double_special_attack) {
+	if (class_id == Class::Monk && can_process_monk_ability) {
 		if (is_monk_special_attack) {
 			reuse_time = MonkSpecialAttack(GetTarget(), ca_atk->m_skill) - 1 - skill_reduction;
 		}
@@ -559,14 +573,6 @@ void Client::OPCombatAbility(const CombatAbility_Struct *ca_atk)
 		);
 
 		if (double_special_attack_chance) {
-			const int monk_special_attacks[5] = {
-				EQ::skills::SkillFlyingKick,
-				EQ::skills::SkillDragonPunch,
-				EQ::skills::SkillEagleStrike,
-				EQ::skills::SkillTigerClaw,
-				EQ::skills::SkillRoundKick
-			};
-
 			int extra = 0;
 			// always 1/4 of the double attack chance, 25% at rank 5 (100/4)
 			while (double_special_attack_chance > 0) {
@@ -594,7 +600,11 @@ void Client::OPCombatAbility(const CombatAbility_Struct *ca_atk)
 			while (extra) {
 				MonkSpecialAttack(
 					GetTarget(),
-					(is_classic_master_wu ? monk_special_attacks[zone->random.Int(0, 4)] : ca_atk->m_skill)
+					static_cast<uint8>(
+						is_classic_master_wu ?
+						MonkSpecialAttackSkills[zone->random.Int(0, static_cast<int>(MonkSpecialAttackSkills.size() - 1))] :
+						skill
+					)
 				);
 				--extra;
 			}
@@ -604,7 +614,7 @@ void Client::OPCombatAbility(const CombatAbility_Struct *ca_atk)
 			// hackish... but we return a huge reuse time if this is an
 			// invalid skill, otherwise, we can safely assume it is a
 			// valid monk skill and just cast it to a SkillType
-			CheckIncreaseSkill((EQ::skills::SkillType) ca_atk->m_skill, GetTarget(), 10);
+			CheckIncreaseSkill(skill, GetTarget(), 10);
 		}
 
 		found_skill = true;

--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -498,6 +498,14 @@ void Client::OPCombatAbility(const CombatAbility_Struct *ca_atk)
 	}
 
 	const uint8 class_id = GetClass();
+	const bool is_kick = ca_atk->m_skill == EQ::skills::SkillKick;
+	const bool is_monk_special_attack = (
+		ca_atk->m_skill == EQ::skills::SkillFlyingKick ||
+		ca_atk->m_skill == EQ::skills::SkillDragonPunch ||
+		ca_atk->m_skill == EQ::skills::SkillEagleStrike ||
+		ca_atk->m_skill == EQ::skills::SkillTigerClaw ||
+		ca_atk->m_skill == EQ::skills::SkillRoundKick
+	);
 
 	// Warrior, Ranger, Monk, Beastlord, and Berserker can kick always
 	const uint32 allowed_kick_classes = RuleI(Combat, ExtraAllowedKickClassesBitmask);
@@ -515,7 +523,7 @@ void Client::OPCombatAbility(const CombatAbility_Struct *ca_atk)
 
 	if (
 		ca_atk->m_atk == 100 &&
-		ca_atk->m_skill == EQ::skills::SkillKick &&
+		is_kick &&
 		can_use_kick
 	) {
 		if (GetTarget() != this) {
@@ -536,17 +544,21 @@ void Client::OPCombatAbility(const CombatAbility_Struct *ca_atk)
 		}
 	}
 
-	if (class_id == Class::Monk) {
-		reuse_time = MonkSpecialAttack(GetTarget(), ca_atk->m_skill) - 1 - skill_reduction;
+	const bool can_use_monk_double_special_attack = is_monk_special_attack || (is_kick && found_skill);
 
-		// Live AA - Technique of Master Wu
-		int wu_chance = (
+	if (class_id == Class::Monk && can_use_monk_double_special_attack) {
+		if (is_monk_special_attack) {
+			reuse_time = MonkSpecialAttack(GetTarget(), ca_atk->m_skill) - 1 - skill_reduction;
+		}
+
+		// Double special attack effects, such as Technique of Master Wu
+		int double_special_attack_chance = (
 			itembonuses.DoubleSpecialAttack +
 			spellbonuses.DoubleSpecialAttack +
 			aabonuses.DoubleSpecialAttack
 		);
 
-		if (wu_chance) {
+		if (double_special_attack_chance) {
 			const int monk_special_attacks[5] = {
 				EQ::skills::SkillFlyingKick,
 				EQ::skills::SkillDragonPunch,
@@ -557,14 +569,14 @@ void Client::OPCombatAbility(const CombatAbility_Struct *ca_atk)
 
 			int extra = 0;
 			// always 1/4 of the double attack chance, 25% at rank 5 (100/4)
-			while (wu_chance > 0) {
-				if (zone->random.Roll(wu_chance)) {
+			while (double_special_attack_chance > 0) {
+				if (zone->random.Roll(double_special_attack_chance)) {
 					++extra;
 				} else {
 					break;
 				}
 
-				wu_chance /= 4;
+				double_special_attack_chance /= 4;
 			}
 
 			if (extra) {
@@ -588,7 +600,7 @@ void Client::OPCombatAbility(const CombatAbility_Struct *ca_atk)
 			}
 		}
 
-		if (reuse_time < 100) {
+		if (is_monk_special_attack && reuse_time < 100) {
 			// hackish... but we return a huge reuse time if this is an
 			// invalid skill, otherwise, we can safely assume it is a
 			// valid monk skill and just cast it to a SkillType


### PR DESCRIPTION
## Summary

Fixes monk regular Kick being processed twice from a single combat ability packet when no double-special bonus is present.

## Root Cause

`Client::OPCombatAbility` first handled `SkillKick` through the generic kick branch, then immediately let every monk combat ability fall through into `MonkSpecialAttack`. Because `MonkSpecialAttack` also accepts `SkillKick`, monks could produce two regular kick attacks without any `DoubleSpecialAttack` chance being involved.

## Change

The monk path now separates baseline execution from generic double-special extra-attack handling:

- Regular `SkillKick` is handled once by the generic Kick branch.
- Regular `SkillKick` can still receive `DoubleSpecialAttack` extra attacks when an AA, spell, or item bonus provides that chance.
- Monk specials still use `MonkSpecialAttack` for their baseline hit and remain eligible for `DoubleSpecialAttack` extra attacks.

This preserves bonus-driven double regular Kick while removing the unconditional duplicate regular Kick.

## Validation

- `git diff --check`
- `cmake --build build-codex --target zone --config RelWithDebInfo --parallel 2`

The targeted zone build completed successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Combat ability handling for monks changed in a hot path; wrong gating could affect kick specials, reuse timers, or Master Wu procs, though scope is limited to `OPCombatAbility`.
> 
> **Overview**
> Fixes a combat bug where monk **Kick** could land twice from one ability packet because the generic kick path and the monk `MonkSpecialAttack` path both handled `SkillKick`.
> 
> **`Client::OPCombatAbility`** now classifies the incoming skill (`is_kick`, `IsMonkSpecialAttack`) and only enters the monk block when the ability is a monk special or when a kick was already resolved in the generic kick branch (so **DoubleSpecialAttack** / Master Wu extras can still apply). Baseline **Kick** damage runs once in the shared kick branch; **`MonkSpecialAttack`** is used only for flying kick, punches, etc., not as a second baseline kick.
> 
> Monk special skill IDs are centralized in a **`MonkSpecialAttackSkills`** array with a small helper, and Master Wu bonus attacks pick from that list when **ClassicMasterWu** is enabled. Skill-increase and reuse handling for monk specials is scoped so invalid or kick-only paths do not reuse the old always-`MonkSpecialAttack` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fe9ab2af2d2aae669994baca1fc5f6c5184a22c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->