### PR TITLE
[Buyer System] Filter buyer item search by discovered items

### DIFF
--- a/common/repositories/discovered_items_repository.h
+++ b/common/repositories/discovered_items_repository.h
@@ -80,6 +80,7 @@ public:
 		);
 
 		if (!results.Success()) {
+			LogWarning("Failed to load discovered item IDs: {}", results.ErrorMessage());
 			return item_ids;
 		}
 

--- a/common/repositories/discovered_items_repository.h
+++ b/common/repositories/discovered_items_repository.h
@@ -5,6 +5,8 @@
 #include "common/database.h"
 #include "common/strings.h"
 
+#include <unordered_set>
+
 class DiscoveredItemsRepository: public BaseDiscoveredItemsRepository {
 public:
 
@@ -63,6 +65,33 @@ public:
 		);
 
 		return results.Success() && results.RowsAffected() > 0;
+	}
+
+	static std::unordered_set<uint32_t> GetAllItemIDs(Database& db)
+	{
+		std::unordered_set<uint32_t> item_ids;
+
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"SELECT `{}` FROM {}",
+				PrimaryKey(),
+				TableName()
+			)
+		);
+
+		if (!results.Success()) {
+			return item_ids;
+		}
+
+		item_ids.reserve(results.RowCount());
+
+		for (auto row = results.begin(); row != results.end(); ++row) {
+			if (row[0]) {
+				item_ids.insert(static_cast<uint32_t>(strtoul(row[0], nullptr, 10)));
+			}
+		}
+
+		return item_ids;
 	}
 
 };

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -2445,6 +2445,11 @@ void Client::BuyerItemSearch(const EQApplicationPacket *app)
 	std::unordered_set<uint32_t> discovered_item_ids;
 	if (filter_discovered_items) {
 		discovered_item_ids = DiscoveredItemsRepository::GetAllItemIDs(database);
+		for (const auto &[_, inst] : GetInv().GetPersonal()) {
+			if (inst && inst->GetItem()) {
+				discovered_item_ids.insert(inst->GetID());
+			}
+		}
 	}
 
 	while ((item = database.IterateItems(&it)) && bisr.results.size() < RuleI(Bazaar, MaxBuyerInventorySearchResults)) {

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -26,6 +26,7 @@
 #include "common/repositories/buyer_buy_lines_repository.h"
 #include "common/repositories/buyer_repository.h"
 #include "common/repositories/character_offline_transactions_repository.h"
+#include "common/repositories/discovered_items_repository.h"
 #include "common/repositories/trader_repository.h"
 #include "common/rulesys.h"
 #include "common/strings.h"
@@ -35,6 +36,7 @@
 #include "zone/string_ids.h"
 #include "zone/worldserver.h"
 #include <numeric>
+#include <unordered_set>
 
 class QueryServ;
 
@@ -2437,15 +2439,26 @@ void Client::BuyerItemSearch(const EQApplicationPacket *app)
 	uint32             it    = 0;
 
 	BuyerItemSearchResults_Struct bisr{};
+	const std::string             search_string = Strings::ToLower(bis->search_string);
+	const bool                    filter_discovered_items = RuleB(Character, EnableDiscoveredItems);
+
+	std::unordered_set<uint32_t> discovered_item_ids;
+	if (filter_discovered_items) {
+		discovered_item_ids = DiscoveredItemsRepository::GetAllItemIDs(database);
+	}
 
 	while ((item = database.IterateItems(&it)) && bisr.results.size() < RuleI(Bazaar, MaxBuyerInventorySearchResults)) {
 		if (!item->NoDrop) {
 			continue;
 		}
 
+		if (filter_discovered_items && !discovered_item_ids.contains(item->ID)) {
+			continue;
+		}
+
 		auto item_name_match = std::strstr(
 			Strings::ToLower(item->Name).c_str(),
-			Strings::ToLower(bis->search_string).c_str()
+			search_string.c_str()
 		);
 
 		if (item_name_match) {

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -2445,11 +2445,6 @@ void Client::BuyerItemSearch(const EQApplicationPacket *app)
 	std::unordered_set<uint32_t> discovered_item_ids;
 	if (filter_discovered_items) {
 		discovered_item_ids = DiscoveredItemsRepository::GetAllItemIDs(database);
-		for (const auto &[_, inst] : GetInv().GetPersonal()) {
-			if (inst && inst->GetItem()) {
-				discovered_item_ids.insert(inst->GetID());
-			}
-		}
 	}
 
 	while ((item = database.IterateItems(&it)) && bisr.results.size() < RuleI(Bazaar, MaxBuyerInventorySearchResults)) {


### PR DESCRIPTION
## What changed

Barter Buyer item search now filters item-name search results against the discovered item table when discovered item tracking is enabled.

A lightweight repository helper now loads discovered item IDs once for the search, and `Client::BuyerItemSearch` skips undiscovered item IDs before adding results to the response packet.

## Why

The Barter Buyer window previously iterated the full item database and returned matching NoDrop items regardless of whether those items had been discovered. That could expose undiscovered database items through buyer search.

## Impact

Players using the Barter Buyer item search will only see discovered items on servers with `Character:EnableDiscoveredItems` enabled. Servers with discovered item tracking disabled keep the existing unrestricted search behavior because discovery state is not maintained in that mode.

## Testing
Validated the buyer window is filtering out undiscovered items now.
<img width="717" height="477" alt="image" src="https://github.com/user-attachments/assets/40b692c1-6868-4c42-bccf-049dd3b4cea3" />


## Validation

- `git diff --check`
- `cmake --build build-codex --target zone --config RelWithDebInfo -j 4`
- `cmake --build build-codex --target tests --config RelWithDebInfo -j 4`
- `build-codex\bin\RelWithDebInfo\tests.exe` - 134 tests, 100% correct, exit code 0


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what players see in buyer search when discovery is enabled; a failed ID load yields an empty discovered set and would filter out all search hits until the query succeeds.
> 
> **Overview**
> When **`Character:EnableDiscoveredItems`** is on, Barter Buyer **item name search** no longer returns every matching NoDrop item from the item DB. It loads discovered item IDs once via new **`DiscoveredItemsRepository::GetAllItemIDs`** and skips IDs not in that set before building search results.
> 
> Servers with discovery tracking disabled keep the previous behavior (no DB load, no extra filter). Search string lowercasing is also done once per request instead of inside the loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2913193c1ec33f845d573f080639d4033d9874d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->