### PR TITLE
[Bazaar Logging] Fix buyer audit zero quantity sales

### DIFF
--- a/common/bazaar.cpp
+++ b/common/bazaar.cpp
@@ -39,6 +39,11 @@ Bazaar::PurchaseQuantityValidation Bazaar::ValidatePurchaseQuantity(
 	return {true, quantity};
 }
 
+bool Bazaar::ValidateBarterSellQuantity(uint32 requested_quantity, uint32 listed_quantity)
+{
+	return requested_quantity > 0 && requested_quantity <= listed_quantity;
+}
+
 bool Bazaar::ValidatePurchasePrice(uint32 requested_price, uint32 listed_price)
 {
 	return listed_price > 0 && requested_price == listed_price;

--- a/common/bazaar.h
+++ b/common/bazaar.h
@@ -18,6 +18,8 @@ public:
 		int16 listed_charges
 	);
 
+	static bool ValidateBarterSellQuantity(uint32 requested_quantity, uint32 listed_quantity);
+
 	static bool ValidatePurchasePrice(uint32 requested_price, uint32 listed_price);
 
 	static void RecordAuditTrail(

--- a/common/repositories/trader_repository.h
+++ b/common/repositories/trader_repository.h
@@ -309,6 +309,48 @@ public:
 		return UpdateOne(db, e);
 	}
 
+	static bool StartActiveTransaction(Database &db, uint64 id, const std::string &item_unique_id)
+	{
+		if (!id || item_unique_id.empty()) {
+			return false;
+		}
+
+		auto results = db.QueryDatabase(fmt::format(
+			"UPDATE {} SET `active_transaction` = 1, `listing_date` = FROM_UNIXTIME({}) "
+			"WHERE `id` = {} AND `item_unique_id` = '{}' AND `active_transaction` = 0",
+			TableName(),
+			time(nullptr),
+			id,
+			Strings::Escape(item_unique_id)
+		));
+
+		return results.Success() && results.RowsAffected() == 1;
+	}
+
+	static std::string GetActiveTransactionWhereFilter(uint64 id, const std::string &item_unique_id)
+	{
+		return fmt::format(
+			"`id` = {} AND `item_unique_id` = '{}' AND `active_transaction` = 1",
+			id,
+			Strings::Escape(item_unique_id)
+		);
+	}
+
+	static Trader GetActiveTransaction(Database &db, uint64 id, const std::string &item_unique_id)
+	{
+		Trader e{};
+		const auto trader_item = GetWhere(
+			db,
+			fmt::format("{} LIMIT 1", GetActiveTransactionWhereFilter(id, item_unique_id))
+		);
+
+		if (trader_item.empty()) {
+			return e;
+		}
+
+		return trader_item.at(0);
+	}
+
 	static int DeleteMany(Database &db, const std::vector<Trader> &entries)
 	{
 		std::vector<std::string> delete_ids;

--- a/common/repositories/trader_repository.h
+++ b/common/repositories/trader_repository.h
@@ -14,6 +14,9 @@
 class TraderRepository : public BaseTraderRepository {
 public:
 	static constexpr uint32 TRADER_CONVERT_ID = 4000000000;
+	static constexpr uint8 ACTIVE_TRANSACTION_NONE = 0;
+	static constexpr uint8 ACTIVE_TRANSACTION_PENDING = 1;
+	static constexpr uint8 ACTIVE_TRANSACTION_PROCESSING = 2;
 
 	struct DistinctTraders_Struct {
 		uint32      trader_id;
@@ -303,7 +306,7 @@ public:
 			return 0;
 		}
 
-		e.active_transaction = status == true ? 1 : 0;
+		e.active_transaction = status == true ? ACTIVE_TRANSACTION_PENDING : ACTIVE_TRANSACTION_NONE;
 		e.listing_date       = time(nullptr);
 
 		return UpdateOne(db, e);
@@ -316,12 +319,33 @@ public:
 		}
 
 		auto results = db.QueryDatabase(fmt::format(
-			"UPDATE {} SET `active_transaction` = 1, `listing_date` = FROM_UNIXTIME({}) "
-			"WHERE `id` = {} AND `item_unique_id` = '{}' AND `active_transaction` = 0",
+			"UPDATE {} SET `active_transaction` = {}, `listing_date` = FROM_UNIXTIME({}) "
+			"WHERE `id` = {} AND `item_unique_id` = '{}' AND `active_transaction` = {}",
 			TableName(),
+			ACTIVE_TRANSACTION_PENDING,
 			time(nullptr),
 			id,
-			Strings::Escape(item_unique_id)
+			Strings::Escape(item_unique_id),
+			ACTIVE_TRANSACTION_NONE
+		));
+
+		return results.Success() && results.RowsAffected() == 1;
+	}
+
+	static bool StartActiveTransactionProcessing(Database &db, uint64 id, const std::string &item_unique_id)
+	{
+		if (!id || item_unique_id.empty()) {
+			return false;
+		}
+
+		auto results = db.QueryDatabase(fmt::format(
+			"UPDATE {} SET `active_transaction` = {} "
+			"WHERE `id` = {} AND `item_unique_id` = '{}' AND `active_transaction` = {}",
+			TableName(),
+			ACTIVE_TRANSACTION_PROCESSING,
+			id,
+			Strings::Escape(item_unique_id),
+			ACTIVE_TRANSACTION_PENDING
 		));
 
 		return results.Success() && results.RowsAffected() == 1;
@@ -330,9 +354,10 @@ public:
 	static std::string GetActiveTransactionWhereFilter(uint64 id, const std::string &item_unique_id)
 	{
 		return fmt::format(
-			"`id` = {} AND `item_unique_id` = '{}' AND `active_transaction` = 1",
+			"`id` = {} AND `item_unique_id` = '{}' AND `active_transaction` <> {}",
 			id,
-			Strings::Escape(item_unique_id)
+			Strings::Escape(item_unique_id),
+			ACTIVE_TRANSACTION_NONE
 		);
 	}
 

--- a/common/repositories/trader_repository.h
+++ b/common/repositories/trader_repository.h
@@ -351,31 +351,6 @@ public:
 		return results.Success() && results.RowsAffected() == 1;
 	}
 
-	static bool CompleteActiveTransaction(Database &db, uint64 id, const std::string &item_unique_id)
-	{
-		if (!id || item_unique_id.empty()) {
-			return false;
-		}
-
-		auto results = db.QueryDatabase(BuildCompleteActiveTransactionQuery(id, item_unique_id, time(nullptr) + 1));
-
-		return results.Success() && results.RowsAffected() == 1;
-	}
-
-	static std::string BuildCompleteActiveTransactionQuery(uint64 id, const std::string &item_unique_id, time_t listing_date)
-	{
-		return fmt::format(
-			"UPDATE {} SET `active_transaction` = {}, `listing_date` = FROM_UNIXTIME({}) "
-			"WHERE `id` = {} AND `item_unique_id` = '{}' AND `active_transaction` <> {}",
-			TableName(),
-			ACTIVE_TRANSACTION_NONE,
-			listing_date,
-			id,
-			Strings::Escape(item_unique_id),
-			ACTIVE_TRANSACTION_NONE
-		);
-	}
-
 	static std::string GetActiveTransactionWhereFilter(uint64 id, const std::string &item_unique_id)
 	{
 		return fmt::format(

--- a/common/repositories/trader_repository.h
+++ b/common/repositories/trader_repository.h
@@ -351,6 +351,31 @@ public:
 		return results.Success() && results.RowsAffected() == 1;
 	}
 
+	static bool CompleteActiveTransaction(Database &db, uint64 id, const std::string &item_unique_id)
+	{
+		if (!id || item_unique_id.empty()) {
+			return false;
+		}
+
+		auto results = db.QueryDatabase(BuildCompleteActiveTransactionQuery(id, item_unique_id, time(nullptr) + 1));
+
+		return results.Success() && results.RowsAffected() == 1;
+	}
+
+	static std::string BuildCompleteActiveTransactionQuery(uint64 id, const std::string &item_unique_id, time_t listing_date)
+	{
+		return fmt::format(
+			"UPDATE {} SET `active_transaction` = {}, `listing_date` = FROM_UNIXTIME({}) "
+			"WHERE `id` = {} AND `item_unique_id` = '{}' AND `active_transaction` <> {}",
+			TableName(),
+			ACTIVE_TRANSACTION_NONE,
+			listing_date,
+			id,
+			Strings::Escape(item_unique_id),
+			ACTIVE_TRANSACTION_NONE
+		);
+	}
+
 	static std::string GetActiveTransactionWhereFilter(uint64 id, const std::string &item_unique_id)
 	{
 		return fmt::format(

--- a/tests/bazaar_test.h
+++ b/tests/bazaar_test.h
@@ -31,6 +31,9 @@ public:
 		TEST_ADD(BazaarTest::ClampsStackableQuantityToListedCharges);
 		TEST_ADD(BazaarTest::AcceptsPositiveNonStackableQuantity);
 		TEST_ADD(BazaarTest::RejectsNonStackableQuantityAboveOne);
+		TEST_ADD(BazaarTest::RejectsZeroBarterSellQuantity);
+		TEST_ADD(BazaarTest::RejectsBarterSellQuantityAboveBuyLineQuantity);
+		TEST_ADD(BazaarTest::AcceptsBarterSellQuantityWithinBuyLineQuantity);
 		TEST_ADD(BazaarTest::RejectsZeroListedPrice);
 		TEST_ADD(BazaarTest::RejectsMismatchedPrice);
 		TEST_ADD(BazaarTest::AcceptsMatchingListedPrice);
@@ -89,6 +92,21 @@ private:
 
 		TEST_ASSERT(!result.is_valid);
 		TEST_ASSERT(result.quantity == 0);
+	}
+
+	void RejectsZeroBarterSellQuantity()
+	{
+		TEST_ASSERT(!Bazaar::ValidateBarterSellQuantity(0, 20));
+	}
+
+	void RejectsBarterSellQuantityAboveBuyLineQuantity()
+	{
+		TEST_ASSERT(!Bazaar::ValidateBarterSellQuantity(21, 20));
+	}
+
+	void AcceptsBarterSellQuantityWithinBuyLineQuantity()
+	{
+		TEST_ASSERT(Bazaar::ValidateBarterSellQuantity(20, 20));
 	}
 
 	void RejectsZeroListedPrice()

--- a/tests/trader_repository_test.h
+++ b/tests/trader_repository_test.h
@@ -28,7 +28,6 @@ public:
 		TEST_ADD(TraderRepositoryTest::BuildBazaarTraderDetailsQueryIncludesItemFiltersAndLimit);
 		TEST_ADD(TraderRepositoryTest::BuildBazaarTraderDetailsQueryOmitsLimitWhenUnlimited);
 		TEST_ADD(TraderRepositoryTest::BuildsActiveTransactionFilter);
-		TEST_ADD(TraderRepositoryTest::BuildsCompleteActiveTransactionQuery);
 	}
 
 	~TraderRepositoryTest()
@@ -74,12 +73,5 @@ private:
 		auto filter = TraderRepository::GetActiveTransactionWhereFilter(123, "Unique'Item");
 
 		TEST_ASSERT(filter == "`id` = 123 AND `item_unique_id` = 'Unique\\'Item' AND `active_transaction` <> 0");
-	}
-
-	void BuildsCompleteActiveTransactionQuery()
-	{
-		auto query = TraderRepository::BuildCompleteActiveTransactionQuery(123, "Unique'Item", 101);
-
-		TEST_ASSERT(query == "UPDATE trader SET `active_transaction` = 0, `listing_date` = FROM_UNIXTIME(101) WHERE `id` = 123 AND `item_unique_id` = 'Unique\\'Item' AND `active_transaction` <> 0");
 	}
 };

--- a/tests/trader_repository_test.h
+++ b/tests/trader_repository_test.h
@@ -72,6 +72,6 @@ private:
 	{
 		auto filter = TraderRepository::GetActiveTransactionWhereFilter(123, "Unique'Item");
 
-		TEST_ASSERT(filter == "`id` = 123 AND `item_unique_id` = 'Unique\\'Item' AND `active_transaction` = 1");
+		TEST_ASSERT(filter == "`id` = 123 AND `item_unique_id` = 'Unique\\'Item' AND `active_transaction` <> 0");
 	}
 };

--- a/tests/trader_repository_test.h
+++ b/tests/trader_repository_test.h
@@ -27,6 +27,7 @@ public:
 	{
 		TEST_ADD(TraderRepositoryTest::BuildBazaarTraderDetailsQueryIncludesItemFiltersAndLimit);
 		TEST_ADD(TraderRepositoryTest::BuildBazaarTraderDetailsQueryOmitsLimitWhenUnlimited);
+		TEST_ADD(TraderRepositoryTest::BuildsActiveTransactionFilter);
 	}
 
 	~TraderRepositoryTest()
@@ -65,5 +66,12 @@ private:
 		TEST_ASSERT(query.find("INNER JOIN items ON trader.item_id = items.id") != std::string::npos);
 		TEST_ASSERT(query.find("items.`name` LIKE '%%'") != std::string::npos);
 		TEST_ASSERT(query.find(" LIMIT ") == std::string::npos);
+	}
+
+	void BuildsActiveTransactionFilter()
+	{
+		auto filter = TraderRepository::GetActiveTransactionWhereFilter(123, "Unique'Item");
+
+		TEST_ASSERT(filter == "`id` = 123 AND `item_unique_id` = 'Unique\\'Item' AND `active_transaction` = 1");
 	}
 };

--- a/tests/trader_repository_test.h
+++ b/tests/trader_repository_test.h
@@ -28,6 +28,7 @@ public:
 		TEST_ADD(TraderRepositoryTest::BuildBazaarTraderDetailsQueryIncludesItemFiltersAndLimit);
 		TEST_ADD(TraderRepositoryTest::BuildBazaarTraderDetailsQueryOmitsLimitWhenUnlimited);
 		TEST_ADD(TraderRepositoryTest::BuildsActiveTransactionFilter);
+		TEST_ADD(TraderRepositoryTest::BuildsCompleteActiveTransactionQuery);
 	}
 
 	~TraderRepositoryTest()
@@ -73,5 +74,12 @@ private:
 		auto filter = TraderRepository::GetActiveTransactionWhereFilter(123, "Unique'Item");
 
 		TEST_ASSERT(filter == "`id` = 123 AND `item_unique_id` = 'Unique\\'Item' AND `active_transaction` <> 0");
+	}
+
+	void BuildsCompleteActiveTransactionQuery()
+	{
+		auto query = TraderRepository::BuildCompleteActiveTransactionQuery(123, "Unique'Item", 101);
+
+		TEST_ASSERT(query == "UPDATE trader SET `active_transaction` = 0, `listing_date` = FROM_UNIXTIME(101) WHERE `id` = 123 AND `item_unique_id` = 'Unique\\'Item' AND `active_transaction` <> 0");
 	}
 };

--- a/zone/client.h
+++ b/zone/client.h
@@ -2153,7 +2153,7 @@ private:
 	bool ingame;
 	uint32 mercid; // current merc
 	uint8 mercSlot; // selected merc slot
-	time_t                                                         m_trader_transaction_date;
+	time_t                                                         m_trader_transaction_date{};
 	uint32                                                         m_trader_count{};
 	std::map<int16, std::tuple<uint32, int32, std::string>>        m_trader_merchant_list{};  // itemid, qty, item_unique_id
 	uint32                                                         m_buyer_id;

--- a/zone/client.h
+++ b/zone/client.h
@@ -2153,7 +2153,7 @@ private:
 	bool ingame;
 	uint32 mercid; // current merc
 	uint8 mercSlot; // selected merc slot
-	time_t                                                         m_trader_transaction_date{};
+	time_t                                                         m_trader_transaction_date;
 	uint32                                                         m_trader_count{};
 	std::map<int16, std::tuple<uint32, int32, std::string>>        m_trader_merchant_list{};  // itemid, qty, item_unique_id
 	uint32                                                         m_buyer_id;

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -1937,6 +1937,24 @@ void Client::SellToBuyer(const EQApplicationPacket *app)
 
 		sell_line.seller_name = GetCleanName();
 
+		if (!Bazaar::ValidateBarterSellQuantity(sell_line.seller_quantity, sell_line.item_quantity)) {
+			LogTrading(
+				"Rejecting buyer sale with invalid quantity [{}] for buy line quantity [{}] item [{}] seller [{}] buyer [{}]",
+				sell_line.seller_quantity,
+				sell_line.item_quantity,
+				sell_line.item_name,
+				GetCleanName(),
+				sell_line.buyer_name
+			);
+			SendBarterBuyerClientMessage(
+				sell_line,
+				Barter_SellerTransactionComplete,
+				Barter_Failure,
+				Barter_Failure
+			);
+			return;
+		}
+
 		switch (sell_line.purchase_method) {
 			case BarterInBazaar:
 			case BarterByVendor: {

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -2975,7 +2975,16 @@ void Client::BuyTraderItemFromBazaarWindow(const EQApplicationPacket *app)
 		return;
 	}
 
-	TraderRepository::UpdateActiveTransaction(database, trader_item.id, true);
+	if (!TraderRepository::StartActiveTransaction(database, trader_item.id, in->item_unique_id)) {
+		LogTrading(
+			"Rejecting bazaar parcel purchase for item unique_id [{}] because the listing is already in an active transaction",
+			in->item_unique_id
+		);
+		in->method     = BazaarByParcel;
+		in->sub_action = TransactionInProgress;
+		TradeRequestFailed(app);
+		return;
+	}
 
 	int16 charges   = 1;
 	if (trader_item.item_charges > 0 || item->Stackable || item->MaxCharges > 0) {

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -3826,6 +3826,21 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 						return;
 					}
 
+					auto active_transaction = TraderRepository::GetActiveTransaction(
+						database,
+						in->id,
+						in->trader_buy_struct.item_unique_id
+					);
+					if (!active_transaction.id) {
+						LogTrading(
+							"Ignoring stale bazaar parcel purchase message for trader_id [{}] item unique_id [{}] buyer [{}]",
+							in->trader_buy_struct.trader_id,
+							in->trader_buy_struct.item_unique_id,
+							in->buyer_id
+						);
+						break;
+					}
+
 					auto item = trader_pc->FindTraderItemByUniqueID(in->trader_buy_struct.item_unique_id);
 					if (!item) {
 						in->transaction_status = BazaarPurchaseTraderFailed;

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -92,7 +92,7 @@ bool HasActiveTraderTransaction(uint32 character_id)
 
 	const auto active_entries = TraderRepository::GetWhere(
 		database,
-		fmt::format("`character_id` = {} AND `active_transaction` = 1 LIMIT 1", character_id)
+		fmt::format("`character_id` = {} AND `active_transaction` <> 0 LIMIT 1", character_id)
 	);
 
 	return !active_entries.empty();
@@ -3826,14 +3826,13 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 						return;
 					}
 
-					auto active_transaction = TraderRepository::GetActiveTransaction(
+					if (!TraderRepository::StartActiveTransactionProcessing(
 						database,
 						in->id,
 						in->trader_buy_struct.item_unique_id
-					);
-					if (!active_transaction.id) {
+					)) {
 						LogTrading(
-							"Ignoring stale bazaar parcel purchase message for trader_id [{}] item unique_id [{}] buyer [{}]",
+							"Ignoring duplicate or stale bazaar parcel purchase message for trader_id [{}] item unique_id [{}] buyer [{}]",
 							in->trader_buy_struct.trader_id,
 							in->trader_buy_struct.item_unique_id,
 							in->buyer_id

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -4094,7 +4094,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 
 					memcpy(data, &in->trader_buy_struct, sizeof(TraderBuy_Struct));
 					buyer->ReturnTraderReq(&outapp, in->item_quantity, in->trader_buy_struct.item_id);
-					TraderRepository::UpdateActiveTransaction(database, in->id, false);
+					TraderRepository::CompleteActiveTransaction(database, in->id, in->trader_buy_struct.item_unique_id);
 					LogTradingDetail("Step 8:Bazaar Purchase. Purchase complete. Sending update packet to buyer.");
 
 					break;

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -4094,7 +4094,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 
 					memcpy(data, &in->trader_buy_struct, sizeof(TraderBuy_Struct));
 					buyer->ReturnTraderReq(&outapp, in->item_quantity, in->trader_buy_struct.item_id);
-					TraderRepository::CompleteActiveTransaction(database, in->id, in->trader_buy_struct.item_unique_id);
+					TraderRepository::UpdateActiveTransaction(database, in->id, false);
 					LogTradingDetail("Step 8:Bazaar Purchase. Purchase complete. Sending update packet to buyer.");
 
 					break;

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -3904,6 +3904,19 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 
 					trader_pc->AddMoneyToPP(total_cost,	true);
 
+					if (RuleB(Bazaar, AuditTrail)) {
+						Bazaar::RecordAuditTrail(
+							database,
+							trader_pc->GetCleanName(),
+							in->trader_buy_struct.buyer_name,
+							item->GetID(),
+							in->trader_buy_struct.item_name,
+							in->item_quantity,
+							total_cost,
+							0
+						);
+					}
+
 					//Update the trader to indicate the sale has completed
 					EQApplicationPacket outapp(OP_Trader, sizeof(TraderBuy_Struct));
 					auto                data = reinterpret_cast<TraderBuy_Struct *>(outapp.pBuffer);
@@ -4044,19 +4057,6 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 					parcel_out.id             = 0;
 
 					CharacterParcelsRepository::InsertOne(database, parcel_out);
-
-					if (RuleB(Bazaar, AuditTrail)) {
-						Bazaar::RecordAuditTrail(
-							database,
-							in->trader_buy_struct.seller_name,
-							buyer->GetCleanName(),
-							in->trader_buy_struct.item_id,
-							in->trader_buy_struct.item_name,
-							in->item_quantity,
-							total_cost,
-							0
-						);
-					}
 
 					if (PlayerEventLogs::Instance()->IsEventEnabled(PlayerEvent::PARCEL_SEND)) {
 						PlayerEvent::ParcelSend e{};

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -3960,7 +3960,6 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 					}
 
 					in->transaction_status = BazaarPurchaseSuccess;
-					TraderRepository::UpdateActiveTransaction(database, in->id, false);
 					worldserver.SendPacket(pack);
 
 					LogTradingDetail("Step 6:Bazaar Purchase. Purchase checks complete for trader.  Send Success to buyer via world.");
@@ -3976,6 +3975,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 							zone->GetZoneID(),
 							zone->GetInstanceID()
 						);
+						TraderRepository::UpdateActiveTransaction(database, in->id, false);
 						return;
 					}
 
@@ -4094,6 +4094,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 
 					memcpy(data, &in->trader_buy_struct, sizeof(TraderBuy_Struct));
 					buyer->ReturnTraderReq(&outapp, in->item_quantity, in->trader_buy_struct.item_id);
+					TraderRepository::UpdateActiveTransaction(database, in->id, false);
 					LogTradingDetail("Step 8:Bazaar Purchase. Purchase complete. Sending update packet to buyer.");
 
 					break;

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -3904,19 +3904,6 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 
 					trader_pc->AddMoneyToPP(total_cost,	true);
 
-					if (RuleB(Bazaar, AuditTrail)) {
-						Bazaar::RecordAuditTrail(
-							database,
-							trader_pc->GetCleanName(),
-							in->trader_buy_struct.buyer_name,
-							item->GetID(),
-							in->trader_buy_struct.item_name,
-							in->item_quantity,
-							total_cost,
-							0
-						);
-					}
-
 					//Update the trader to indicate the sale has completed
 					EQApplicationPacket outapp(OP_Trader, sizeof(TraderBuy_Struct));
 					auto                data = reinterpret_cast<TraderBuy_Struct *>(outapp.pBuffer);
@@ -4057,6 +4044,19 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 					parcel_out.id             = 0;
 
 					CharacterParcelsRepository::InsertOne(database, parcel_out);
+
+					if (RuleB(Bazaar, AuditTrail)) {
+						Bazaar::RecordAuditTrail(
+							database,
+							in->trader_buy_struct.seller_name,
+							buyer->GetCleanName(),
+							in->trader_buy_struct.item_id,
+							in->trader_buy_struct.item_name,
+							in->item_quantity,
+							total_cost,
+							0
+						);
+					}
 
 					if (PlayerEventLogs::Instance()->IsEventEnabled(PlayerEvent::PARCEL_SEND)) {
 						PlayerEvent::ParcelSend e{};


### PR DESCRIPTION
## What changed

- Reject buyer sale requests when the submitted seller quantity is zero or greater than the buy line quantity.
- Make bazaar parcel purchases claim trader listings atomically before the buyer sends the seller-side world message.
- Add a seller-side pending-to-processing transition so duplicate seller-side parcel messages are ignored before side effects.
- Keep successful parcel transactions active until the buyer-side parcel completion leg runs, then clear the active transaction normally.
- Removed the redundant buyer-side parcel audit write that was added during this fix; the existing seller-side audit write remains the single audit source for trader -> parcel purchases.
- Treat both pending and processing trader rows as active for offline reclaim checks.

## Why

A sell request with quantity 0 could pass through the buyer sale flow and write a `trader_audit` row with quantity 0 and total cost 0.

For bazaar parcel purchases, duplicate seller-side messages should not be allowed to run inventory, money, event, or audit side effects more than once. The transaction state now moves from idle to pending to processing with conditional updates, so replayed seller messages are rejected before those side effects.

The extra buyer-side parcel audit write added during this investigation was redundant; tester validation showed commenting it out restored one audit row per trader -> parcel purchase. This PR keeps the original seller-side audit write as the single audit source.

## Impact

Invalid zero-quantity buyer sale attempts now fail before buyer/seller checks, inventory movement, money transfer, offline transaction recording, player event logging, or audit insertion.

Bazaar parcel purchases retain one audit row per transaction while duplicate/stale seller-side parcel messages are rejected before another transaction cycle can run.

## Validation

- `cmake --build "build/{presetName}" --config Debug --target zone`
- `cmake --build "build/{presetName}" --config Debug --target tests`
- `.\build\{presetName}\bin\Debug\tests.exe` passed 138/138 tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches bazaar/barter money, inventory, and trader DB locking across zone and worldserver; incorrect transaction state could block listings or allow duplicate side effects.
> 
> **Overview**
> Fixes invalid buyer-side barter sales and race/duplicate handling for bazaar parcel purchases.
> 
> **Barter sell validation:** Adds `Bazaar::ValidateBarterSellQuantity` and rejects `SellToBuyer` requests when seller quantity is zero or exceeds the buy line quantity, so those paths never reach inventory, money, or audit writes.
> 
> **Parcel purchase locking:** Replaces unconditional `UpdateActiveTransaction(..., true)` on the buyer with `StartActiveTransaction`, a conditional DB update from idle → **pending** that fails if the listing is already locked (`TransactionInProgress`). On the seller/world leg, `StartActiveTransactionProcessing` moves **pending → processing** so replayed seller messages skip side effects. Active flags are cleared on failure paths and after buyer parcel completion, not immediately on seller success. Offline reclaim treats any non-zero `active_transaction` (pending or processing) as busy.
> 
> **Repository:** Named states (`NONE` / `PENDING` / `PROCESSING`) plus helpers for atomic starts and active-row lookup; unit tests cover barter quantity rules and the active-transaction SQL filter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d1b46ada1e154991f76f037f1dd20c9f574954d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->