### PR TITLE
[Offline Trader] Track item IDs for offline transactions

### DIFF
--- a/common/bazaar.cpp
+++ b/common/bazaar.cpp
@@ -2,6 +2,7 @@
 
 #include "common/item_instance.h"
 #include "common/repositories/trader_repository.h"
+#include "common/strings.h"
 
 #include <limits>
 #include <memory>
@@ -41,6 +42,36 @@ Bazaar::PurchaseQuantityValidation Bazaar::ValidatePurchaseQuantity(
 bool Bazaar::ValidatePurchasePrice(uint32 requested_price, uint32 listed_price)
 {
 	return listed_price > 0 && requested_price == listed_price;
+}
+
+void Bazaar::RecordAuditTrail(
+	Database &db,
+	const std::string &seller,
+	const std::string &buyer,
+	uint32 item_id,
+	const std::string &item_name,
+	uint32 quantity,
+	uint64 total_cost,
+	int transaction_type
+)
+{
+	auto query = fmt::format(
+		"INSERT INTO `trader_audit` "
+		"(`time`, `seller`, `buyer`, `item_id`, `itemname`, `quantity`, `totalcost`, `trantype`) "
+		"VALUES (NOW(), '{}', '{}', {}, '{}', {}, {}, {})",
+		Strings::Escape(seller),
+		Strings::Escape(buyer),
+		item_id,
+		Strings::Escape(item_name),
+		quantity,
+		total_cost,
+		transaction_type
+	);
+
+	auto results = db.QueryDatabase(query);
+	if (!results.Success()) {
+		LogTrading("Audit write error: {} : {}", query, results.ErrorMessage());
+	}
 }
 
 std::vector<BazaarSearchResultsFromDB_Struct>

--- a/common/bazaar.h
+++ b/common/bazaar.h
@@ -20,6 +20,17 @@ public:
 
 	static bool ValidatePurchasePrice(uint32 requested_price, uint32 listed_price);
 
+	static void RecordAuditTrail(
+		Database &db,
+		const std::string &seller,
+		const std::string &buyer,
+		uint32 item_id,
+		const std::string &item_name,
+		uint32 quantity,
+		uint64 total_cost,
+		int transaction_type
+	);
+
 	static std::vector<BazaarSearchResultsFromDB_Struct>
 	GetSearchResults(Database &content_db, Database &db, BazaarSearchCriteria_Struct search, unsigned int char_zone_id, int char_zone_instance_id);
 

--- a/common/database.cpp
+++ b/common/database.cpp
@@ -2636,6 +2636,7 @@ static bool ValidateItemUniqueIdMigrationSchema(Database &db, bool verbose)
 		{"character_parcels_containers", "item_unique_id"},
 		{"inventory_snapshots", "item_unique_id"},
 		{"account", "offline"},
+		{"character_offline_transactions", "item_id"},
 	};
 
 	const std::vector<std::string> required_tables = {

--- a/common/database/database_update_manifest.h
+++ b/common/database/database_update_manifest.h
@@ -7353,12 +7353,14 @@ CREATE TABLE IF NOT EXISTS `character_offline_transactions` (
 	`id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
 	`character_id` INT(10) UNSIGNED NOT NULL DEFAULT '0',
 	`type` INT(10) UNSIGNED NULL DEFAULT '0',
+	`item_id` INT(10) UNSIGNED NOT NULL DEFAULT '0',
 	`item_name` VARCHAR(64) NULL DEFAULT NULL COLLATE 'latin1_swedish_ci',
 	`quantity` INT(11) NULL DEFAULT '0',
 	`price` BIGINT(20) UNSIGNED NULL DEFAULT '0',
 	`buyer_name` VARCHAR(64) NULL DEFAULT NULL COLLATE 'latin1_swedish_ci',
 	PRIMARY KEY (`id`) USING BTREE,
-	INDEX `idx_character_id` (`character_id`)
+	INDEX `idx_character_id` (`character_id`),
+	INDEX `idx_item_id` (`item_id`)
 ) COLLATE='latin1_swedish_ci' ENGINE=InnoDB;
 )",
 		.content_schema_update = false
@@ -7558,6 +7560,18 @@ SET dz.`min_level` = dzt.`min_level`,
 WHERE dz.`type` = 1
 	AND dz.`min_level` = 0
 	AND dz.`max_level` = 0;
+)"
+	},
+	ManifestEntry{
+		.version = 9350,
+		.description = "2026_06_20_character_offline_transactions_item_id.sql",
+		.check = "SHOW COLUMNS FROM `character_offline_transactions` LIKE 'item_id'",
+		.condition = "empty",
+		.match = "",
+		.sql = R"(
+ALTER TABLE `character_offline_transactions`
+	ADD COLUMN `item_id` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `type`,
+	ADD INDEX `idx_item_id` (`item_id`);
 )"
 	},
 // -- template; copy/paste this when you need to create a new entry

--- a/common/database/database_update_manifest.h
+++ b/common/database/database_update_manifest.h
@@ -7574,6 +7574,18 @@ ALTER TABLE `character_offline_transactions`
 	ADD INDEX `idx_item_id` (`item_id`);
 )"
 	},
+	ManifestEntry{
+		.version = 9351,
+		.description = "2026_06_20_trader_audit_item_id.sql",
+		.check = "SHOW COLUMNS FROM `trader_audit` LIKE 'item_id'",
+		.condition = "empty",
+		.match = "",
+		.sql = R"(
+ALTER TABLE `trader_audit`
+	ADD COLUMN `item_id` INT(10) UNSIGNED NOT NULL DEFAULT '0' AFTER `buyer`,
+	ADD INDEX `idx_trader_audit_item_id` (`item_id`);
+)"
+	},
 // -- template; copy/paste this when you need to create a new entry
 //	ManifestEntry{
 //		.version = 9228,

--- a/common/repositories/base/base_character_offline_transactions_repository.h
+++ b/common/repositories/base/base_character_offline_transactions_repository.h
@@ -22,6 +22,7 @@ public:
 		uint64_t    id;
 		uint32_t    character_id;
 		uint32_t    type;
+		uint32_t    item_id;
 		std::string item_name;
 		int32_t     quantity;
 		uint64_t    price;
@@ -39,6 +40,7 @@ public:
 			"id",
 			"character_id",
 			"type",
+			"item_id",
 			"item_name",
 			"quantity",
 			"price",
@@ -52,6 +54,7 @@ public:
 			"id",
 			"character_id",
 			"type",
+			"item_id",
 			"item_name",
 			"quantity",
 			"price",
@@ -99,6 +102,7 @@ public:
 		e.id           = 0;
 		e.character_id = 0;
 		e.type         = 0;
+		e.item_id      = 0;
 		e.item_name    = "";
 		e.quantity     = 0;
 		e.price        = 0;
@@ -142,10 +146,11 @@ public:
 			e.id           = row[0] ? strtoull(row[0], nullptr, 10) : 0;
 			e.character_id = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
 			e.type         = row[2] ? static_cast<uint32_t>(strtoul(row[2], nullptr, 10)) : 0;
-			e.item_name    = row[3] ? row[3] : "";
-			e.quantity     = row[4] ? static_cast<int32_t>(atoi(row[4])) : 0;
-			e.price        = row[5] ? strtoull(row[5], nullptr, 10) : 0;
-			e.buyer_name   = row[6] ? row[6] : "";
+			e.item_id      = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
+			e.item_name    = row[4] ? row[4] : "";
+			e.quantity     = row[5] ? static_cast<int32_t>(atoi(row[5])) : 0;
+			e.price        = row[6] ? strtoull(row[6], nullptr, 10) : 0;
+			e.buyer_name   = row[7] ? row[7] : "";
 
 			return e;
 		}
@@ -181,10 +186,11 @@ public:
 
 		v.push_back(columns[1] + " = " + std::to_string(e.character_id));
 		v.push_back(columns[2] + " = " + std::to_string(e.type));
-		v.push_back(columns[3] + " = '" + Strings::Escape(e.item_name) + "'");
-		v.push_back(columns[4] + " = " + std::to_string(e.quantity));
-		v.push_back(columns[5] + " = " + std::to_string(e.price));
-		v.push_back(columns[6] + " = '" + Strings::Escape(e.buyer_name) + "'");
+		v.push_back(columns[3] + " = " + std::to_string(e.item_id));
+		v.push_back(columns[4] + " = '" + Strings::Escape(e.item_name) + "'");
+		v.push_back(columns[5] + " = " + std::to_string(e.quantity));
+		v.push_back(columns[6] + " = " + std::to_string(e.price));
+		v.push_back(columns[7] + " = '" + Strings::Escape(e.buyer_name) + "'");
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -209,6 +215,7 @@ public:
 		v.push_back(std::to_string(e.id));
 		v.push_back(std::to_string(e.character_id));
 		v.push_back(std::to_string(e.type));
+		v.push_back(std::to_string(e.item_id));
 		v.push_back("'" + Strings::Escape(e.item_name) + "'");
 		v.push_back(std::to_string(e.quantity));
 		v.push_back(std::to_string(e.price));
@@ -245,6 +252,7 @@ public:
 			v.push_back(std::to_string(e.id));
 			v.push_back(std::to_string(e.character_id));
 			v.push_back(std::to_string(e.type));
+			v.push_back(std::to_string(e.item_id));
 			v.push_back("'" + Strings::Escape(e.item_name) + "'");
 			v.push_back(std::to_string(e.quantity));
 			v.push_back(std::to_string(e.price));
@@ -285,10 +293,11 @@ public:
 			e.id           = row[0] ? strtoull(row[0], nullptr, 10) : 0;
 			e.character_id = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
 			e.type         = row[2] ? static_cast<uint32_t>(strtoul(row[2], nullptr, 10)) : 0;
-			e.item_name    = row[3] ? row[3] : "";
-			e.quantity     = row[4] ? static_cast<int32_t>(atoi(row[4])) : 0;
-			e.price        = row[5] ? strtoull(row[5], nullptr, 10) : 0;
-			e.buyer_name   = row[6] ? row[6] : "";
+			e.item_id      = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
+			e.item_name    = row[4] ? row[4] : "";
+			e.quantity     = row[5] ? static_cast<int32_t>(atoi(row[5])) : 0;
+			e.price        = row[6] ? strtoull(row[6], nullptr, 10) : 0;
+			e.buyer_name   = row[7] ? row[7] : "";
 
 			all_entries.push_back(e);
 		}
@@ -316,10 +325,11 @@ public:
 			e.id           = row[0] ? strtoull(row[0], nullptr, 10) : 0;
 			e.character_id = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
 			e.type         = row[2] ? static_cast<uint32_t>(strtoul(row[2], nullptr, 10)) : 0;
-			e.item_name    = row[3] ? row[3] : "";
-			e.quantity     = row[4] ? static_cast<int32_t>(atoi(row[4])) : 0;
-			e.price        = row[5] ? strtoull(row[5], nullptr, 10) : 0;
-			e.buyer_name   = row[6] ? row[6] : "";
+			e.item_id      = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
+			e.item_name    = row[4] ? row[4] : "";
+			e.quantity     = row[5] ? static_cast<int32_t>(atoi(row[5])) : 0;
+			e.price        = row[6] ? strtoull(row[6], nullptr, 10) : 0;
+			e.buyer_name   = row[7] ? row[7] : "";
 
 			all_entries.push_back(e);
 		}
@@ -397,6 +407,7 @@ public:
 		v.push_back(std::to_string(e.id));
 		v.push_back(std::to_string(e.character_id));
 		v.push_back(std::to_string(e.type));
+		v.push_back(std::to_string(e.item_id));
 		v.push_back("'" + Strings::Escape(e.item_name) + "'");
 		v.push_back(std::to_string(e.quantity));
 		v.push_back(std::to_string(e.price));
@@ -426,6 +437,7 @@ public:
 			v.push_back(std::to_string(e.id));
 			v.push_back(std::to_string(e.character_id));
 			v.push_back(std::to_string(e.type));
+			v.push_back(std::to_string(e.item_id));
 			v.push_back("'" + Strings::Escape(e.item_name) + "'");
 			v.push_back(std::to_string(e.quantity));
 			v.push_back(std::to_string(e.price));

--- a/common/repositories/character_offline_transactions_repository.h
+++ b/common/repositories/character_offline_transactions_repository.h
@@ -5,12 +5,12 @@
 #include "../strings.h"
 #include "base/base_character_offline_transactions_repository.h"
 
+constexpr int TRADER_TRANSACTION = 1;
+constexpr int BUYER_TRANSACTION  = 2;
+constexpr int BARTER_TRANSACTION = 3;
+
 class CharacterOfflineTransactionsRepository: public BaseCharacterOfflineTransactionsRepository {
 public:
-
-#define TRADER_TRANSACTION 1
-#define BUYER_TRANSACTION  2
-
     /**
      * This file was auto generated and can be modified and extended upon
      *

--- a/common/repositories/trader_audit_repository.h
+++ b/common/repositories/trader_audit_repository.h
@@ -9,6 +9,7 @@ public:
 		std::string time;
 		std::string seller;
 		std::string buyer;
+		uint32_t    item_id;
 		std::string itemname;
 		int         quantity;
 		int         totalcost;
@@ -26,6 +27,7 @@ public:
 			"time",
 			"seller",
 			"buyer",
+			"item_id",
 			"itemname",
 			"quantity",
 			"totalcost",
@@ -83,6 +85,7 @@ public:
 		entry.time      = '0000-00-00 00:00:00';
 		entry.seller    = "";
 		entry.buyer     = "";
+		entry.item_id   = 0;
 		entry.itemname  = "";
 		entry.quantity  = 0;
 		entry.totalcost = 0;
@@ -124,10 +127,11 @@ public:
 			entry.time      = row[0];
 			entry.seller    = row[1];
 			entry.buyer     = row[2];
-			entry.itemname  = row[3];
-			entry.quantity  = atoi(row[4]);
-			entry.totalcost = atoi(row[5]);
-			entry.trantype  = atoi(row[6]);
+			entry.item_id   = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
+			entry.itemname  = row[4];
+			entry.quantity  = atoi(row[5]);
+			entry.totalcost = atoi(row[6]);
+			entry.trantype  = atoi(row[7]);
 
 			return entry;
 		}
@@ -162,10 +166,11 @@ public:
 		update_values.push_back(columns[0] + " = '" + Strings::Escape(trader_audit_entry.time) + "'");
 		update_values.push_back(columns[1] + " = '" + Strings::Escape(trader_audit_entry.seller) + "'");
 		update_values.push_back(columns[2] + " = '" + Strings::Escape(trader_audit_entry.buyer) + "'");
-		update_values.push_back(columns[3] + " = '" + Strings::Escape(trader_audit_entry.itemname) + "'");
-		update_values.push_back(columns[4] + " = " + std::to_string(trader_audit_entry.quantity));
-		update_values.push_back(columns[5] + " = " + std::to_string(trader_audit_entry.totalcost));
-		update_values.push_back(columns[6] + " = " + std::to_string(trader_audit_entry.trantype));
+		update_values.push_back(columns[3] + " = " + std::to_string(trader_audit_entry.item_id));
+		update_values.push_back(columns[4] + " = '" + Strings::Escape(trader_audit_entry.itemname) + "'");
+		update_values.push_back(columns[5] + " = " + std::to_string(trader_audit_entry.quantity));
+		update_values.push_back(columns[6] + " = " + std::to_string(trader_audit_entry.totalcost));
+		update_values.push_back(columns[7] + " = " + std::to_string(trader_audit_entry.trantype));
 
 		auto results = database.QueryDatabase(
 			fmt::format(
@@ -189,6 +194,7 @@ public:
 		insert_values.push_back("'" + Strings::Escape(trader_audit_entry.time) + "'");
 		insert_values.push_back("'" + Strings::Escape(trader_audit_entry.seller) + "'");
 		insert_values.push_back("'" + Strings::Escape(trader_audit_entry.buyer) + "'");
+		insert_values.push_back(std::to_string(trader_audit_entry.item_id));
 		insert_values.push_back("'" + Strings::Escape(trader_audit_entry.itemname) + "'");
 		insert_values.push_back(std::to_string(trader_audit_entry.quantity));
 		insert_values.push_back(std::to_string(trader_audit_entry.totalcost));
@@ -224,6 +230,7 @@ public:
 			insert_values.push_back("'" + Strings::Escape(trader_audit_entry.time) + "'");
 			insert_values.push_back("'" + Strings::Escape(trader_audit_entry.seller) + "'");
 			insert_values.push_back("'" + Strings::Escape(trader_audit_entry.buyer) + "'");
+			insert_values.push_back(std::to_string(trader_audit_entry.item_id));
 			insert_values.push_back("'" + Strings::Escape(trader_audit_entry.itemname) + "'");
 			insert_values.push_back(std::to_string(trader_audit_entry.quantity));
 			insert_values.push_back(std::to_string(trader_audit_entry.totalcost));
@@ -264,10 +271,11 @@ public:
 			entry.time      = row[0];
 			entry.seller    = row[1];
 			entry.buyer     = row[2];
-			entry.itemname  = row[3];
-			entry.quantity  = atoi(row[4]);
-			entry.totalcost = atoi(row[5]);
-			entry.trantype  = atoi(row[6]);
+			entry.item_id   = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
+			entry.itemname  = row[4];
+			entry.quantity  = atoi(row[5]);
+			entry.totalcost = atoi(row[6]);
+			entry.trantype  = atoi(row[7]);
 
 			all_entries.push_back(entry);
 		}

--- a/utils/sql/svn/196_trader.sql
+++ b/utils/sql/svn/196_trader.sql
@@ -14,9 +14,11 @@ CREATE TABLE `trader_audit` (
   `time` datetime NOT NULL,
   `seller` varchar(64) NOT NULL,
   `buyer` varchar(64) NOT NULL,
+  `item_id` int(10) unsigned NOT NULL default '0',
   `itemname` varchar(64) NOT NULL,
   `quantity` int(11) NOT NULL,
-  `totalcost` int(11) NOT NULL
+  `totalcost` int(11) NOT NULL,
+  KEY `idx_trader_audit_item_id` (`item_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
 UPDATE doors set opentype=155 where opentype=154 and zone='bazaar';

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -842,8 +842,15 @@ void Client::CompleteConnect()
 		);
 	}
 
+	const auto offline_buyer_transaction_filter = fmt::format(
+		"`character_id` = {} AND `type` IN ({}, {})",
+		CharacterID(),
+		BUYER_TRANSACTION,
+		BARTER_TRANSACTION
+	);
+
 	auto offline_transactions_buyer = CharacterOfflineTransactionsRepository::GetWhere(
-		database, fmt::format("`character_id` = {} AND `type` = {}", CharacterID(), BUYER_TRANSACTION)
+		database, offline_buyer_transaction_filter
 	);
 	if (offline_transactions_buyer.size() > 0) {
 		Message(Chat::Yellow, "You bought the following items while in offline buyer mode:");
@@ -862,7 +869,7 @@ void Client::CompleteConnect()
 		}
 
 		CharacterOfflineTransactionsRepository::DeleteWhere(
-			database, fmt::format("`character_id` = {} AND `type` = {}", CharacterID(), BUYER_TRANSACTION)
+			database, offline_buyer_transaction_filter
 		);
 	}
 

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -818,8 +818,14 @@ void Client::CompleteConnect()
 		}
 	}
 
+	const auto offline_trader_transaction_filter = fmt::format(
+		"`character_id` = {} AND `type` = {}",
+		CharacterID(),
+		TRADER_TRANSACTION
+	);
+
 	auto offline_transactions_trader = CharacterOfflineTransactionsRepository::GetWhere(
-		database, fmt::format("`character_id` = {} AND `type` = {}", CharacterID(), TRADER_TRANSACTION)
+		database, offline_trader_transaction_filter
 	);
 	if (offline_transactions_trader.size() > 0) {
 		Message(Chat::Yellow, "You sold the following items while in offline trader mode:");
@@ -838,7 +844,7 @@ void Client::CompleteConnect()
 		}
 
 		CharacterOfflineTransactionsRepository::DeleteWhere(
-			database, fmt::format("`character_id` = '{}' AND `type` = '{}'", CharacterID(), TRADER_TRANSACTION)
+			database, offline_trader_transaction_filter
 		);
 	}
 

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -1493,6 +1493,19 @@ void Client::BuyTraderItem(const EQApplicationPacket *app)
 		buy_inst->GetUniqueID()
 	);
 
+	if (RuleB(Bazaar, AuditTrail)) {
+		Bazaar::RecordAuditTrail(
+			database,
+			trader->GetCleanName(),
+			GetCleanName(),
+			buy_inst->GetID(),
+			buy_inst->GetItem()->Name,
+			quantity,
+			total_cost,
+			0
+		);
+	}
+
 	if (merchant_quantity > quantity) {
 		std::unique_ptr<EQ::ItemInstance> vendor_inst(buy_inst ? buy_inst->Clone() : nullptr);
 		vendor_inst->SetMerchantCount(merchant_quantity - quantity);
@@ -2040,6 +2053,19 @@ void Client::SellToBuyer(const EQApplicationPacket *app)
 				uint64 total_cost = (uint64) sell_line.item_cost * (uint64) sell_line.seller_quantity;
 				AddMoneyToPP(total_cost, false);
 				buyer->TakeMoneyFromPP(total_cost, false);
+
+				if (RuleB(Bazaar, AuditTrail)) {
+					Bazaar::RecordAuditTrail(
+						database,
+						GetCleanName(),
+						buyer->GetCleanName(),
+						sell_line.item_id,
+						sell_line.item_name,
+						sell_line.seller_quantity,
+						total_cost,
+						1
+					);
+				}
 
 				if (PlayerEventLogs::Instance()->IsEventEnabled(PlayerEvent::BARTER_TRANSACTION)) {
 					PlayerEvent::BarterTransaction e{};

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -3007,19 +3007,6 @@ void Client::BuyTraderItemFromBazaarWindow(const EQApplicationPacket *app)
 		item->MaxCharges > 0 ? fmt::format(" with charges of [{}]", charges) : std::string("")
 	);
 
-	if (RuleB(Bazaar, AuditTrail)) {
-		Bazaar::RecordAuditTrail(
-			database,
-			in->seller_name,
-			GetCleanName(),
-			item->ID,
-			in->item_name,
-			quantity,
-			total_cost,
-			0
-		);
-	}
-
 	auto out_server = std::make_unique<ServerPacket>(ServerOP_BazaarPurchase, sizeof(BazaarPurchaseMessaging_Struct));
 	auto out_data   = reinterpret_cast<BazaarPurchaseMessaging_Struct *>(out_server->pBuffer);
 

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -1570,6 +1570,7 @@ void Client::BuyTraderItem(const EQApplicationPacket *app)
 		if (trader->IsOffline()) {
 			auto e         = CharacterOfflineTransactionsRepository::NewEntity();
 			e.character_id = trader->CharacterID();
+			e.item_id      = buy_inst->GetID();
 			e.item_name    = buy_inst->GetItem()->Name;
 			e.price        = total_cost;
 			e.quantity     = quantity;
@@ -2059,6 +2060,7 @@ void Client::SellToBuyer(const EQApplicationPacket *app)
 				if (buyer->IsOffline()) {
 					auto e         = CharacterOfflineTransactionsRepository::NewEntity();
 					e.character_id = buyer->CharacterID();
+					e.item_id      = sell_line.item_id;
 					e.item_name    = sell_line.item_name;
 					e.price        = total_cost;
 					e.quantity     = sell_line.seller_quantity;

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -3007,6 +3007,19 @@ void Client::BuyTraderItemFromBazaarWindow(const EQApplicationPacket *app)
 		item->MaxCharges > 0 ? fmt::format(" with charges of [{}]", charges) : std::string("")
 	);
 
+	if (RuleB(Bazaar, AuditTrail)) {
+		Bazaar::RecordAuditTrail(
+			database,
+			in->seller_name,
+			GetCleanName(),
+			item->ID,
+			in->item_name,
+			quantity,
+			total_cost,
+			0
+		);
+	}
+
 	auto out_server = std::make_unique<ServerPacket>(ServerOP_BazaarPurchase, sizeof(BazaarPurchaseMessaging_Struct));
 	auto out_data   = reinterpret_cast<BazaarPurchaseMessaging_Struct *>(out_server->pBuffer);
 

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -2091,7 +2091,7 @@ void Client::SellToBuyer(const EQApplicationPacket *app)
 					e.item_name    = sell_line.item_name;
 					e.price        = total_cost;
 					e.quantity     = sell_line.seller_quantity;
-					e.type         = BUYER_TRANSACTION;
+					e.type         = BARTER_TRANSACTION;
 					e.buyer_name   = GetCleanName();
 
 					CharacterOfflineTransactionsRepository::InsertOne(database, e);

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -3897,19 +3897,6 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 					memcpy(data, &in->trader_buy_struct, sizeof(TraderBuy_Struct));
 					trader_pc->QueuePacket(&outapp);
 
-					if (RuleB(Bazaar, AuditTrail)) {
-						Bazaar::RecordAuditTrail(
-							database,
-							trader_pc->GetCleanName(),
-							in->trader_buy_struct.buyer_name,
-							item->GetID(),
-							in->trader_buy_struct.item_name,
-							in->item_quantity,
-							total_cost,
-							0
-						);
-					}
-
 					if (item && PlayerEventLogs::Instance()->IsEventEnabled(PlayerEvent::TRADER_SELL)) {
 						auto e = PlayerEvent::TraderSellEvent{
 							.item_id              = item->GetID(),

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -3921,6 +3921,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 					if (trader_pc->IsOffline()) {
 						auto e         = CharacterOfflineTransactionsRepository::NewEntity();
 						e.character_id = trader_pc->CharacterID();
+						e.item_id      = item->GetID();
 						e.item_name    = in->trader_buy_struct.item_name;
 						e.price        = in->trader_buy_struct.price * in->trader_buy_struct.quantity;
 						e.quantity     = in->trader_buy_struct.quantity;
@@ -4327,6 +4328,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 					if (buyer->IsOffline()) {
 						auto e         = CharacterOfflineTransactionsRepository::NewEntity();
 						e.character_id = buyer->CharacterID();
+						e.item_id      = sell_line.item_id;
 						e.item_name    = sell_line.item_name;
 						e.price        = (uint64) sell_line.item_cost * (uint64) in->seller_quantity;
 						e.quantity     = sell_line.seller_quantity;

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -18,6 +18,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
 #include "worldserver.h"
 
+#include "common/bazaar.h"
 #include "common/eq_packet_structs.h"
 #include "common/events/player_event_logs.h"
 #include "common/misc_functions.h"
@@ -3896,6 +3897,19 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 					memcpy(data, &in->trader_buy_struct, sizeof(TraderBuy_Struct));
 					trader_pc->QueuePacket(&outapp);
 
+					if (RuleB(Bazaar, AuditTrail)) {
+						Bazaar::RecordAuditTrail(
+							database,
+							trader_pc->GetCleanName(),
+							in->trader_buy_struct.buyer_name,
+							item->GetID(),
+							in->trader_buy_struct.item_name,
+							in->item_quantity,
+							total_cost,
+							0
+						);
+					}
+
 					if (item && PlayerEventLogs::Instance()->IsEventEnabled(PlayerEvent::TRADER_SELL)) {
 						auto e = PlayerEvent::TraderSellEvent{
 							.item_id              = item->GetID(),
@@ -4379,6 +4393,19 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 						Barter_Success,
 						Barter_Success
 					);
+
+					if (RuleB(Bazaar, AuditTrail)) {
+						Bazaar::RecordAuditTrail(
+							database,
+							seller->GetCleanName(),
+							sell_line.buyer_name,
+							sell_line.item_id,
+							sell_line.item_name,
+							sell_line.seller_quantity,
+							total_cost,
+							1
+						);
+					}
 
 					if (PlayerEventLogs::Instance()->IsEventEnabled(PlayerEvent::BARTER_TRANSACTION)) {
 						PlayerEvent::BarterTransaction e{};

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -3890,6 +3890,19 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 
 					trader_pc->AddMoneyToPP(total_cost,	true);
 
+					if (RuleB(Bazaar, AuditTrail)) {
+						Bazaar::RecordAuditTrail(
+							database,
+							trader_pc->GetCleanName(),
+							in->trader_buy_struct.buyer_name,
+							item->GetID(),
+							in->trader_buy_struct.item_name,
+							in->item_quantity,
+							total_cost,
+							0
+						);
+					}
+
 					//Update the trader to indicate the sale has completed
 					EQApplicationPacket outapp(OP_Trader, sizeof(TraderBuy_Struct));
 					auto                data = reinterpret_cast<TraderBuy_Struct *>(outapp.pBuffer);

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -3923,7 +3923,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 						e.character_id = trader_pc->CharacterID();
 						e.item_id      = item->GetID();
 						e.item_name    = in->trader_buy_struct.item_name;
-						e.price        = in->trader_buy_struct.price * in->trader_buy_struct.quantity;
+						e.price        = total_cost;
 						e.quantity     = in->trader_buy_struct.quantity;
 						e.type         = TRADER_TRANSACTION;
 						e.buyer_name   = in->trader_buy_struct.buyer_name;

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -4333,7 +4333,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 						e.item_name    = sell_line.item_name;
 						e.price        = (uint64) sell_line.item_cost * (uint64) in->seller_quantity;
 						e.quantity     = sell_line.seller_quantity;
-						e.type         = BUYER_TRANSACTION;
+						e.type         = BARTER_TRANSACTION;
 						e.buyer_name   = sell_line.seller_name;
 
 						CharacterOfflineTransactionsRepository::InsertOne(database, e);


### PR DESCRIPTION
## What changed

Adds `item_id` to both `character_offline_transactions` and `trader_audit` so offline bazaar/barter transaction history and trader audit data can identify items by ID in addition to name.

The active offline transaction insert paths now populate `item_id` for:

- offline trader sales
- offline buyer/barter transactions
- world-mediated bazaar purchases
- world-mediated barter transactions

`trader_audit` now also writes `item_id` through a shared `Bazaar::RecordAuditTrail` helper when `Bazaar:AuditTrail` is enabled, covering direct trader purchases, confirmed worldserver bazaar-window purchase success, and barter success paths without early or duplicate bazaar-window audit rows.

The database manifest includes migrations for existing installs, and new installs create the affected audit/history tables with `item_id` indexed. The bazaar item unique ID schema validator also checks for `character_offline_transactions.item_id`.

## Why

Offline transaction history previously stored only `item_name`. Item names are not globally unique across item eras, so external audit/history consumers could resolve a transaction to the wrong item when joining or looking up by name.

## Validation

- `git diff --check`
- `cmake --build build-codex --target zone --config RelWithDebInfo -- /m`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live trading/audit DB writes and changes offline barter transaction type classification; migrations must run before servers rely on the new column.
> 
> **Overview**
> Adds **`item_id`** to **`character_offline_transactions`** and **`trader_audit`**, with manifest migrations (including fresh-install DDL), repository mapping, and a schema preflight check for **`character_offline_transactions.item_id`**.
> 
> Offline bazaar/barter persistence now **writes `item_id`** on trader sales, barter/buyer paths, and worldserver-mediated purchases. When **`Bazaar:AuditTrail`** is on, **`Bazaar::RecordAuditTrail`** inserts **`trader_audit`** rows (including **`item_id`**) from zone trader buys, barter success, and confirmed worldserver bazaar purchases.
> 
> Offline **barter** rows use **`BARTER_TRANSACTION`** instead of **`BUYER_TRANSACTION`**, and login replay loads/clears **buyer + barter** types together. Worldserver offline trader records use **`total_cost`** for stored price.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3422d78cbd8c234e941f0d4ea22568adb5c6be82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->