### PR TITLE
[Expedition] List blocking expedition bosses

### DIFF
--- a/zone/expedition_config.h
+++ b/zone/expedition_config.h
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
 class Client;
 
@@ -24,6 +25,7 @@ struct ExpeditionCheckResult
 	uint32_t max_players = 0;
 	bool is_raid = false;
 	std::string reason;
+	std::vector<std::string> base_zone_bosses_alive;
 };
 
 uint32_t ParseExpeditionDuration(const std::string& duration);

--- a/zone/expedition_db.cpp
+++ b/zone/expedition_db.cpp
@@ -419,9 +419,8 @@ namespace {
 		return boss_names;
 	}
 
-	void SendActiveBaseZoneBossList(Client& client, const Template& template_data)
+	void SendActiveBaseZoneBossList(Client& client, const std::vector<std::string>& boss_names)
 	{
-		const auto boss_names = ActiveBaseZoneBossNames(template_data);
 		if (boss_names.empty()) {
 			return;
 		}
@@ -506,7 +505,7 @@ namespace {
 			if (!template_data.silent) {
 				client.Message(Chat::Red, fmt::format("Cannot create expedition: {}.", RequestFailureLabel(check)).c_str());
 				if (IsBaseZoneBossSpawnedReason(check.reason)) {
-					SendActiveBaseZoneBossList(client, template_data);
+					SendActiveBaseZoneBossList(client, check.base_zone_bosses_alive);
 				}
 			}
 			return true;
@@ -710,7 +709,7 @@ namespace {
 					entry.note = RequestMenuNoteLabel(check);
 					entry.status_block = IsRequesterStatusBlockReason(check.reason);
 					if (IsBaseZoneBossSpawnedReason(check.reason)) {
-						entry.required_bosses_alive = ActiveBaseZoneBossNames(*template_data);
+						entry.required_bosses_alive = check.base_zone_bosses_alive;
 					}
 				}
 			}
@@ -1936,7 +1935,8 @@ ExpeditionCheckResult CheckExpeditionFromTemplate(Client& client, const Template
 		return result;
 	}
 
-	if (HasActiveBaseZoneBoss(template_data)) {
+	result.base_zone_bosses_alive = ActiveBaseZoneBossNames(template_data);
+	if (!result.base_zone_bosses_alive.empty()) {
 		result.reason = kBaseZoneBossSpawnedReason;
 		return result;
 	}

--- a/zone/expedition_db.cpp
+++ b/zone/expedition_db.cpp
@@ -365,25 +365,71 @@ namespace {
 			zone->GetZoneID() == static_cast<uint32_t>(template_data.dz_template.zone_id);
 	}
 
+	bool ShouldCheckBaseZoneBossAvailability(const Template& template_data)
+	{
+		return template_data.require_bosses_dead && IsCurrentBaseZoneForTemplate(template_data);
+	}
+
+	bool IsActiveBaseZoneBoss(const EventNpc& event_npc)
+	{
+		return IsBaseZoneAvailabilityBoss(event_npc) &&
+			entity_list.IsActiveNPCSpawnedByNpcTypeID(event_npc.npc_type_id, event_npc.spawn2_id);
+	}
+
 	bool HasActiveBaseZoneBoss(const Template& template_data)
 	{
-		if (!template_data.require_bosses_dead || !IsCurrentBaseZoneForTemplate(template_data)) {
+		if (!ShouldCheckBaseZoneBossAvailability(template_data)) {
 			return false;
 		}
 
 		for (const auto& event_data : template_data.events) {
 			for (const auto& event_npc : event_data.npcs) {
-				if (!IsBaseZoneAvailabilityBoss(event_npc)) {
-					continue;
-				}
-
-				if (entity_list.IsActiveNPCSpawnedByNpcTypeID(event_npc.npc_type_id, event_npc.spawn2_id)) {
+				if (IsActiveBaseZoneBoss(event_npc)) {
 					return true;
 				}
 			}
 		}
 
 		return false;
+	}
+
+	std::vector<std::string> ActiveBaseZoneBossNames(const Template& template_data)
+	{
+		std::vector<std::string> boss_names;
+		if (!ShouldCheckBaseZoneBossAvailability(template_data)) {
+			return boss_names;
+		}
+
+		std::unordered_set<std::string> seen_bosses;
+		for (const auto& event_data : template_data.events) {
+			for (const auto& event_npc : event_data.npcs) {
+				if (!IsActiveBaseZoneBoss(event_npc)) {
+					continue;
+				}
+
+				const std::string key = fmt::format("{}:{}", event_npc.npc_type_id, event_npc.spawn2_id);
+				if (!seen_bosses.insert(key).second) {
+					continue;
+				}
+
+				boss_names.push_back(NpcTypeName(event_npc.npc_type_id));
+			}
+		}
+
+		return boss_names;
+	}
+
+	void SendActiveBaseZoneBossList(Client& client, const Template& template_data)
+	{
+		const auto boss_names = ActiveBaseZoneBossNames(template_data);
+		if (boss_names.empty()) {
+			return;
+		}
+
+		client.Message(Chat::Red, "Required bosses still alive:");
+		for (const auto& boss_name : boss_names) {
+			client.Message(Chat::Red, "  - %s", boss_name.c_str());
+		}
 	}
 
 	std::string RequestFailureLabel(const ExpeditionCheckResult& check)
@@ -459,6 +505,9 @@ namespace {
 		if (!check.success) {
 			if (!template_data.silent) {
 				client.Message(Chat::Red, fmt::format("Cannot create expedition: {}.", RequestFailureLabel(check)).c_str());
+				if (IsBaseZoneBossSpawnedReason(check.reason)) {
+					SendActiveBaseZoneBossList(client, template_data);
+				}
 			}
 			return true;
 		}
@@ -611,6 +660,7 @@ namespace {
 			std::string note;
 			std::string level_text;
 			std::string players_text;
+			std::vector<std::string> required_bosses_alive;
 			bool level_met = false;
 			bool players_met = false;
 			bool status_block = false;
@@ -659,6 +709,9 @@ namespace {
 				else {
 					entry.note = RequestMenuNoteLabel(check);
 					entry.status_block = IsRequesterStatusBlockReason(check.reason);
+					if (IsBaseZoneBossSpawnedReason(check.reason)) {
+						entry.required_bosses_alive = ActiveBaseZoneBossNames(*template_data);
+					}
 				}
 			}
 			entries.push_back(std::move(entry));
@@ -700,6 +753,12 @@ namespace {
 			// real eligibility (green = meets it, red = does not; independent of any GM bypass).
 			client.Message(entry.level_met ? Chat::Green : Chat::Red, "     %s", entry.level_text.c_str());
 			client.Message(entry.players_met ? Chat::Green : Chat::Red, "     %s", entry.players_text.c_str());
+			if (!entry.required_bosses_alive.empty()) {
+				client.Message(Chat::Red, "     Required bosses still alive:");
+				for (const auto& boss_name : entry.required_bosses_alive) {
+					client.Message(Chat::Red, "       - %s", boss_name.c_str());
+				}
+			}
 
 			// Light divider between expeditions (omitted after the last one).
 			if (multi && i + 1 < entries.size()) {


### PR DESCRIPTION
## Summary

- Show players which configured base-zone bosses are still alive when a DB-driven expedition is unavailable because `require_bosses_dead` is blocking creation.
- Render the boss list in red under the affected requester hail menu entry.
- Reuse the same boss list for direct creation failures so both request paths give the same actionable feedback.

## QA

- Reviewed the requester menu and direct create failure paths for scope and per-template behavior.
- `git diff --check`
- `cmake --build build-codex --target zone --config Debug`
- `cmake --build build-codex --target tests --config Debug`
- `.\build-codex\bin\Debug\tests.exe` (`121 tests, 100% correct`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Player-facing chat only; expedition eligibility rules are unchanged aside from surfacing boss names already used for blocking.
> 
> **Overview**
> When a DB-driven expedition is blocked because **`require_bosses_dead`** still has live bosses in the base zone, players now see **which** bosses are up—not only a generic unavailable message.
> 
> **`ExpeditionCheckResult`** gains **`base_zone_bosses_alive`**, filled by a new **`ActiveBaseZoneBossNames`** path (deduped by npc type + spawn2, resolved via **`NpcTypeName`**). Boss gating logic is refactored around **`ShouldCheckBaseZoneBossAvailability`** and **`IsActiveBaseZoneBoss`**.
> 
> The **requester hail menu** prints a red, indented bullet list under entries that fail for this reason. **Direct create** failures (non-silent templates) reuse **`SendActiveBaseZoneBossList`** so both paths match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b308ad4129da4589a40d88b9c1227eee4275ad0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->