### PR TITLE
[Offline Trader] Fix offline trading boot cleanup

### DIFF
--- a/world/world_boot.cpp
+++ b/world/world_boot.cpp
@@ -290,11 +290,7 @@ bool WorldBoot::DatabaseLoadRoutines(int argc, char **argv)
 	database.ClearGuildOnlineStatus();
 	LogInfo("Clearing inventory snapshots");
 	database.ClearInvSnapshots();
-	LogInfo("Loading items");
-	LogInfo("Clearing trader table details");
-	database.ClearTraderDetails();
-	database.ClearBuyerDetails();
-	LogInfo("Clearing buyer table details");
+	database.ClearOfflineTradingState();
 
 	if (RuleB(Bots, Enabled)) {
 		LogInfo("Clearing [bot_pet_buffs] table of stale entries");
@@ -303,6 +299,7 @@ bool WorldBoot::DatabaseLoadRoutines(int argc, char **argv)
 		);
 	}
 
+	LogInfo("Loading items");
 	if (!content_db.LoadItems(hotfix_name)) {
 		LogError("Error: Could not load item data. But ignoring");
 	}


### PR DESCRIPTION
## What changed

World startup now uses `Database::ClearOfflineTradingState()` instead of independently clearing only trader and buyer table details.

## Why

The new offline trader/buyer reclaim flow persists active offline sessions in `offline_character_sessions`. World boot already cleared trader rows, buyer rows, and account offline flags, but it did not clear that session table. After a restart, stale session rows could cause unnecessary reclaim handling or temporary character-entry failure even though the corresponding trader/buyer rows had already been cleared.

## Impact

Startup cleanup now removes all offline trading session/control state consistently: trader rows, buyer rows, account offline flags, and offline session rows. Players will not inherit stale offline-session records after world boot.

This does **not** clear or depend on `character_offline_transactions`. Offline sale/purchase notices are stored separately by `character_id` and are still read and deleted only when the character enters zone and receives the notification.

## Validation

- `git diff --check HEAD~1..HEAD`

A full C++ build was not run for this one-line call-site change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single call-site swap at world startup with no auth or payment logic; main risk is incomplete cleanup if the new helper omits something the old calls covered.
> 
> **Overview**
> World boot startup now calls **`Database::ClearOfflineTradingState()`** instead of separately clearing trader and buyer table details with their own log lines.
> 
> That consolidates offline trading cleanup so **trader rows, buyer rows, account offline flags, and `offline_character_sessions`** are cleared together after a restart. Previously boot could leave stale session rows even when trader/buyer data was wiped, which could trigger bad reclaim behavior or brief character-entry issues.
> 
> **Loading items** is logged and run *after* this cleanup step (order change only; item load still happens in the same boot routine).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8277833b7a1e96ed5ddca28e5e1942dc7828809d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->