### PR TITLE
[Bug Fix] Fix expedition boss-only trigger spawns

### DIFF
--- a/tests/expedition_schema_test.h
+++ b/tests/expedition_schema_test.h
@@ -27,6 +27,8 @@ public:
 		TEST_ADD(ExpeditionSchemaTest::BossEventNpcRemovalDeletesEvent);
 		TEST_ADD(ExpeditionSchemaTest::LockoutNamespaceUsesDynamicZoneName);
 		TEST_ADD(ExpeditionSchemaTest::BossOnlyFilterKeepsRequestersUnrestricted);
+		TEST_ADD(ExpeditionSchemaTest::BossOnlyFilterEnforcesWithoutConcreteBossSpawn);
+		TEST_ADD(ExpeditionSchemaTest::BossOnlyFilterAllowsTriggerSpawnOverrides);
 		TEST_ADD(ExpeditionSchemaTest::SimpleBuilderDefaultsAreRaidReady);
 		TEST_ADD(ExpeditionSchemaTest::SharedRequesterMenuSortsExpeditions);
 		TEST_ADD(ExpeditionSchemaTest::RequesterLockoutReasonsAreStatusAware);
@@ -268,6 +270,96 @@ private:
 		TEST_ASSERT(!boss_allowed_types->contains(100));
 
 		TEST_ASSERT(filter.AllowedNPCTypeIDs(30) == nullptr);
+	}
+
+	void BossOnlyFilterEnforcesWithoutConcreteBossSpawn()
+	{
+		ExpeditionDB::Template template_data;
+		template_data.boss_only_spawn = true;
+
+		ExpeditionDB::RequestNpc request_npc;
+		request_npc.enabled = true;
+		request_npc.npc_type_id = 300;
+		request_npc.spawn2_id = 30;
+		template_data.request_npcs.push_back(request_npc);
+
+		ExpeditionDB::Event event_data;
+		ExpeditionDB::EventNpc dynamic_boss;
+		dynamic_boss.role = "boss";
+		dynamic_boss.npc_type_id = 200;
+		dynamic_boss.spawn2_id = 0;
+		event_data.npcs.push_back(dynamic_boss);
+		template_data.events.push_back(event_data);
+
+		const auto filter = ExpeditionDB::BuildBossOnlySpawnFilter(template_data);
+
+		TEST_ASSERT(filter.enabled);
+		TEST_ASSERT(filter.AllowsSpawn2(30));
+		TEST_ASSERT(!filter.AllowsSpawn2(10));
+		TEST_ASSERT(filter.unrestricted_spawn2_ids.contains(30));
+		TEST_ASSERT(filter.npc_type_ids_by_spawn2_id.empty());
+	}
+
+	void BossOnlyFilterAllowsTriggerSpawnOverrides()
+	{
+		ExpeditionDB::Template template_data;
+		template_data.boss_only_spawn = true;
+
+		ExpeditionDB::Event event_data;
+		ExpeditionDB::EventNpc boss_npc;
+		boss_npc.role = "boss";
+		boss_npc.npc_type_id = 200;
+		boss_npc.spawn2_id = 20;
+		event_data.npcs.push_back(boss_npc);
+		template_data.events.push_back(event_data);
+
+		const auto filter = ExpeditionDB::BuildBossOnlySpawnFilter(template_data);
+
+		ExpeditionDB::NPCTypeIDsBySpawn2ID always_allowed_npc_type_ids_by_spawn2_id;
+		always_allowed_npc_type_ids_by_spawn2_id[10].insert(67000);
+		always_allowed_npc_type_ids_by_spawn2_id[20].insert(67001);
+
+		bool blocked_spawn_enabled = true;
+		std::unordered_set<uint32_t> blocked_combined_allowed;
+		const auto* blocked_allowed = ExpeditionDB::ResolveBossOnlyAllowedNPCTypeIDs(
+			filter,
+			always_allowed_npc_type_ids_by_spawn2_id,
+			10,
+			blocked_spawn_enabled,
+			blocked_combined_allowed
+		);
+
+		TEST_ASSERT(blocked_spawn_enabled);
+		TEST_ASSERT(blocked_allowed != nullptr);
+		TEST_ASSERT(blocked_allowed->contains(67000));
+
+		bool boss_spawn_enabled = true;
+		std::unordered_set<uint32_t> boss_combined_allowed;
+		const auto* boss_allowed = ExpeditionDB::ResolveBossOnlyAllowedNPCTypeIDs(
+			filter,
+			always_allowed_npc_type_ids_by_spawn2_id,
+			20,
+			boss_spawn_enabled,
+			boss_combined_allowed
+		);
+
+		TEST_ASSERT(boss_spawn_enabled);
+		TEST_ASSERT(boss_allowed != nullptr);
+		TEST_ASSERT(boss_allowed->contains(200));
+		TEST_ASSERT(boss_allowed->contains(67001));
+
+		bool trash_spawn_enabled = true;
+		std::unordered_set<uint32_t> trash_combined_allowed;
+		const auto* trash_allowed = ExpeditionDB::ResolveBossOnlyAllowedNPCTypeIDs(
+			filter,
+			always_allowed_npc_type_ids_by_spawn2_id,
+			50,
+			trash_spawn_enabled,
+			trash_combined_allowed
+		);
+
+		TEST_ASSERT(!trash_spawn_enabled);
+		TEST_ASSERT(trash_allowed == nullptr);
 	}
 
 	void SimpleBuilderDefaultsAreRaidReady()

--- a/zone/expedition_db.cpp
+++ b/zone/expedition_db.cpp
@@ -1654,7 +1654,7 @@ ValidationResult ValidateTemplate(const Template& template_data)
 		}
 
 		if (!has_concrete_boss) {
-			result.errors.push_back("Boss-only spawn mode requires at least one boss NPC mapping with a concrete spawn2_id.");
+			result.warnings.push_back("Boss-only spawn mode has no boss NPC mapping with a concrete spawn2_id; only request NPCs, trigger NPCs, and script-spawned NPCs will be available.");
 		}
 	}
 

--- a/zone/expedition_db.h
+++ b/zone/expedition_db.h
@@ -359,6 +359,48 @@ struct BossOnlySpawnFilter {
 	}
 };
 
+using NPCTypeIDsBySpawn2ID = std::unordered_map<uint32_t, std::unordered_set<uint32_t>>;
+
+inline const std::unordered_set<uint32_t>* FindNPCTypeIDsBySpawn2ID(
+	const NPCTypeIDsBySpawn2ID& npc_type_ids_by_spawn2_id,
+	uint32_t spawn2_id
+)
+{
+	const auto it = npc_type_ids_by_spawn2_id.find(spawn2_id);
+	return it != npc_type_ids_by_spawn2_id.end() ? &it->second : nullptr;
+}
+
+inline const std::unordered_set<uint32_t>* ResolveBossOnlyAllowedNPCTypeIDs(
+	const BossOnlySpawnFilter& filter,
+	const NPCTypeIDsBySpawn2ID& always_allowed_npc_type_ids_by_spawn2_id,
+	uint32_t spawn2_id,
+	bool& spawn_enabled,
+	std::unordered_set<uint32_t>& combined_allowed_npc_type_ids
+)
+{
+	if (!filter.enabled) {
+		return nullptr;
+	}
+
+	const auto* always_allowed_npc_type_ids = FindNPCTypeIDsBySpawn2ID(always_allowed_npc_type_ids_by_spawn2_id, spawn2_id);
+	if (!filter.AllowsSpawn2(spawn2_id)) {
+		if (!always_allowed_npc_type_ids) {
+			spawn_enabled = false;
+		}
+
+		return always_allowed_npc_type_ids;
+	}
+
+	const auto* allowed_npc_type_ids = filter.AllowedNPCTypeIDs(spawn2_id);
+	if (!allowed_npc_type_ids || !always_allowed_npc_type_ids) {
+		return allowed_npc_type_ids;
+	}
+
+	combined_allowed_npc_type_ids = *allowed_npc_type_ids;
+	combined_allowed_npc_type_ids.insert(always_allowed_npc_type_ids->begin(), always_allowed_npc_type_ids->end());
+	return &combined_allowed_npc_type_ids;
+}
+
 inline BossOnlySpawnFilter BuildBossOnlySpawnFilter(const Template& template_data)
 {
 	BossOnlySpawnFilter filter;
@@ -392,7 +434,7 @@ inline BossOnlySpawnFilter BuildBossOnlySpawnFilter(const Template& template_dat
 		}
 	}
 
-	filter.enabled = !filter.npc_type_ids_by_spawn2_id.empty();
+	filter.enabled = true;
 	return filter;
 }
 

--- a/zone/spawn2.cpp
+++ b/zone/spawn2.cpp
@@ -18,6 +18,7 @@
 
 #include "spawn2.h"
 
+#include "common/bodytypes.h"
 #include "common/repositories/criteria/content_filter_criteria.h"
 #include "common/repositories/respawn_times_repository.h"
 #include "common/repositories/spawn_condition_values_repository.h"
@@ -490,6 +491,60 @@ void Spawn2::DeathReset(bool realdeath)
 	}
 }
 
+std::unordered_map<uint32, std::unordered_set<uint32>> ZoneDatabase::GetNPCTypeIDsByBodyTypeBySpawn2ID(
+	uint32 zone_id,
+	int16 version,
+	uint8 body_type_id
+)
+{
+	std::unordered_map<uint32, std::unordered_set<uint32>> npc_type_ids_by_spawn2_id;
+	const auto body_type_filter = static_cast<uint32>(body_type_id);
+
+	const char* zone_name = ZoneName(zone_id);
+	if (!zone_name) {
+		return npc_type_ids_by_spawn2_id;
+	}
+
+	auto results = QueryDatabase(fmt::format(
+		SQL(
+			SELECT DISTINCT
+				spawn2.id,
+				spawnentry.npcID
+			FROM spawn2
+			INNER JOIN spawnentry
+				ON spawnentry.spawngroupID = spawn2.spawngroupID
+			INNER JOIN npc_types
+				ON npc_types.id = spawnentry.npcID
+			WHERE spawn2.zone = '{}'
+				AND (spawn2.version = {} OR spawn2.version = -1)
+				AND npc_types.bodytype = {}
+				{}
+				{}
+		),
+		zone_name,
+		version,
+		body_type_filter,
+		ContentFilterCriteria::apply("spawn2"),
+		ContentFilterCriteria::apply("spawnentry")
+	));
+
+	if (!results.Success()) {
+		LogError(
+			"Failed to load bodytype [{}] NPC types by spawn2 for zone [{}]: {}",
+			body_type_filter,
+			zone_name,
+			results.ErrorMessage()
+		);
+		return npc_type_ids_by_spawn2_id;
+	}
+
+	for (auto row = results.begin(); row != results.end(); ++row) {
+		npc_type_ids_by_spawn2_id[Strings::ToUnsignedInt(row[0])].insert(Strings::ToUnsignedInt(row[1]));
+	}
+
+	return npc_type_ids_by_spawn2_id;
+}
+
 bool ZoneDatabase::PopulateZoneSpawnList(uint32 zoneid, LinkedList<Spawn2*> &spawn2_list, int16 version) {
 
 	std::unordered_map<uint32, uint32> spawn_times;
@@ -560,6 +615,10 @@ bool ZoneDatabase::PopulateZoneSpawnList(uint32 zoneid, LinkedList<Spawn2*> &spa
 	}
 
 	const auto boss_only_filter = ExpeditionDB::GetBossOnlySpawnFilter(zone->GetDynamicZone());
+	const ExpeditionDB::NPCTypeIDsBySpawn2ID always_allowed_npc_type_ids_by_spawn2_id =
+		boss_only_filter.enabled ?
+			GetNPCTypeIDsByBodyTypeBySpawn2ID(zoneid, version, BodyType::Special) :
+			ExpeditionDB::NPCTypeIDsBySpawn2ID{};
 
 	// normal spawn2 loading
 	for (auto &s: spawns) {
@@ -578,15 +637,15 @@ bool ZoneDatabase::PopulateZoneSpawnList(uint32 zoneid, LinkedList<Spawn2*> &spa
 			}
 		}
 
-		const std::unordered_set<uint32_t>* allowed_npc_type_ids = nullptr;
-		if (boss_only_filter.enabled) {
-			if (!boss_only_filter.AllowsSpawn2(s.id)) {
-				spawn_enabled = false;
-			}
-			else {
-				allowed_npc_type_ids = boss_only_filter.AllowedNPCTypeIDs(s.id);
-			}
-		}
+		std::unordered_set<uint32_t> combined_allowed_npc_type_ids;
+		const std::unordered_set<uint32_t>* allowed_npc_type_ids =
+			ExpeditionDB::ResolveBossOnlyAllowedNPCTypeIDs(
+				boss_only_filter,
+				always_allowed_npc_type_ids_by_spawn2_id,
+				s.id,
+				spawn_enabled,
+				combined_allowed_npc_type_ids
+			);
 
 		auto new_spawn = new Spawn2(
 			s.id,

--- a/zone/zone_save_state.cpp
+++ b/zone/zone_save_state.cpp
@@ -1,5 +1,6 @@
 #include "zone_save_state.h"
 
+#include "common/bodytypes.h"
 #include "common/repositories/criteria/content_filter_criteria.h"
 #include "common/repositories/spawn2_repository.h"
 #include "zone/corpse.h"
@@ -432,6 +433,10 @@ bool Zone::LoadZoneState(
 
 	LogInfo("Loading zone state spawns for zone [{}] instance [{}] spawns [{}]", GetShortName(), zone->GetInstanceID(), spawn_states.size());
 	const auto boss_only_filter = ExpeditionDB::GetBossOnlySpawnFilter(GetDynamicZone());
+	const ExpeditionDB::NPCTypeIDsBySpawn2ID always_allowed_npc_type_ids_by_spawn2_id =
+		boss_only_filter.enabled ?
+			content_db.GetNPCTypeIDsByBodyTypeBySpawn2ID(zoneid, zone->GetInstanceVersion(), BodyType::Special) :
+			ExpeditionDB::NPCTypeIDsBySpawn2ID{};
 
 	if (!IsZoneStateValid(spawn_states)) {
 		LogZoneState("Invalid zone state data for zone [{}]", GetShortName());
@@ -489,15 +494,15 @@ bool Zone::LoadZoneState(
 			}
 		}
 
-		const std::unordered_set<uint32_t>* allowed_npc_type_ids = nullptr;
-		if (boss_only_filter.enabled) {
-			if (!boss_only_filter.AllowsSpawn2(s.spawn2_id)) {
-				spawn_enabled = false;
-			}
-			else {
-				allowed_npc_type_ids = boss_only_filter.AllowedNPCTypeIDs(s.spawn2_id);
-			}
-		}
+		std::unordered_set<uint32_t> combined_allowed_npc_type_ids;
+		const std::unordered_set<uint32_t>* allowed_npc_type_ids =
+			ExpeditionDB::ResolveBossOnlyAllowedNPCTypeIDs(
+				boss_only_filter,
+				always_allowed_npc_type_ids_by_spawn2_id,
+				s.spawn2_id,
+				spawn_enabled,
+				combined_allowed_npc_type_ids
+			);
 
 		// find spawn 2 by id
 		Spawn2Repository::Spawn2 spawn2;
@@ -582,15 +587,15 @@ bool Zone::LoadZoneState(
 				}
 			}
 
-			const std::unordered_set<uint32_t>* allowed_npc_type_ids = nullptr;
-			if (boss_only_filter.enabled) {
-				if (!boss_only_filter.AllowsSpawn2(s.id)) {
-					spawn_enabled = false;
-				}
-				else {
-					allowed_npc_type_ids = boss_only_filter.AllowedNPCTypeIDs(s.id);
-				}
-			}
+			std::unordered_set<uint32_t> combined_allowed_npc_type_ids;
+			const std::unordered_set<uint32_t>* allowed_npc_type_ids =
+				ExpeditionDB::ResolveBossOnlyAllowedNPCTypeIDs(
+					boss_only_filter,
+					always_allowed_npc_type_ids_by_spawn2_id,
+					s.id,
+					spawn_enabled,
+					combined_allowed_npc_type_ids
+				);
 
 			LogZoneState("Missing spawn2 [{}] in zone state, this NPC spawn was newly created", s.id);
 			uint32 spawn_time_left = 0;

--- a/zone/zonedb.h
+++ b/zone/zonedb.h
@@ -13,6 +13,7 @@
 #include "zone/event_codes.h"
 #include "zone/position.h"
 
+#include <unordered_map>
 #include <unordered_set>
 
 class Client;
@@ -533,6 +534,7 @@ public:
 	bool		LoadSpawnGroups(const char* zone_name, uint16 version, SpawnGroupList* spawn_group_list);
 	bool		LoadSpawnGroupsByID(int spawn_group_id, SpawnGroupList* spawn_group_list);
 	bool		PopulateZoneSpawnList(uint32 zoneid, LinkedList<Spawn2*> &spawn2_list, int16 version);
+	std::unordered_map<uint32, std::unordered_set<uint32>> GetNPCTypeIDsByBodyTypeBySpawn2ID(uint32 zone_id, int16 version, uint8 body_type_id);
 	bool		CreateSpawn2(Client* c, uint32 spawngroup_id, const std::string& zone_short_name, const glm::vec4& position, uint32 respawn, uint32 variance, uint16 condition, int16 condition_value);
 	void		UpdateRespawnTime(uint32 spawn2_id, uint16 instance_id,uint32 timeleft);
 	uint32		GetSpawnTimeLeft(uint32 spawn2_id, uint16 instance_id);


### PR DESCRIPTION
## Summary
- Keep expedition boss-only spawn filters enabled even when tracked boss mappings are dynamic/script-spawned and have no concrete spawn2_id.
- Permit bodytype 67 trigger NPCs through boss-only filtering by adding those NPC types to the allowed set for their spawn2.
- Downgrade the no-concrete-boss authoring check from an error to a warning, since event-controller boss setups are valid.

## Validation
- git diff --check
- powershell -ExecutionPolicy Bypass -File C:\Users\rgagn\.codex\skills\emu-compile\scripts\invoke-akkstack-eqemu-build.ps1 -BuildMode linux-test -Ref current -Targets zone,tests -RunTests -NoMonitor -NoOpenSpire -SkipSpireBuild
  - ExpeditionSchemaTest: 24/24, 100% correct
  - Total: 121 tests, 100% correct

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes expedition instance spawn gating at load and zone-state restore; incorrect allowlist logic could block or over-allow spawns, but scope is limited to boss-only dynamic zones and is covered by new unit tests.
> 
> **Overview**
> Fixes expedition **boss-only spawn** mode so it still applies when bosses are script-spawned or have no concrete `spawn2_id`, and so **bodytype 67 (Special) trigger NPCs** can spawn on otherwise blocked spawn points.
> 
> **Filter behavior:** `BuildBossOnlySpawnFilter` now stays **enabled** whenever `boss_only_spawn` is on (not only when there are concrete boss spawn mappings). Template validation downgrades missing concrete boss mappings from an **error** to a **warning**, reflecting valid event-controller setups.
> 
> **Runtime resolution:** New `ResolveBossOnlyAllowedNPCTypeIDs` merges expedition filter rules with zone-loaded **Special** bodytype NPC types per spawn2. Blocked spawns stay enabled if they only need trigger types; allowed boss spawns union configured boss types with trigger overrides. Normal spawn load and zone-state restore both use this helper and load trigger NPC types via new `GetNPCTypeIDsByBodyTypeBySpawn2ID`.
> 
> **Tests:** Two schema tests cover dynamic-boss-only templates and trigger override merging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e311918ebe3bf859f0c76dcee88d6841c7423d8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->