### PR TITLE
[Feature] Add player autoskill system

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 set(common_sources
+    auto_skill.cpp
     base_packet.cpp
     bazaar.cpp
     bodytypes.cpp

--- a/common/auto_skill.cpp
+++ b/common/auto_skill.cpp
@@ -96,10 +96,14 @@ uint32 EQ::skills::autoskill::SetEnabled(uint32 enabled_mask, EQ::skills::SkillT
 
 uint32 EQ::skills::autoskill::SanitizeMask(uint32 enabled_mask)
 {
-	uint32 supported_mask = 0;
-	for (const auto &definition : GetSkillDefinitions()) {
-		supported_mask |= definition.mask;
-	}
+	static const uint32 supported_mask = []() {
+		uint32 mask = 0;
+		for (const auto &definition : GetSkillDefinitions()) {
+			mask |= definition.mask;
+		}
+
+		return mask;
+	}();
 
 	return enabled_mask & supported_mask;
 }

--- a/common/auto_skill.cpp
+++ b/common/auto_skill.cpp
@@ -1,0 +1,117 @@
+#include "common/auto_skill.h"
+
+#include <cctype>
+
+namespace {
+
+bool AutoSkillNameMatches(const EQ::skills::autoskill::AutoSkillDefinition &definition, const std::string &normalized_name)
+{
+	if (EQ::skills::autoskill::NormalizeSkillName(definition.name) == normalized_name) {
+		return true;
+	}
+
+	if (EQ::skills::autoskill::NormalizeSkillName(definition.command_name) == normalized_name) {
+		return true;
+	}
+
+	for (const auto &alias : definition.aliases) {
+		if (EQ::skills::autoskill::NormalizeSkillName(alias) == normalized_name) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+} // namespace
+
+const std::vector<EQ::skills::autoskill::AutoSkillDefinition> &EQ::skills::autoskill::GetSkillDefinitions()
+{
+	static const std::vector<AutoSkillDefinition> auto_skill_definitions = {
+		{ EQ::skills::SkillBackstab,    1u << 0, "Backstab",     "backstab",     { "back stab" } },
+		{ EQ::skills::SkillFrenzy,      1u << 1, "Frenzy",       "frenzy",       {} },
+		{ EQ::skills::SkillFlyingKick,  1u << 2, "Flying Kick",  "flying kick",  { "flyingkick" } },
+		{ EQ::skills::SkillDragonPunch, 1u << 3, "Dragon Punch", "dragon punch", { "dragonpunch", "tail rake", "tailrake" } },
+		{ EQ::skills::SkillEagleStrike, 1u << 4, "Eagle Strike", "eagle strike", { "eaglestrike" } },
+		{ EQ::skills::SkillTigerClaw,   1u << 5, "Tiger Claw",   "tiger claw",   { "tigerclaw" } },
+		{ EQ::skills::SkillRoundKick,   1u << 6, "Round Kick",   "round kick",   { "roundkick" } },
+		{ EQ::skills::SkillKick,        1u << 7, "Kick",         "kick",         {} },
+		{ EQ::skills::SkillBash,        1u << 8, "Bash",         "bash",         { "slam" } }
+	};
+
+	return auto_skill_definitions;
+}
+
+const EQ::skills::autoskill::AutoSkillDefinition *EQ::skills::autoskill::GetSkillDefinition(EQ::skills::SkillType skill)
+{
+	for (const auto &definition : GetSkillDefinitions()) {
+		if (definition.skill == skill) {
+			return &definition;
+		}
+	}
+
+	return nullptr;
+}
+
+const EQ::skills::autoskill::AutoSkillDefinition *EQ::skills::autoskill::FindSkillDefinition(const std::string &skill_name)
+{
+	const auto normalized_name = NormalizeSkillName(skill_name);
+	if (normalized_name.empty()) {
+		return nullptr;
+	}
+
+	for (const auto &definition : GetSkillDefinitions()) {
+		if (AutoSkillNameMatches(definition, normalized_name)) {
+			return &definition;
+		}
+	}
+
+	return nullptr;
+}
+
+bool EQ::skills::autoskill::IsSupported(EQ::skills::SkillType skill)
+{
+	return GetSkillDefinition(skill) != nullptr;
+}
+
+bool EQ::skills::autoskill::IsEnabled(uint32 enabled_mask, EQ::skills::SkillType skill)
+{
+	const auto *definition = GetSkillDefinition(skill);
+	return definition && ((enabled_mask & definition->mask) != 0);
+}
+
+uint32 EQ::skills::autoskill::SetEnabled(uint32 enabled_mask, EQ::skills::SkillType skill, bool enabled)
+{
+	const auto *definition = GetSkillDefinition(skill);
+	if (!definition) {
+		return SanitizeMask(enabled_mask);
+	}
+
+	if (enabled) {
+		return SanitizeMask(enabled_mask | definition->mask);
+	}
+
+	return SanitizeMask(enabled_mask & ~definition->mask);
+}
+
+uint32 EQ::skills::autoskill::SanitizeMask(uint32 enabled_mask)
+{
+	uint32 supported_mask = 0;
+	for (const auto &definition : GetSkillDefinitions()) {
+		supported_mask |= definition.mask;
+	}
+
+	return enabled_mask & supported_mask;
+}
+
+std::string EQ::skills::autoskill::NormalizeSkillName(const std::string &skill_name)
+{
+	std::string normalized_name;
+	for (const unsigned char character : skill_name) {
+		if (std::isalnum(character)) {
+			normalized_name.push_back(static_cast<char>(std::tolower(character)));
+		}
+	}
+
+	return normalized_name;
+}

--- a/common/auto_skill.h
+++ b/common/auto_skill.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "common/skills.h"
+#include "common/types.h"
+
+#include <string>
+#include <vector>
+
+namespace EQ {
+namespace skills {
+namespace autoskill {
+
+struct AutoSkillDefinition {
+	EQ::skills::SkillType skill;
+	uint32 mask;
+	const char *name;
+	const char *command_name;
+	std::vector<const char *> aliases;
+};
+
+const std::vector<AutoSkillDefinition> &GetSkillDefinitions();
+const AutoSkillDefinition *GetSkillDefinition(EQ::skills::SkillType skill);
+const AutoSkillDefinition *FindSkillDefinition(const std::string &skill_name);
+
+bool IsSupported(EQ::skills::SkillType skill);
+bool IsEnabled(uint32 enabled_mask, EQ::skills::SkillType skill);
+uint32 SetEnabled(uint32 enabled_mask, EQ::skills::SkillType skill, bool enabled);
+uint32 SanitizeMask(uint32 enabled_mask);
+std::string NormalizeSkillName(const std::string &skill_name);
+
+} // namespace autoskill
+} // namespace skills
+} // namespace EQ

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -624,6 +624,7 @@ RULE_INT(Combat, SneakPullAssistRange, 400, "Modified range of assist for sneak 
 RULE_BOOL(Combat, Classic2HBAnimation, false, "2HB will use the 2 hand piercing animation instead of the overhead slashing animation")
 RULE_BOOL(Combat, ArcheryConsumesAmmo, true, "Set to false to disable Archery Ammo Consumption")
 RULE_BOOL(Combat, ThrowingConsumesAmmo, true, "Set to false to disable Throwing Ammo Consumption")
+RULE_BOOL(Combat, EnableAutoSkill, false, "Enable or disable the player #autoskill system for supported base combat abilities")
 RULE_BOOL(Combat, UseLiveRiposteMechanics, false, "Set to true to disable SPA 173 SpellEffect::RiposteChance from making those with the effect on them immune to enrage, can longer riposte from a riposte.")
 RULE_INT(Combat, FrontalStunImmunityClasses, 0, "Bitmask for Classes than have frontal stun immunity, No Races (0) by default.")
 RULE_BOOL(Combat, NPCsUseFrontalStunImmunityClasses, false, "Enable or disable NPCs using frontal stun immunity Classes from Combat:FrontalStunImmunityClasses, false by default.")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ set(tests_sources
 
 set(tests_headers
 	atobool_test.h
+	autoskill_util_test.h
 	buyer_buy_lines_repository_test.h
 	crash_report_endpoint_test.h
 	data_verification_test.h

--- a/tests/autoskill_util_test.h
+++ b/tests/autoskill_util_test.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "common/auto_skill.h"
+#include "cppunit/cpptest.h"
+
+class AutoSkillUtilTest : public Test::Suite {
+	typedef void(AutoSkillUtilTest::*TestFunction)(void);
+
+public:
+	AutoSkillUtilTest() {
+		TEST_ADD(AutoSkillUtilTest::FindsSkillsAndAliases);
+		TEST_ADD(AutoSkillUtilTest::HandlesEnabledMask);
+		TEST_ADD(AutoSkillUtilTest::KeepsPriorityOrder);
+	}
+
+	~AutoSkillUtilTest() {
+	}
+
+private:
+	void FindsSkillsAndAliases() {
+		auto *flying_kick = EQ::skills::autoskill::FindSkillDefinition("Flying-Kick");
+		TEST_ASSERT(flying_kick);
+		TEST_ASSERT(flying_kick->skill == EQ::skills::SkillFlyingKick);
+
+		auto *tail_rake = EQ::skills::autoskill::FindSkillDefinition("tail rake");
+		TEST_ASSERT(tail_rake);
+		TEST_ASSERT(tail_rake->skill == EQ::skills::SkillDragonPunch);
+
+		auto *slam = EQ::skills::autoskill::FindSkillDefinition("slam");
+		TEST_ASSERT(slam);
+		TEST_ASSERT(slam->skill == EQ::skills::SkillBash);
+
+		TEST_ASSERT(!EQ::skills::autoskill::FindSkillDefinition("taunt"));
+	}
+
+	void HandlesEnabledMask() {
+		uint32 enabled_mask = 0;
+
+		enabled_mask = EQ::skills::autoskill::SetEnabled(enabled_mask, EQ::skills::SkillKick, true);
+		TEST_ASSERT(EQ::skills::autoskill::IsEnabled(enabled_mask, EQ::skills::SkillKick));
+
+		enabled_mask = EQ::skills::autoskill::SetEnabled(enabled_mask, EQ::skills::SkillKick, false);
+		TEST_ASSERT(!EQ::skills::autoskill::IsEnabled(enabled_mask, EQ::skills::SkillKick));
+
+		enabled_mask = EQ::skills::autoskill::SetEnabled(enabled_mask, EQ::skills::SkillTaunt, true);
+		TEST_ASSERT(enabled_mask == 0);
+
+		TEST_ASSERT(EQ::skills::autoskill::SanitizeMask(0xFFFFFFFF) == 0x1FF);
+	}
+
+	void KeepsPriorityOrder() {
+		const auto &definitions = EQ::skills::autoskill::GetSkillDefinitions();
+
+		TEST_ASSERT(definitions.size() == 9);
+		TEST_ASSERT(definitions.front().skill == EQ::skills::SkillBackstab);
+		TEST_ASSERT(definitions[1].skill == EQ::skills::SkillFrenzy);
+		TEST_ASSERT(definitions.back().skill == EQ::skills::SkillBash);
+	}
+};

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -17,6 +17,7 @@
 */
 
 #include "tests/atobool_test.h"
+#include "tests/autoskill_util_test.h"
 #include "tests/buyer_buy_lines_repository_test.h"
 #include "tests/crash_report_endpoint_test.h"
 #include "tests/data_verification_test.h"
@@ -58,6 +59,7 @@ int main()
 		tests.add(new FixedMemoryVariableHashTest());
 		tests.add(new ExpeditionSchemaTest());
 		tests.add(new atoboolTest());
+		tests.add(new AutoSkillUtilTest());
 		tests.add(new BuyerBuyLinesRepositoryTest());
 		tests.add(new CrashReportEndpointTest());
 		tests.add(new hextoi_32_64_Test());

--- a/zone/CMakeLists.txt
+++ b/zone/CMakeLists.txt
@@ -7,6 +7,7 @@ set(zone_sources
     aggromanager.cpp
     api_service.cpp
     attack.cpp
+    autoskill.cpp
     aura.cpp
     beacon.cpp
     bonuses.cpp
@@ -381,6 +382,7 @@ set(gm_command_sources
     gm_commands/appearance.cpp
     gm_commands/appearanceeffects.cpp
     gm_commands/attack.cpp
+    gm_commands/autoskill.cpp
     gm_commands/augmentitem.cpp
     gm_commands/ban.cpp
     gm_commands/bugs.cpp

--- a/zone/autoskill.cpp
+++ b/zone/autoskill.cpp
@@ -2,6 +2,7 @@
 
 #include "common/auto_skill.h"
 #include "common/classes.h"
+#include "common/features.h"
 #include "common/item_data.h"
 #include "common/item_instance.h"
 #include "common/rulesys.h"
@@ -92,6 +93,56 @@ pTimerType GetAutoSkillTimer(const Client *client, EQ::skills::SkillType skill)
 	}
 
 	return pTimerCombatAbility;
+}
+
+uint32 GetVisibleAutoSkillReuseTime(Client *client, EQ::skills::SkillType skill, int reuse_time)
+{
+	reuse_time -= client->GetSkillReuseTime(skill);
+
+	if (reuse_time <= 0) {
+		return 0;
+	}
+
+	return static_cast<uint32>(reuse_time);
+}
+
+uint32 GetMinimumAutoSkillReuseTime(Client *client, EQ::skills::SkillType skill)
+{
+	switch (skill) {
+		case EQ::skills::SkillBackstab:
+			return GetVisibleAutoSkillReuseTime(client, skill, BackstabReuseTime - 1);
+		case EQ::skills::SkillFrenzy:
+			return GetVisibleAutoSkillReuseTime(client, skill, FrenzyReuseTime - 1);
+		case EQ::skills::SkillFlyingKick:
+			return GetVisibleAutoSkillReuseTime(client, skill, FlyingKickReuseTime - 1);
+		case EQ::skills::SkillDragonPunch:
+			return GetVisibleAutoSkillReuseTime(client, skill, TailRakeReuseTime - 1);
+		case EQ::skills::SkillEagleStrike:
+			return GetVisibleAutoSkillReuseTime(client, skill, EagleStrikeReuseTime - 1);
+		case EQ::skills::SkillTigerClaw:
+			return GetVisibleAutoSkillReuseTime(client, skill, TigerClawReuseTime - 1);
+		case EQ::skills::SkillRoundKick:
+			return GetVisibleAutoSkillReuseTime(client, skill, RoundKickReuseTime - 1);
+		case EQ::skills::SkillKick:
+			return GetVisibleAutoSkillReuseTime(client, skill, KickReuseTime + 3);
+		case EQ::skills::SkillBash:
+			return GetVisibleAutoSkillReuseTime(client, skill, BashReuseTime + 3);
+		default:
+			return 0;
+	}
+}
+
+void ConstrainAutoSkillTimer(Client *client, pTimerType timer, EQ::skills::SkillType skill)
+{
+	const auto minimum_reuse_time = GetMinimumAutoSkillReuseTime(client, skill);
+	if (minimum_reuse_time == 0) {
+		return;
+	}
+
+	const auto remaining_time = client->GetPTimers().GetRemainingTime(timer);
+	if (remaining_time > 0 && remaining_time < minimum_reuse_time) {
+		client->GetPTimers().Start(timer, minimum_reuse_time);
+	}
 }
 
 bool IsValidAutoSkillTarget(Client *client, Mob *target)
@@ -245,6 +296,7 @@ void Client::ProcessAutoSkills()
 		combat_ability.m_skill = skill;
 
 		OPCombatAbility(&combat_ability);
+		ConstrainAutoSkillTimer(this, timer, skill);
 
 		if (GetTarget() != target || target->GetHP() <= -10) {
 			return;

--- a/zone/autoskill.cpp
+++ b/zone/autoskill.cpp
@@ -1,0 +1,233 @@
+#include "zone/client.h"
+
+#include "common/auto_skill.h"
+#include "common/classes.h"
+#include "common/item_data.h"
+#include "common/item_instance.h"
+#include "common/rulesys.h"
+#include "common/strings.h"
+
+namespace {
+
+constexpr const char *AutoSkillBucketKey = "autoskill.enabled_mask";
+
+bool IsSlamRace(uint16 race_id)
+{
+	switch (race_id) {
+		case Race::Ogre:
+		case Race::Troll:
+		case Race::Barbarian:
+			return true;
+		default:
+			return false;
+	}
+}
+
+bool IsMonkSpecialAttack(EQ::skills::SkillType skill)
+{
+	switch (skill) {
+		case EQ::skills::SkillFlyingKick:
+		case EQ::skills::SkillDragonPunch:
+		case EQ::skills::SkillEagleStrike:
+		case EQ::skills::SkillTigerClaw:
+		case EQ::skills::SkillRoundKick:
+			return true;
+		default:
+			return false;
+	}
+}
+
+bool CanUseKickClass(const Client *client)
+{
+	const auto class_id = client->GetClass();
+	const auto extra_allowed_kick_classes = RuleI(Combat, ExtraAllowedKickClassesBitmask);
+
+	return (
+		class_id == Class::Warrior ||
+		class_id == Class::Ranger ||
+		class_id == Class::Monk ||
+		class_id == Class::Beastlord ||
+		class_id == Class::Berserker ||
+		(extra_allowed_kick_classes & GetPlayerClassBit(class_id))
+	);
+}
+
+bool HasPrimaryPiercingWeapon(const Client *client)
+{
+	const auto *item_instance = client->GetInv().GetItem(EQ::invslot::slotPrimary);
+	return (
+		item_instance &&
+		item_instance->GetItem() &&
+		item_instance->GetItem()->ItemType == EQ::item::ItemType1HPiercing
+	);
+}
+
+pTimerType GetAutoSkillTimer(const Client *client, EQ::skills::SkillType skill)
+{
+	if (
+		client->ClientVersion() >= EQ::versions::ClientVersion::RoF2 &&
+		skill == EQ::skills::SkillTigerClaw
+	) {
+		return pTimerCombatAbility2;
+	}
+
+	return pTimerCombatAbility;
+}
+
+bool IsValidAutoSkillTarget(Client *client, Mob *target)
+{
+	return (
+		target &&
+		target != client &&
+		target->GetHP() > -10 &&
+		client->IsAttackAllowed(target) &&
+		client->CombatRange(target) &&
+		client->CheckLosFN(target) &&
+		client->IsFacingMob(target)
+	);
+}
+
+} // namespace
+
+bool Client::IsAutoSkillEnabled(EQ::skills::SkillType skill_id) const
+{
+	return EQ::skills::autoskill::IsEnabled(auto_skill_enabled_mask, skill_id);
+}
+
+bool Client::IsAutoSkillUsable(EQ::skills::SkillType skill_id) const
+{
+	if (!EQ::skills::autoskill::IsSupported(skill_id)) {
+		return false;
+	}
+
+	if (skill_id == EQ::skills::SkillBash) {
+		return MaxSkill(skill_id) > 0 || IsSlamRace(GetRace());
+	}
+
+	if (MaxSkill(skill_id) == 0) {
+		return false;
+	}
+
+	if (skill_id == EQ::skills::SkillKick) {
+		return CanUseKickClass(this);
+	}
+
+	if (skill_id == EQ::skills::SkillBackstab) {
+		return GetClass() == Class::Rogue;
+	}
+
+	if (skill_id == EQ::skills::SkillFrenzy) {
+		return GetClass() == Class::Berserker;
+	}
+
+	if (IsMonkSpecialAttack(skill_id)) {
+		return GetClass() == Class::Monk;
+	}
+
+	return true;
+}
+
+void Client::SetAutoSkillEnabled(EQ::skills::SkillType skill_id, bool enabled)
+{
+	auto_skill_enabled_mask = EQ::skills::autoskill::SetEnabled(auto_skill_enabled_mask, skill_id, enabled);
+	SaveAutoSkillSettings();
+}
+
+void Client::LoadAutoSkillSettings()
+{
+	auto_skill_enabled_mask = 0;
+
+	const auto auto_skill_bucket = GetBucket(AutoSkillBucketKey);
+	if (auto_skill_bucket.empty()) {
+		return;
+	}
+
+	auto_skill_enabled_mask = EQ::skills::autoskill::SanitizeMask(Strings::ToUnsignedInt(auto_skill_bucket));
+}
+
+void Client::SaveAutoSkillSettings()
+{
+	auto_skill_enabled_mask = EQ::skills::autoskill::SanitizeMask(auto_skill_enabled_mask);
+
+	if (auto_skill_enabled_mask == 0) {
+		DeleteBucket(AutoSkillBucketKey);
+		return;
+	}
+
+	SetBucket(AutoSkillBucketKey, std::to_string(auto_skill_enabled_mask));
+}
+
+std::vector<EQ::skills::SkillType> Client::GetApplicableAutoSkills() const
+{
+	std::vector<EQ::skills::SkillType> applicable_skills;
+
+	for (const auto &definition : EQ::skills::autoskill::GetSkillDefinitions()) {
+		if (IsAutoSkillUsable(definition.skill)) {
+			applicable_skills.push_back(definition.skill);
+		}
+	}
+
+	return applicable_skills;
+}
+
+void Client::ProcessAutoSkills()
+{
+	if (
+		!RuleB(Combat, EnableAutoSkill) ||
+		!auto_attack ||
+		auto_skill_enabled_mask == 0 ||
+		!auto_skill_process_timer.Check() ||
+		IsAIControlled() ||
+		dead ||
+		IsStunned() ||
+		IsFeared() ||
+		IsMezzed() ||
+		GetAppearance() == eaDead ||
+		IsMeleeDisabled()
+	) {
+		return;
+	}
+
+	auto_skill_enabled_mask = EQ::skills::autoskill::SanitizeMask(auto_skill_enabled_mask);
+
+	Mob *target = GetTarget();
+	if (!IsValidAutoSkillTarget(this, target)) {
+		return;
+	}
+
+	for (const auto &definition : EQ::skills::autoskill::GetSkillDefinitions()) {
+		const auto skill = definition.skill;
+
+		if (!EQ::skills::autoskill::IsEnabled(auto_skill_enabled_mask, skill)) {
+			continue;
+		}
+
+		if (!IsAutoSkillUsable(skill)) {
+			continue;
+		}
+
+		if (skill == EQ::skills::SkillBackstab && !HasPrimaryPiercingWeapon(this)) {
+			continue;
+		}
+
+		if (!IsValidAutoSkillTarget(this, target)) {
+			return;
+		}
+
+		const auto timer = GetAutoSkillTimer(this, skill);
+		if (!p_timers.Expired(&database, timer, false)) {
+			continue;
+		}
+
+		CombatAbility_Struct combat_ability = {};
+		combat_ability.m_target = target->GetID();
+		combat_ability.m_atk = 100;
+		combat_ability.m_skill = skill;
+
+		OPCombatAbility(&combat_ability);
+
+		if (GetTarget() != target || target->GetHP() <= -10) {
+			return;
+		}
+	}
+}

--- a/zone/autoskill.cpp
+++ b/zone/autoskill.cpp
@@ -62,6 +62,26 @@ bool HasPrimaryPiercingWeapon(const Client *client)
 	);
 }
 
+bool CanAutoSkillBackstab(const Client *client, Mob *target)
+{
+	if (!HasPrimaryPiercingWeapon(client)) {
+		return false;
+	}
+
+	if (client->BehindMob(target, client->GetX(), client->GetY())) {
+		return true;
+	}
+
+	const auto item_bonuses = client->GetItemBonuses();
+	const auto spell_bonuses = client->GetSpellBonuses();
+	const auto aa_bonuses = client->GetAABonuses();
+
+	return (
+		(item_bonuses.FrontalBackstabChance + spell_bonuses.FrontalBackstabChance + aa_bonuses.FrontalBackstabChance) > 0 ||
+		(item_bonuses.FrontalBackstabMinDmg + spell_bonuses.FrontalBackstabMinDmg + aa_bonuses.FrontalBackstabMinDmg) > 0
+	);
+}
+
 pTimerType GetAutoSkillTimer(const Client *client, EQ::skills::SkillType skill)
 {
 	if (
@@ -206,7 +226,7 @@ void Client::ProcessAutoSkills()
 			continue;
 		}
 
-		if (skill == EQ::skills::SkillBackstab && !HasPrimaryPiercingWeapon(this)) {
+		if (skill == EQ::skills::SkillBackstab && !CanAutoSkillBackstab(this, target)) {
 			continue;
 		}
 

--- a/zone/autoskill.cpp
+++ b/zone/autoskill.cpp
@@ -99,11 +99,12 @@ int GetAutoSkillHasteModifier(Client *client)
 {
 	const int haste = client->GetHaste();
 
-	if (haste >= 0) {
-		return 10000 / (100 + haste);
+	if (haste <= 0) {
+		return 100;
 	}
 
-	return 100 - haste;
+	// Client haste is 100-based: 100 is unmodified speed.
+	return 10000 / haste;
 }
 
 uint32 GetAdjustedAutoSkillReuseTime(Client *client, EQ::skills::SkillType skill, int reuse_time)

--- a/zone/autoskill.cpp
+++ b/zone/autoskill.cpp
@@ -95,10 +95,27 @@ pTimerType GetAutoSkillTimer(const Client *client, EQ::skills::SkillType skill)
 	return pTimerCombatAbility;
 }
 
-uint32 GetVisibleAutoSkillReuseTime(Client *client, EQ::skills::SkillType skill, int reuse_time)
+int GetAutoSkillHasteModifier(Client *client)
 {
+	const int haste = client->GetHaste();
+
+	if (haste >= 0) {
+		return 10000 / (100 + haste);
+	}
+
+	return 100 - haste;
+}
+
+uint32 GetAdjustedAutoSkillReuseTime(Client *client, EQ::skills::SkillType skill, int reuse_time)
+{
+	reuse_time -= 1;
 	reuse_time -= client->GetSkillReuseTime(skill);
 
+	if (reuse_time <= 0) {
+		return 0;
+	}
+
+	reuse_time = (reuse_time * GetAutoSkillHasteModifier(client)) / 100;
 	if (reuse_time <= 0) {
 		return 0;
 	}
@@ -110,23 +127,23 @@ uint32 GetMinimumAutoSkillReuseTime(Client *client, EQ::skills::SkillType skill)
 {
 	switch (skill) {
 		case EQ::skills::SkillBackstab:
-			return GetVisibleAutoSkillReuseTime(client, skill, BackstabReuseTime - 1);
+			return GetAdjustedAutoSkillReuseTime(client, skill, BackstabReuseTime);
 		case EQ::skills::SkillFrenzy:
-			return GetVisibleAutoSkillReuseTime(client, skill, FrenzyReuseTime - 1);
+			return GetAdjustedAutoSkillReuseTime(client, skill, FrenzyReuseTime);
 		case EQ::skills::SkillFlyingKick:
-			return GetVisibleAutoSkillReuseTime(client, skill, FlyingKickReuseTime - 1);
+			return GetAdjustedAutoSkillReuseTime(client, skill, FlyingKickReuseTime);
 		case EQ::skills::SkillDragonPunch:
-			return GetVisibleAutoSkillReuseTime(client, skill, TailRakeReuseTime - 1);
+			return GetAdjustedAutoSkillReuseTime(client, skill, TailRakeReuseTime);
 		case EQ::skills::SkillEagleStrike:
-			return GetVisibleAutoSkillReuseTime(client, skill, EagleStrikeReuseTime - 1);
+			return GetAdjustedAutoSkillReuseTime(client, skill, EagleStrikeReuseTime);
 		case EQ::skills::SkillTigerClaw:
-			return GetVisibleAutoSkillReuseTime(client, skill, TigerClawReuseTime - 1);
+			return GetAdjustedAutoSkillReuseTime(client, skill, TigerClawReuseTime);
 		case EQ::skills::SkillRoundKick:
-			return GetVisibleAutoSkillReuseTime(client, skill, RoundKickReuseTime - 1);
+			return GetAdjustedAutoSkillReuseTime(client, skill, RoundKickReuseTime);
 		case EQ::skills::SkillKick:
-			return GetVisibleAutoSkillReuseTime(client, skill, KickReuseTime + 3);
+			return GetAdjustedAutoSkillReuseTime(client, skill, KickReuseTime);
 		case EQ::skills::SkillBash:
-			return GetVisibleAutoSkillReuseTime(client, skill, BashReuseTime + 3);
+			return GetAdjustedAutoSkillReuseTime(client, skill, BashReuseTime);
 		default:
 			return 0;
 	}
@@ -281,7 +298,7 @@ void Client::ProcessAutoSkills()
 			continue;
 		}
 
-		if (!IsValidAutoSkillTarget(this, target)) {
+		if (GetTarget() != target) {
 			return;
 		}
 

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -179,7 +179,8 @@ Client::Client() : Mob(
 				   tmSitting(0),
 				   parcel_timer(RuleI(Parcel, ParcelDeliveryDelay)),
 				   lazy_load_bank_check_timer(1000),
-				   bandolier_throttle_timer(0)
+				   bandolier_throttle_timer(0),
+				   auto_skill_process_timer(250)
 {
 	eqs = nullptr;
 	for (auto client_filter = FilterNone; client_filter < _FilterCount; client_filter = eqFilterType(client_filter + 1)) {
@@ -229,6 +230,7 @@ Client::Client() : Mob(
 	SetTarget(0);
 	auto_attack = false;
 	auto_fire = false;
+	auto_skill_enabled_mask = 0;
 	runmode = false;
 	linkdead_timer.Disable();
 	zonesummon_id = 0;
@@ -488,7 +490,8 @@ Client::Client(EQStreamInterface *ieqs) : Mob(
 	tmSitting(0),
 	parcel_timer(RuleI(Parcel, ParcelDeliveryDelay)),
 	lazy_load_bank_check_timer(1000),
-	bandolier_throttle_timer(0)
+	bandolier_throttle_timer(0),
+	auto_skill_process_timer(250)
 {
 	for (auto client_filter = FilterNone; client_filter < _FilterCount; client_filter = eqFilterType(client_filter + 1)) {
 		SetFilter(client_filter, FilterShow);
@@ -540,6 +543,7 @@ Client::Client(EQStreamInterface *ieqs) : Mob(
 	SetTarget(0);
 	auto_attack = false;
 	auto_fire = false;
+	auto_skill_enabled_mask = 0;
 	runmode = false;
 	linkdead_timer.Disable();
 	zonesummon_id = 0;

--- a/zone/client.h
+++ b/zone/client.h
@@ -982,6 +982,14 @@ public:
 	uint32 GetRawSkill(EQ::skills::SkillType skill_id) const { if (skill_id <= EQ::skills::HIGHEST_SKILL) { return(m_pp.skills[skill_id]); } return 0; }
 	bool HasSkill(EQ::skills::SkillType skill_id) const;
 	bool CanHaveSkill(EQ::skills::SkillType skill_id) const;
+	uint32 GetAutoSkillEnabledMask() const { return auto_skill_enabled_mask; }
+	bool IsAutoSkillEnabled(EQ::skills::SkillType skill_id) const;
+	bool IsAutoSkillUsable(EQ::skills::SkillType skill_id) const;
+	void SetAutoSkillEnabled(EQ::skills::SkillType skill_id, bool enabled);
+	void LoadAutoSkillSettings();
+	void SaveAutoSkillSettings();
+	std::vector<EQ::skills::SkillType> GetApplicableAutoSkills() const;
+	void ProcessAutoSkills();
 	void SetSkill(EQ::skills::SkillType skill_num, uint16 value);
 	void AddSkill(EQ::skills::SkillType skillid, uint16 value);
 	void CheckSpecializeIncrease(uint16 spell_id);
@@ -2132,6 +2140,7 @@ private:
 	bool m_is_manual_afk = false;
 	bool auto_attack;
 	bool auto_fire;
+	uint32 auto_skill_enabled_mask = 0;
 	bool runmode;
 	uint8 gmspeed;
 	bool gminvul;
@@ -2269,6 +2278,7 @@ private:
 	Timer parcel_timer;	//Used to limit the number of parcels to one every 30 seconds (default).  Changable via rule.
 	Timer lazy_load_bank_check_timer;
 	Timer bandolier_throttle_timer;
+	Timer auto_skill_process_timer;
 
 	bool m_lazy_load_bank            = false;
 	int  m_lazy_load_sent_bank_slots = 0;

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -1487,6 +1487,7 @@ void Client::Handle_Connect_OP_ZoneEntry(const EQApplicationPacket *app)
 	// Load Data Buckets
 	ClearDataBucketCache();
 	LoadDataBucketsCache();
+	LoadAutoSkillSettings();
 
 	// Max Level for Character:PerCharacterQglobalMaxLevel and Character:PerCharacterBucketMaxLevel
 	uint8 client_max_level = 0;

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -438,6 +438,11 @@ bool Client::Process() {
 		}
 
 		Mob *auto_attack_target = GetTarget();
+		if (auto_attack && auto_attack_target != nullptr && may_use_attacks) {
+			ProcessAutoSkills();
+			auto_attack_target = GetTarget();
+		}
+
 		if (auto_attack && auto_attack_target != nullptr && may_use_attacks && attack_timer.Check()) {
 			//check if change
 			//only check on primary attack.. sorry offhand you gotta wait!

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -86,6 +86,7 @@ int command_init(void)
 		command_add("appearanceeffects", "[Help|Remove|Set|View] - Modify appearance effects on yourself or your target.", AccountStatus::GMAdmin, command_appearanceeffects) ||
 		command_add("apply_shared_memory", "[shared_memory_name] - Tells every zone and world to apply a specific shared memory segment by name.", AccountStatus::GMImpossible, command_apply_shared_memory) ||
 		command_add("attack", "[Entity Name] - Make your NPC target attack an entity by name", AccountStatus::GMLeadAdmin, command_attack) ||
+		command_add("autoskill", "[skill] [on|off] - Automatically use supported combat skills while auto-attack is active", AccountStatus::Player, command_autoskill) ||
 		command_add("augmentitem", "Force augments an item. Must have the augment item window open.", AccountStatus::GMImpossible, command_augmentitem) ||
 		command_add("ban", "[Character Name] [Reason] - Ban by character name", AccountStatus::GMLeadAdmin, command_ban) ||
 		command_add("bugs", "[Close|Delete|Review|Search|View] - Handles player bug reports", AccountStatus::QuestTroupe, command_bugs) ||

--- a/zone/command.h
+++ b/zone/command.h
@@ -49,6 +49,7 @@ void command_appearance(Client *c, const Seperator *sep);
 void command_appearanceeffects(Client *c, const Seperator *sep);
 void command_apply_shared_memory(Client *c, const Seperator *sep);
 void command_attack(Client *c, const Seperator *sep);
+void command_autoskill(Client *c, const Seperator *sep);
 void command_augmentitem(Client *c, const Seperator *sep);
 void command_ban(Client *c, const Seperator *sep);
 void command_bugs(Client *c, const Seperator *sep);

--- a/zone/gm_commands/autoskill.cpp
+++ b/zone/gm_commands/autoskill.cpp
@@ -83,6 +83,59 @@ std::string GetApplicableSkillsList(Client *client)
 	return Strings::Join(skill_names, ", ");
 }
 
+bool UsesSecondaryCombatAbilityCooldown(Client *client, EQ::skills::SkillType skill)
+{
+	return (
+		client->ClientVersion() >= EQ::versions::ClientVersion::RoF2 &&
+		skill == EQ::skills::SkillTigerClaw
+	);
+}
+
+void ShowAutoSkillMenuEntry(Client *client, EQ::skills::SkillType skill)
+{
+	const auto *definition = EQ::skills::autoskill::GetSkillDefinition(skill);
+	if (!definition) {
+		return;
+	}
+
+	const bool enabled = client->IsAutoSkillEnabled(skill);
+	const auto toggle_link = Saylink::Silent(
+		fmt::format(
+			"#autoskill {} {}",
+			definition->command_name,
+			enabled ? "off" : "on"
+		),
+		enabled ? "[Turn Off]" : "[Turn On]"
+	);
+
+	client->Message(
+		Chat::White,
+		fmt::format(
+			"  {}: {} {}",
+			definition->name,
+			enabled ? "On" : "Off",
+			toggle_link
+		).c_str()
+	);
+}
+
+void ShowAutoSkillMenuGroup(
+	Client *client,
+	const std::string &title,
+	const std::vector<EQ::skills::SkillType> &skills
+)
+{
+	if (skills.empty()) {
+		return;
+	}
+
+	client->Message(Chat::White, title.c_str());
+
+	for (const auto skill : skills) {
+		ShowAutoSkillMenuEntry(client, skill);
+	}
+}
+
 void ShowAutoSkillMenu(Client *client)
 {
 	const auto applicable_skills = client->GetApplicableAutoSkills();
@@ -91,34 +144,23 @@ void ShowAutoSkillMenu(Client *client)
 		return;
 	}
 
-	client->Message(Chat::White, "Autoskill settings:");
+	std::vector<EQ::skills::SkillType> shared_cooldown_skills;
+	std::vector<EQ::skills::SkillType> secondary_cooldown_skills;
 
 	for (const auto skill : applicable_skills) {
-		const auto *definition = EQ::skills::autoskill::GetSkillDefinition(skill);
-		if (!definition) {
+		if (UsesSecondaryCombatAbilityCooldown(client, skill)) {
+			secondary_cooldown_skills.push_back(skill);
 			continue;
 		}
 
-		const bool enabled = client->IsAutoSkillEnabled(skill);
-		const auto toggle_link = Saylink::Silent(
-			fmt::format(
-				"#autoskill {} {}",
-				definition->command_name,
-				enabled ? "off" : "on"
-			),
-			enabled ? "[Turn Off]" : "[Turn On]"
-		);
-
-		client->Message(
-			Chat::White,
-			fmt::format(
-				"{}: {} {}",
-				definition->name,
-				enabled ? "On" : "Off",
-				toggle_link
-			).c_str()
-		);
+		shared_cooldown_skills.push_back(skill);
 	}
+
+	client->Message(Chat::White, "Autoskill settings:");
+	client->Message(Chat::White, "Skills grouped together share a cooldown. In a shared group, the first enabled skill listed has priority.");
+
+	ShowAutoSkillMenuGroup(client, "Shared Combat Ability Cooldown:", shared_cooldown_skills);
+	ShowAutoSkillMenuGroup(client, "Secondary Combat Ability Cooldown:", secondary_cooldown_skills);
 }
 
 } // namespace

--- a/zone/gm_commands/autoskill.cpp
+++ b/zone/gm_commands/autoskill.cpp
@@ -1,0 +1,191 @@
+#include "zone/client.h"
+
+#include "common/auto_skill.h"
+#include "common/rulesys.h"
+#include "common/say_link.h"
+#include "common/strings.h"
+
+#include "fmt/format.h"
+
+#include <sstream>
+#include <vector>
+
+namespace {
+
+bool TryParseAutoSkillState(const std::string &state_token, bool &enabled)
+{
+	const auto normalized_state = EQ::skills::autoskill::NormalizeSkillName(state_token);
+
+	if (
+		normalized_state == "on" ||
+		normalized_state == "enable" ||
+		normalized_state == "enabled" ||
+		normalized_state == "true" ||
+		normalized_state == "1"
+	) {
+		enabled = true;
+		return true;
+	}
+
+	if (
+		normalized_state == "off" ||
+		normalized_state == "disable" ||
+		normalized_state == "disabled" ||
+		normalized_state == "false" ||
+		normalized_state == "0"
+	) {
+		enabled = false;
+		return true;
+	}
+
+	return false;
+}
+
+std::vector<std::string> TokenizeCommandRemainder(const std::string &remainder)
+{
+	std::vector<std::string> tokens;
+	std::istringstream stream(remainder);
+	std::string token;
+
+	while (stream >> token) {
+		tokens.push_back(token);
+	}
+
+	return tokens;
+}
+
+std::string JoinTokens(const std::vector<std::string> &tokens)
+{
+	std::string joined_tokens;
+
+	for (const auto &token : tokens) {
+		if (!joined_tokens.empty()) {
+			joined_tokens.append(" ");
+		}
+
+		joined_tokens.append(token);
+	}
+
+	return joined_tokens;
+}
+
+std::string GetApplicableSkillsList(Client *client)
+{
+	std::vector<std::string> skill_names;
+
+	for (const auto skill : client->GetApplicableAutoSkills()) {
+		const auto *definition = EQ::skills::autoskill::GetSkillDefinition(skill);
+		if (definition) {
+			skill_names.emplace_back(definition->name);
+		}
+	}
+
+	return Strings::Join(skill_names, ", ");
+}
+
+void ShowAutoSkillMenu(Client *client)
+{
+	const auto applicable_skills = client->GetApplicableAutoSkills();
+	if (applicable_skills.empty()) {
+		client->Message(Chat::White, "No supported autoskills are available to your character at this level.");
+		return;
+	}
+
+	client->Message(Chat::White, "Autoskill settings:");
+
+	for (const auto skill : applicable_skills) {
+		const auto *definition = EQ::skills::autoskill::GetSkillDefinition(skill);
+		if (!definition) {
+			continue;
+		}
+
+		const bool enabled = client->IsAutoSkillEnabled(skill);
+		const auto toggle_link = Saylink::Silent(
+			fmt::format(
+				"#autoskill {} {}",
+				definition->command_name,
+				enabled ? "off" : "on"
+			),
+			enabled ? "[Turn Off]" : "[Turn On]"
+		);
+
+		client->Message(
+			Chat::White,
+			fmt::format(
+				"{}: {} {}",
+				definition->name,
+				enabled ? "On" : "Off",
+				toggle_link
+			).c_str()
+		);
+	}
+}
+
+} // namespace
+
+void command_autoskill(Client *c, const Seperator *sep)
+{
+	if (!RuleB(Combat, EnableAutoSkill)) {
+		c->Message(Chat::Red, "Autoskill is disabled on this server.");
+		return;
+	}
+
+	const std::string command_remainder = sep->argplus[1] ? sep->argplus[1] : "";
+	auto tokens = TokenizeCommandRemainder(command_remainder);
+
+	if (tokens.empty()) {
+		ShowAutoSkillMenu(c);
+		return;
+	}
+
+	bool has_requested_state = false;
+	bool requested_state = false;
+
+	if (TryParseAutoSkillState(tokens.back(), requested_state)) {
+		has_requested_state = true;
+		tokens.pop_back();
+	}
+
+	const auto skill_name = JoinTokens(tokens);
+	if (skill_name.empty()) {
+		c->Message(Chat::White, "Usage: #autoskill [skill] [on|off]");
+		return;
+	}
+
+	const auto *definition = EQ::skills::autoskill::FindSkillDefinition(skill_name);
+	if (!definition) {
+		const auto skill_list = GetApplicableSkillsList(c);
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"Unsupported autoskill '{}'. Available autoskills: {}.",
+				skill_name,
+				skill_list.empty() ? "None" : skill_list
+			).c_str()
+		);
+		return;
+	}
+
+	if (!c->IsAutoSkillUsable(definition->skill)) {
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"{} is not available to your character at this level.",
+				definition->name
+			).c_str()
+		);
+		return;
+	}
+
+	const bool enabled = has_requested_state ? requested_state : !c->IsAutoSkillEnabled(definition->skill);
+	c->SetAutoSkillEnabled(definition->skill, enabled);
+
+	c->Message(
+		Chat::White,
+		fmt::format(
+			"Autoskill for {} is now {}.",
+			definition->name,
+			enabled ? "on" : "off"
+		).c_str()
+	);
+}


### PR DESCRIPTION
## Summary
- Add a rule-gated `#autoskill` command for supported base combat abilities.
- Persist per-character autoskill toggles through character-scoped data buckets.
- Run enabled autoskills during valid auto-attack windows by reusing the existing `OPCombatAbility()` path and combat ability timers.
- Add shared autoskill metadata helpers and focused helper tests.

Supported skills: 
- Backstab
- Bash/Slam
- Frenzy
- Kick
- Flying Kick
- Dragon Punch/Tail Rake
- Eagle Strike
- Tiger Claw
- Round Kick.

## Activation Order
1. Backstab
2. Frenzy
3. Flying Kick
4. Dragon Punch / Tail Rake
5. Eagle Strike
6. Tiger Claw
7. Round Kick
8. Kick
9. Bash / Slam

## Autoskill Activation Logic
For each skill in that order, it skips the skill unless it is toggled on, usable by the character, and its combat ability cooldown timer is expired. Backstab has extra checks: rogue only, piercing weapon, and behind the target unless the character has frontal backstab bonuses.
When a skill passes those checks, autoskill sends it through OPCombatAbility() using the same combat ability path as a manual hotkey press. The first enabled ready skill on a shared cooldown consumes that cooldown, so lower-priority shared skills do not fire that pass. On RoF2+, Tiger Claw uses the secondary combat ability timer, so it can fire alongside one primary shared-cooldown ability.
After the ability fires, the autoskill code constrains the timer to the same effective manual reuse time so autoskill should not outpace hotkey usage.

## Test
Tested on WAR, MNK, ROG

Ability activations work as expected.

Monk Example:
<img width="595" height="142" alt="image" src="https://github.com/user-attachments/assets/42dce389-0868-45d3-8705-4531f09bd27a" />


## Validation
- `git diff --cached --check`
- Linux `tests` target with `-RunTests`: 124 tests, 100% correct
- Linux `zone` target build

## Notes
- The feature is disabled by default behind `Combat:EnableAutoSkill`.
- Supported abilities are limited to base damage combat skills such as Backstab, Bash/Slam, Frenzy, Kick, and monk special attacks.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live combat timing by injecting abilities into the auto-attack loop through the existing combat-ability handler; mitigated by a default-off rule and reuse/timer checks, but enabled servers should validate balance and edge cases (target changes, shared cooldown priority).
> 
> **Overview**
> Introduces a **player autoskill** feature (off by default via **`Combat:EnableAutoSkill`**) that lets characters toggle automatic use of nine base combat abilities (backstab, frenzy, monk specials, kick, bash/slam, etc.) while **auto-attack** is active.
> 
> Shared **`common/auto_skill`** helpers define skill metadata, fixed **priority order**, name/alias lookup, and a **bitmask** for enabled skills. Per-character settings load/save from the **`autoskill.enabled_mask`** data bucket on login.
> 
> During combat processing, **`ProcessAutoSkills`** runs on a throttled timer when auto-attack is valid: it checks class/race/weapon rules (e.g. rogue backstab with piercing and behind/frontal bonuses), shared vs secondary combat timers (RoF2 Tiger Claw), then invokes the same path as manual abilities through **`OPCombatAbility`**, with reuse time constrained to match manual use.
> 
> Players configure skills with the new **`#autoskill`** command (menu with saylinks and **`#autoskill [skill] [on|off]`**). **Unit tests** cover alias lookup, mask toggling, and definition order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f3110d4319035a417343a65bc01ca5a3fcfa23e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an auto-skill system that can automatically trigger eligible combat abilities, controlled by a new `EnableAutoSkill` combat rule (default: off).
  * Introduced `#autoskill` to display applicable skills and toggle enablement, with per-character saved settings and cooldown/timer enforcement.
* **Tests**
  * Added an AutoSkill utility test suite covering definition lookup, enabled-mask behavior/sanitization, and expected definition ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->