### PR TITLE
[Offline Trader] Exploit Fix & Overflow Protection

### DIFF
--- a/common/bazaar.cpp
+++ b/common/bazaar.cpp
@@ -3,7 +3,40 @@
 #include "common/item_instance.h"
 #include "common/repositories/trader_repository.h"
 
+#include <limits>
 #include <memory>
+
+Bazaar::PurchaseQuantityValidation Bazaar::ValidatePurchaseQuantity(
+	uint32 requested_quantity,
+	bool is_stackable,
+	int16 listed_charges
+)
+{
+	const uint32 max_signed_quantity = static_cast<uint32>(std::numeric_limits<int32>::max());
+	if (requested_quantity == 0 || requested_quantity > max_signed_quantity) {
+		return {false, 0};
+	}
+
+	uint32 quantity = requested_quantity;
+	if (!is_stackable) {
+		if (quantity != 1) {
+			return {false, 0};
+		}
+
+		return {true, quantity};
+	}
+
+	if (listed_charges <= 0) {
+		return {false, 0};
+	}
+
+	const uint32 available_quantity = static_cast<uint32>(listed_charges);
+	if (quantity > available_quantity) {
+		quantity = available_quantity;
+	}
+
+	return {true, quantity};
+}
 
 std::vector<BazaarSearchResultsFromDB_Struct>
 Bazaar::GetSearchResults(

--- a/common/bazaar.cpp
+++ b/common/bazaar.cpp
@@ -38,6 +38,11 @@ Bazaar::PurchaseQuantityValidation Bazaar::ValidatePurchaseQuantity(
 	return {true, quantity};
 }
 
+bool Bazaar::ValidatePurchasePrice(uint32 requested_price, uint32 listed_price)
+{
+	return listed_price > 0 && requested_price == listed_price;
+}
+
 std::vector<BazaarSearchResultsFromDB_Struct>
 Bazaar::GetSearchResults(
 	Database &db,

--- a/common/bazaar.h
+++ b/common/bazaar.h
@@ -7,6 +7,17 @@
 
 class Bazaar {
 public:
+	struct PurchaseQuantityValidation {
+		bool   is_valid;
+		uint32 quantity;
+	};
+
+	static PurchaseQuantityValidation ValidatePurchaseQuantity(
+		uint32 requested_quantity,
+		bool is_stackable,
+		int16 listed_charges
+	);
+
 	static std::vector<BazaarSearchResultsFromDB_Struct>
 	GetSearchResults(Database &content_db, Database &db, BazaarSearchCriteria_Struct search, unsigned int char_zone_id, int char_zone_instance_id);
 

--- a/common/bazaar.h
+++ b/common/bazaar.h
@@ -18,6 +18,8 @@ public:
 		int16 listed_charges
 	);
 
+	static bool ValidatePurchasePrice(uint32 requested_price, uint32 listed_price);
+
 	static std::vector<BazaarSearchResultsFromDB_Struct>
 	GetSearchResults(Database &content_db, Database &db, BazaarSearchCriteria_Struct search, unsigned int char_zone_id, int char_zone_instance_id);
 

--- a/common/eq_limits.h
+++ b/common/eq_limits.h
@@ -35,6 +35,8 @@ namespace EQ
 	void InitializeDynamicLookups();
 
 	namespace constants {
+		constexpr uint64 BAZAAR_MAX_TRANSACTION_DEFAULT = 2000000000ULL;
+
 		struct LookupEntry {
 			EQ::expansions::Expansion Expansion;
 			uint32 ExpansionBit;
@@ -60,7 +62,7 @@ namespace EQ
 				CharacterCreationLimit(CharacterCreationLimit),
 				SayLinkBodySize(SayLinkBodySize),
 				BazaarTraderLimit(BazaarTraderLimit),
-				BazaarMaxTransaction(BazaarMaxTransaction)
+				BazaarMaxTransaction(BazaarMaxTransaction ? BazaarMaxTransaction : BAZAAR_MAX_TRANSACTION_DEFAULT)
 			{ }
 		};
 

--- a/common/patches/rof2_limits.h
+++ b/common/patches/rof2_limits.h
@@ -306,7 +306,7 @@ namespace RoF2
 		const size_t SAY_LINK_BODY_SIZE = 56;
 		const uint32 MAX_GUILD_ID       = 50000;
 		const uint32 MAX_BAZAAR_TRADERS = 600;
-		const uint64 MAX_BAZAAR_TRANSACTION = 3276700000000; //3276700000000
+		const uint64 MAX_BAZAAR_TRANSACTION = 2000000000ULL; // 2 million platinum in copper
 
 	} /*constants*/
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ set(tests_sources
 
 set(tests_headers
 	atobool_test.h
+	bazaar_test.h
 	buyer_buy_lines_repository_test.h
 	crash_report_endpoint_test.h
 	data_verification_test.h

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ set(tests_headers
 	buyer_buy_lines_repository_test.h
 	crash_report_endpoint_test.h
 	data_verification_test.h
+	eq_limits_test.h
 	expedition_schema_test.h
 	fixed_memory_test.h
 	fixed_memory_variable_test.h

--- a/tests/bazaar_test.h
+++ b/tests/bazaar_test.h
@@ -1,0 +1,88 @@
+/*	EQEMu: Everquest Server Emulator
+	Copyright (C) 2001-2013 EQEmu Development Team (http://eqemulator.net)
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; version 2 of the License.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY except by those people which sell it, which
+	are required to give you total support for your newly bought product;
+	without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+	A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program; if not, write to the Free Software
+	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+*/
+
+#pragma once
+
+#include "common/bazaar.h"
+#include "cppunit/cpptest.h"
+
+class BazaarTest : public Test::Suite {
+public:
+	BazaarTest()
+	{
+		TEST_ADD(BazaarTest::RejectsZeroQuantity);
+		TEST_ADD(BazaarTest::RejectsNegativeEncodedQuantity);
+		TEST_ADD(BazaarTest::RejectsStackableWithoutListedCharges);
+		TEST_ADD(BazaarTest::ClampsStackableQuantityToListedCharges);
+		TEST_ADD(BazaarTest::AcceptsPositiveNonStackableQuantity);
+		TEST_ADD(BazaarTest::RejectsNonStackableQuantityAboveOne);
+	}
+
+	~BazaarTest()
+	{
+	}
+
+private:
+	void RejectsZeroQuantity()
+	{
+		auto result = Bazaar::ValidatePurchaseQuantity(0, true, 20);
+
+		TEST_ASSERT(!result.is_valid);
+		TEST_ASSERT(result.quantity == 0);
+	}
+
+	void RejectsNegativeEncodedQuantity()
+	{
+		auto result = Bazaar::ValidatePurchaseQuantity(0xFFFFFFFF, true, 20);
+
+		TEST_ASSERT(!result.is_valid);
+		TEST_ASSERT(result.quantity == 0);
+	}
+
+	void RejectsStackableWithoutListedCharges()
+	{
+		auto result = Bazaar::ValidatePurchaseQuantity(1, true, 0);
+
+		TEST_ASSERT(!result.is_valid);
+		TEST_ASSERT(result.quantity == 0);
+	}
+
+	void ClampsStackableQuantityToListedCharges()
+	{
+		auto result = Bazaar::ValidatePurchaseQuantity(50, true, 20);
+
+		TEST_ASSERT(result.is_valid);
+		TEST_ASSERT(result.quantity == 20);
+	}
+
+	void AcceptsPositiveNonStackableQuantity()
+	{
+		auto result = Bazaar::ValidatePurchaseQuantity(1, false, 0);
+
+		TEST_ASSERT(result.is_valid);
+		TEST_ASSERT(result.quantity == 1);
+	}
+
+	void RejectsNonStackableQuantityAboveOne()
+	{
+		auto result = Bazaar::ValidatePurchaseQuantity(2, false, 0);
+
+		TEST_ASSERT(!result.is_valid);
+		TEST_ASSERT(result.quantity == 0);
+	}
+};

--- a/tests/bazaar_test.h
+++ b/tests/bazaar_test.h
@@ -31,6 +31,9 @@ public:
 		TEST_ADD(BazaarTest::ClampsStackableQuantityToListedCharges);
 		TEST_ADD(BazaarTest::AcceptsPositiveNonStackableQuantity);
 		TEST_ADD(BazaarTest::RejectsNonStackableQuantityAboveOne);
+		TEST_ADD(BazaarTest::RejectsZeroListedPrice);
+		TEST_ADD(BazaarTest::RejectsMismatchedPrice);
+		TEST_ADD(BazaarTest::AcceptsMatchingListedPrice);
 	}
 
 	~BazaarTest()
@@ -84,5 +87,20 @@ private:
 
 		TEST_ASSERT(!result.is_valid);
 		TEST_ASSERT(result.quantity == 0);
+	}
+
+	void RejectsZeroListedPrice()
+	{
+		TEST_ASSERT(!Bazaar::ValidatePurchasePrice(0, 0));
+	}
+
+	void RejectsMismatchedPrice()
+	{
+		TEST_ASSERT(!Bazaar::ValidatePurchasePrice(1, 100));
+	}
+
+	void AcceptsMatchingListedPrice()
+	{
+		TEST_ASSERT(Bazaar::ValidatePurchasePrice(100, 100));
 	}
 };

--- a/tests/eq_limits_test.h
+++ b/tests/eq_limits_test.h
@@ -1,0 +1,67 @@
+/*	EQEMu: Everquest Server Emulator
+	Copyright (C) 2001-2013 EQEmu Development Team (http://eqemulator.net)
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; version 2 of the License.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY except by those people which sell it, which
+	are required to give you total support for your newly bought product;
+	without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+	A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program; if not, write to the Free Software
+	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+*/
+
+#pragma once
+
+#include "common/eq_limits.h"
+#include "cppunit/cpptest.h"
+
+class EqLimitsTest : public Test::Suite {
+public:
+	EqLimitsTest()
+	{
+		TEST_ADD(EqLimitsTest::BazaarMaxTransactionDefaultsWhenUnset);
+		TEST_ADD(EqLimitsTest::StaticLookupsUseSafeBazaarMaxTransaction);
+	}
+
+	~EqLimitsTest()
+	{
+	}
+
+private:
+	void BazaarMaxTransactionDefaultsWhenUnset()
+	{
+		EQ::constants::LookupEntry entry(
+			EQ::expansions::Expansion::EverQuest,
+			EQ::expansions::bitEverQuest,
+			EQ::expansions::maskEverQuest,
+			0,
+			0,
+			0,
+			0
+		);
+
+		TEST_ASSERT(entry.BazaarMaxTransaction == EQ::constants::BAZAAR_MAX_TRANSACTION_DEFAULT);
+	}
+
+	void StaticLookupsUseSafeBazaarMaxTransaction()
+	{
+		TEST_ASSERT(
+			EQ::constants::StaticLookup(EQ::versions::ClientVersion::Titanium)->BazaarMaxTransaction ==
+			EQ::constants::BAZAAR_MAX_TRANSACTION_DEFAULT
+		);
+		TEST_ASSERT(
+			EQ::constants::StaticLookup(EQ::versions::ClientVersion::UF)->BazaarMaxTransaction ==
+			EQ::constants::BAZAAR_MAX_TRANSACTION_DEFAULT
+		);
+		TEST_ASSERT(
+			EQ::constants::StaticLookup(EQ::versions::ClientVersion::RoF2)->BazaarMaxTransaction ==
+			EQ::constants::BAZAAR_MAX_TRANSACTION_DEFAULT
+		);
+	}
+};

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -20,6 +20,7 @@
 #include "tests/buyer_buy_lines_repository_test.h"
 #include "tests/crash_report_endpoint_test.h"
 #include "tests/data_verification_test.h"
+#include "tests/eq_limits_test.h"
 #include "tests/fixed_memory_test.h"
 #include "tests/fixed_memory_variable_test.h"
 #include "tests/expedition_schema_test.h"
@@ -63,6 +64,7 @@ int main()
 		tests.add(new hextoi_32_64_Test());
 		tests.add(new StringUtilTest());
 		tests.add(new DataVerificationTest());
+		tests.add(new EqLimitsTest());
 		tests.add(new SkillsUtilsTest());
 		tests.add(new TaskClassRestrictionTest());
 		tests.add(new TaskStateTest());

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -17,6 +17,7 @@
 */
 
 #include "tests/atobool_test.h"
+#include "tests/bazaar_test.h"
 #include "tests/buyer_buy_lines_repository_test.h"
 #include "tests/crash_report_endpoint_test.h"
 #include "tests/data_verification_test.h"
@@ -59,6 +60,7 @@ int main()
 		tests.add(new FixedMemoryVariableHashTest());
 		tests.add(new ExpeditionSchemaTest());
 		tests.add(new atoboolTest());
+		tests.add(new BazaarTest());
 		tests.add(new BuyerBuyLinesRepositoryTest());
 		tests.add(new CrashReportEndpointTest());
 		tests.add(new hextoi_32_64_Test());

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -2872,6 +2872,31 @@ void Client::BuyTraderItemFromBazaarWindow(const EQApplicationPacket *app)
 		return;
 	}
 
+	auto item = database.GetItem(trader_item.item_id);
+	if (!item) {
+		LogTrading("Unable to find item id [{}] item unique_id [{}] for bazaar purchase", trader_item.item_id, in->item_unique_id);
+		in->method     = BazaarByParcel;
+		in->sub_action = Failed;
+		TradeRequestFailed(app);
+		return;
+	}
+
+	auto quantity_validation = Bazaar::ValidatePurchaseQuantity(in->quantity, item->Stackable, trader_item.item_charges);
+	if (!quantity_validation.is_valid) {
+		LogTrading(
+			"Rejecting bazaar purchase with invalid quantity [{}] for item [{}]",
+			in->quantity,
+			item->Name
+		);
+		in->method     = BazaarByParcel;
+		in->sub_action = Failed;
+		TradeRequestFailed(app);
+		return;
+	}
+
+	uint32 quantity = quantity_validation.quantity;
+	in->quantity = quantity;
+
 	auto next_slot = FindNextFreeParcelSlot(CharacterID());
 	if (next_slot == INVALID_INDEX) {
 		LogTrading(
@@ -2888,9 +2913,6 @@ void Client::BuyTraderItemFromBazaarWindow(const EQApplicationPacket *app)
 	}
 
 	TraderRepository::UpdateActiveTransaction(database, trader_item.id, true);
-
-	uint32 quantity = in->quantity;
-	auto   item     = database.GetItem(trader_item.item_id);
 
 	int16 charges   = 1;
 	if (trader_item.item_charges > 0 || item->Stackable || item->MaxCharges > 0) {
@@ -2949,7 +2971,7 @@ void Client::BuyTraderItemFromBazaarWindow(const EQApplicationPacket *app)
 	out_data->trader_buy_struct.already_sold = in->already_sold;
 	out_data->trader_buy_struct.item_id      = item->ID;
 	out_data->trader_buy_struct.price        = in->price;
-	out_data->trader_buy_struct.quantity     = in->quantity;
+	out_data->trader_buy_struct.quantity     = quantity;
 	out_data->trader_buy_struct.sub_action   = in->sub_action;
 	out_data->trader_buy_struct.trader_id    = trader_item.character_id;
 	out_data->buyer_id                       = CharacterID();

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -41,9 +41,6 @@ class QueryServ;
 extern WorldServer worldserver;
 extern QueryServ* QServ;
 
-// The maximum amount of a single bazaar/barter transaction expressed in copper.
-// Equivalent to 2 Million plat
-constexpr auto MAX_TRANSACTION_VALUE = 2000000000;
 // ##########################################
 // Trade implementation
 // ##########################################
@@ -1413,7 +1410,7 @@ void Client::BuyTraderItem(const EQApplicationPacket *app)
 		return;
 	}
 
-	if (in->price * quantity <= 0) {
+	if (in->price == 0 || quantity == 0) {
         Message(Chat::Red, "Internal error. Aborting trade. Please report this to the ServerOP. Error code is 1");
         trader->Message(Chat::Red, "Internal error. Aborting trade. Please report this to the ServerOP. Error code is 1");
         LogError(
@@ -1430,18 +1427,18 @@ void Client::BuyTraderItem(const EQApplicationPacket *app)
         return;
     }
 
-	uint64 total_transaction_value = static_cast<uint64>(in->price) * static_cast<uint64>(quantity);
-	if (total_transaction_value > EQ::constants::StaticLookup(ClientVersion())->BazaarMaxTransaction) {
+	const uint64 max_transaction_value = EQ::constants::StaticLookup(ClientVersion())->BazaarMaxTransaction;
+	uint64 total_cost = static_cast<uint64>(in->price) * static_cast<uint64>(quantity);
+	if (total_cost > max_transaction_value) {
 		Message(
 			Chat::Red,
 			"That would exceed the single transaction limit of %u platinum.",
-			EQ::constants::StaticLookup(ClientVersion())->BazaarMaxTransaction / 1000
+			static_cast<uint32>(max_transaction_value / 1000)
 		);
 		TradeRequestFailed(app);
 		return;
 	}
 
-	uint64 total_cost = in->price * quantity;
 	if (!TakeMoneyFromPP(total_cost)) {
 		MessageString(Chat::Red, INSUFFICIENT_FUNDS);
         TradeRequestFailed(app);
@@ -2909,12 +2906,13 @@ void Client::BuyTraderItemFromBazaarWindow(const EQApplicationPacket *app)
 		in->item_unique_id
 	);
 
+	const uint64 max_transaction_value = EQ::constants::StaticLookup(ClientVersion())->BazaarMaxTransaction;
 	uint64 total_cost = static_cast<uint64>(in->price) * static_cast<uint64>(quantity);
-	if (total_cost > EQ::constants::StaticLookup(ClientVersion())->BazaarMaxTransaction) {
+	if (total_cost > max_transaction_value) {
 		Message(
 			Chat::Red,
 			"That would exceed the single transaction limit of %u platinum.",
-			EQ::constants::StaticLookup(ClientVersion())->BazaarMaxTransaction / 1000
+			static_cast<uint32>(max_transaction_value / 1000)
 		);
 		TraderRepository::UpdateActiveTransaction(database, trader_item.id, false);
 		TradeRequestFailed(app);

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -2897,6 +2897,22 @@ void Client::BuyTraderItemFromBazaarWindow(const EQApplicationPacket *app)
 	uint32 quantity = quantity_validation.quantity;
 	in->quantity = quantity;
 
+	if (!Bazaar::ValidatePurchasePrice(in->price, trader_item.item_cost)) {
+		LogTrading(
+			"Rejecting bazaar purchase with invalid price [{}] listed price [{}] for item [{}]",
+			in->price,
+			trader_item.item_cost,
+			item->Name
+		);
+		in->method     = BazaarByParcel;
+		in->sub_action = Failed;
+		TradeRequestFailed(app);
+		return;
+	}
+
+	uint32 price = trader_item.item_cost;
+	in->price = price;
+
 	auto next_slot = FindNextFreeParcelSlot(CharacterID());
 	if (next_slot == INVALID_INDEX) {
 		LogTrading(
@@ -2929,7 +2945,7 @@ void Client::BuyTraderItemFromBazaarWindow(const EQApplicationPacket *app)
 	);
 
 	const uint64 max_transaction_value = EQ::constants::StaticLookup(ClientVersion())->BazaarMaxTransaction;
-	uint64 total_cost = static_cast<uint64>(in->price) * static_cast<uint64>(quantity);
+	uint64 total_cost = static_cast<uint64>(price) * static_cast<uint64>(quantity);
 	if (total_cost > max_transaction_value) {
 		Message(
 			Chat::Red,
@@ -2970,7 +2986,7 @@ void Client::BuyTraderItemFromBazaarWindow(const EQApplicationPacket *app)
 	out_data->trader_buy_struct.method       = in->method;
 	out_data->trader_buy_struct.already_sold = in->already_sold;
 	out_data->trader_buy_struct.item_id      = item->ID;
-	out_data->trader_buy_struct.price        = in->price;
+	out_data->trader_buy_struct.price        = price;
 	out_data->trader_buy_struct.quantity     = quantity;
 	out_data->trader_buy_struct.sub_action   = in->sub_action;
 	out_data->trader_buy_struct.trader_id    = trader_item.character_id;


### PR DESCRIPTION
## Summary

Fixes two bazaar purchase safety issues:

- **Exploit Fix:** rejects crafted bazaar-window purchase packets with invalid quantities or client-supplied prices before money, parcel, active-transaction, or world-messaging side effects occur.
- **Overflow Fix:** normalizes bazaar transaction caps to a safe 2,000,000,000 copper default and performs `price * quantity` checks in 64-bit arithmetic before funds are moved.

## Root Cause

The bazaar-window parcel purchase path trusted client-supplied `quantity` and `price`. A crafted request could use invalid quantity values or a mismatched/zero price, allowing the flow to pass buyer-side checks and reach seller/world handling with inconsistent transaction state.

Separately, the client-version transaction cap lookup could produce unsafe caps: unset client versions inherited zero, while RoF2 advertised a multi-trillion-copper limit that the money and packet paths do not safely support. One direct bazaar buy path also used arithmetic that could wrap before money moved.

## Changes

- Adds centralized bazaar purchase quantity validation.
- Rejects zero, negative-encoded, invalid stack, and invalid non-stack quantities.
- Validates client price against the server-side trader listing price and uses the listed price downstream.
- Adds a shared `BAZAAR_MAX_TRANSACTION_DEFAULT` of 2,000,000,000 copper.
- Normalizes unset lookup caps and RoF2 to the safe default.
- Uses explicit 64-bit multiplication before bazaar transaction cap checks.
- Adds unit coverage for bazaar purchase validators and transaction cap lookup values.

## Testing
Confirmed Fixed
<img width="649" height="148" alt="image" src="https://github.com/user-attachments/assets/f5c577d5-b6db-4112-b44b-e9e607c97f0d" />

## Validation

- `cmake --build build-codex --target tests --config Debug -- /m`
- `build-codex\bin\Debug\tests.exe` passed 132/132 tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes bazaar money limits and purchase validation on live trading paths; incorrect validation could block legitimate buys or leave edge cases in stackable quantity handling.
> 
> **Overview**
> **Bazaar transaction limits** are normalized so RoF2 and unset client-version lookups use a shared **2,000,000,000 copper** cap instead of a zero or multi-trillion value that the money/packet paths cannot safely honor. Direct and parcel bazaar buys now compute **`price * quantity` in 64-bit** before comparing against that cap.
> 
> **Purchase validation** is centralized in **`Bazaar::ValidatePurchaseQuantity`** and **`ValidatePurchasePrice`**, and the parcel/bazaar-window path rejects bad client-supplied quantity/price and **overwrites** successful requests with listed charges and cost from the trader record before funds move or world messaging runs. The in-person trader buy path tightens zero-price/zero-qty checks and uses the same cap lookup pattern.
> 
> **Tests** cover the new validators and that static lookups expose the safe default cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fb72ce55c73b5bcbfe51ad4093f1b0fabf24d44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->