### PR TITLE
[Bazaar] Fix bazaar failed purchase response

### DIFF
--- a/common/bazaar.cpp
+++ b/common/bazaar.cpp
@@ -43,6 +43,11 @@ bool Bazaar::ValidatePurchasePrice(uint32 requested_price, uint32 listed_price)
 	return listed_price > 0 && requested_price == listed_price;
 }
 
+uint32 Bazaar::ResolvePurchaseFailureSubAction(uint32 sub_action)
+{
+	return sub_action == Success ? Failed : sub_action;
+}
+
 std::vector<BazaarSearchResultsFromDB_Struct>
 Bazaar::GetSearchResults(
 	Database &db,

--- a/common/bazaar.h
+++ b/common/bazaar.h
@@ -20,6 +20,8 @@ public:
 
 	static bool ValidatePurchasePrice(uint32 requested_price, uint32 listed_price);
 
+	static uint32 ResolvePurchaseFailureSubAction(uint32 sub_action);
+
 	static std::vector<BazaarSearchResultsFromDB_Struct>
 	GetSearchResults(Database &content_db, Database &db, BazaarSearchCriteria_Struct search, unsigned int char_zone_id, int char_zone_instance_id);
 

--- a/tests/bazaar_test.h
+++ b/tests/bazaar_test.h
@@ -34,6 +34,8 @@ public:
 		TEST_ADD(BazaarTest::RejectsZeroListedPrice);
 		TEST_ADD(BazaarTest::RejectsMismatchedPrice);
 		TEST_ADD(BazaarTest::AcceptsMatchingListedPrice);
+		TEST_ADD(BazaarTest::FailureSubActionRewritesSuccess);
+		TEST_ADD(BazaarTest::FailureSubActionPreservesSpecificFailure);
 	}
 
 	~BazaarTest()
@@ -102,5 +104,15 @@ private:
 	void AcceptsMatchingListedPrice()
 	{
 		TEST_ASSERT(Bazaar::ValidatePurchasePrice(100, 100));
+	}
+
+	void FailureSubActionRewritesSuccess()
+	{
+		TEST_ASSERT(Bazaar::ResolvePurchaseFailureSubAction(Success) == Failed);
+	}
+
+	void FailureSubActionPreservesSpecificFailure()
+	{
+		TEST_ASSERT(Bazaar::ResolvePurchaseFailureSubAction(TooManyParcels) == TooManyParcels);
 	}
 };

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -1431,10 +1431,11 @@ void Client::BuyTraderItem(const EQApplicationPacket *app)
 	const uint64 max_transaction_value = EQ::constants::StaticLookup(ClientVersion())->BazaarMaxTransaction;
 	uint64 total_cost = static_cast<uint64>(in->price) * static_cast<uint64>(quantity);
 	if (total_cost > max_transaction_value) {
+		const auto max_transaction_platinum = Strings::Commify(max_transaction_value / 1000);
 		Message(
 			Chat::Red,
-			"That would exceed the single transaction limit of %u platinum.",
-			static_cast<uint32>(max_transaction_value / 1000)
+			"That would exceed the single transaction limit of %s platinum.",
+			max_transaction_platinum.c_str()
 		);
 		TradeRequestFailed(app);
 		return;
@@ -2948,10 +2949,11 @@ void Client::BuyTraderItemFromBazaarWindow(const EQApplicationPacket *app)
 	const uint64 max_transaction_value = EQ::constants::StaticLookup(ClientVersion())->BazaarMaxTransaction;
 	uint64 total_cost = static_cast<uint64>(price) * static_cast<uint64>(quantity);
 	if (total_cost > max_transaction_value) {
+		const auto max_transaction_platinum = Strings::Commify(max_transaction_value / 1000);
 		Message(
 			Chat::Red,
-			"That would exceed the single transaction limit of %u platinum.",
-			static_cast<uint32>(max_transaction_value / 1000)
+			"That would exceed the single transaction limit of %s platinum.",
+			max_transaction_platinum.c_str()
 		);
 		TraderRepository::UpdateActiveTransaction(database, trader_item.id, false);
 		TradeRequestFailed(app);

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -1432,11 +1432,10 @@ void Client::BuyTraderItem(const EQApplicationPacket *app)
 	uint64 total_cost = static_cast<uint64>(in->price) * static_cast<uint64>(quantity);
 	if (total_cost > max_transaction_value) {
 		const auto max_transaction_amount = Strings::Money(max_transaction_value / 1000);
-		Message(
-			Chat::Red,
-			"That would exceed the single transaction limit of %s.",
-			max_transaction_amount.c_str()
-		);
+		Message(Chat::Red, fmt::format(
+			"That would exceed the single transaction limit of {}.",
+			max_transaction_amount
+		).c_str());
 		TradeRequestFailed(app);
 		return;
 	}
@@ -2950,11 +2949,10 @@ void Client::BuyTraderItemFromBazaarWindow(const EQApplicationPacket *app)
 	uint64 total_cost = static_cast<uint64>(price) * static_cast<uint64>(quantity);
 	if (total_cost > max_transaction_value) {
 		const auto max_transaction_amount = Strings::Money(max_transaction_value / 1000);
-		Message(
-			Chat::Red,
-			"That would exceed the single transaction limit of %s.",
-			max_transaction_amount.c_str()
-		);
+		Message(Chat::Red, fmt::format(
+			"That would exceed the single transaction limit of {}.",
+			max_transaction_amount
+		).c_str());
 		TraderRepository::UpdateActiveTransaction(database, trader_item.id, false);
 		TradeRequestFailed(app);
 		return;

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -1431,11 +1431,11 @@ void Client::BuyTraderItem(const EQApplicationPacket *app)
 	const uint64 max_transaction_value = EQ::constants::StaticLookup(ClientVersion())->BazaarMaxTransaction;
 	uint64 total_cost = static_cast<uint64>(in->price) * static_cast<uint64>(quantity);
 	if (total_cost > max_transaction_value) {
-		const auto max_transaction_platinum = Strings::Commify(max_transaction_value / 1000);
+		const auto max_transaction_amount = Strings::Money(max_transaction_value / 1000);
 		Message(
 			Chat::Red,
-			"That would exceed the single transaction limit of %s platinum.",
-			max_transaction_platinum.c_str()
+			"That would exceed the single transaction limit of %s.",
+			max_transaction_amount.c_str()
 		);
 		TradeRequestFailed(app);
 		return;
@@ -2949,11 +2949,11 @@ void Client::BuyTraderItemFromBazaarWindow(const EQApplicationPacket *app)
 	const uint64 max_transaction_value = EQ::constants::StaticLookup(ClientVersion())->BazaarMaxTransaction;
 	uint64 total_cost = static_cast<uint64>(price) * static_cast<uint64>(quantity);
 	if (total_cost > max_transaction_value) {
-		const auto max_transaction_platinum = Strings::Commify(max_transaction_value / 1000);
+		const auto max_transaction_amount = Strings::Money(max_transaction_value / 1000);
 		Message(
 			Chat::Red,
-			"That would exceed the single transaction limit of %s platinum.",
-			max_transaction_platinum.c_str()
+			"That would exceed the single transaction limit of %s.",
+			max_transaction_amount.c_str()
 		);
 		TraderRepository::UpdateActiveTransaction(database, trader_item.id, false);
 		TradeRequestFailed(app);

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -1328,6 +1328,7 @@ void Client::TradeRequestFailed(const EQApplicationPacket *app)
 	auto outtbs = (TraderBuy_Struct *) outapp->pBuffer;
 
 	memcpy(outtbs, tbs, app->size);
+	outtbs->sub_action   = Bazaar::ResolvePurchaseFailureSubAction(tbs->sub_action);
 	outtbs->already_sold = 0xFFFFFFFF;
 	outtbs->trader_id    = 0xFFFFFFFF;
 


### PR DESCRIPTION
# Description

Fixes bazaar failed purchase responses so rejected trader purchases do not echo a success sub-action back to the client.

The server-side transaction limit check already rejects over-limit purchases before moving money or items, but the failure packet copied the original client request and left `sub_action` as `Success`. RoF2 clients receive that field in the encoded trader-buy response, which can make the client display false purchase and money-spent messages after the red transaction-limit error.

This change normalizes failed bazaar purchase sub-actions by converting only `Success` to `Failed`, while preserving more specific failure reasons such as `TooManyParcels`.

Fixes: N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Reported Issue

Was buying an item that had a stack of 1000, I tried to buy all 1000. gave the error, but it took 5m plat from me, gave no items of course, and I had to zone to get my 5m plat back

<img width="642" height="113" alt="image" src="https://github.com/user-attachments/assets/c48bc950-5c53-4714-930f-93f6a1b22a43" />


## Testing

- Built Debug `tests` target with CMake/MSBuild.
- Ran `tests.exe`: 134 tests, 100% correct.
- Built Debug `zone` target with CMake/MSBuild.

Confirmed Fixed
<img width="618" height="102" alt="image" src="https://github.com/user-attachments/assets/315af03f-41da-4f13-a1a0-f31628699cb8" />





<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted client packet fix and message formatting in bazaar failure paths; covered by new unit tests with no auth or persistence changes.
> 
> **Overview**
> Fixes **RoF2 bazaar purchase failures** where the server rejected a trade but still sent `sub_action` as **Success** because `TradeRequestFailed` copied the client request unchanged. Failed responses now run **`Bazaar::ResolvePurchaseFailureSubAction`**, rewriting only `Success` to **`Failed`** while leaving specific codes (e.g. **`TooManyParcels`**, **`InsufficientFunds`**) intact.
> 
> Also formats the **single-transaction limit** chat error with **`Strings::Money`** instead of a raw platinum integer in both direct trader and parcel bazaar purchase paths. Unit tests cover the new helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e85e997c19f2409432362684d1cb4e597277903. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->