### PR TITLE
Fix Nexus crash report r358fu43

### DIFF
--- a/zone/embperl.cpp
+++ b/zone/embperl.cpp
@@ -81,9 +81,10 @@ void Embperl::DoInit()
 	//a little routine we use a lot.
 	eval_pv("sub my_eval { eval $_[0];}", TRUE);    //dies on error
 	
-	//ruin the perl exit and command:
+	//ruin the perl exit, sleep, and filesystem ownership commands:
 	eval_pv("sub my_exit {}", TRUE);
 	eval_pv("sub my_sleep {}", TRUE);
+	eval_pv("sub my_chown { return 0; }", TRUE);
 	if (gv_stashpv("CORE::GLOBAL", FALSE)) {
 		GV* exitgp = gv_fetchpv("CORE::GLOBAL::exit", TRUE, SVt_PVCV);
 		GvCV_set(exitgp, perl_get_cv("my_exit", TRUE));    //dies on error
@@ -91,6 +92,9 @@ void Embperl::DoInit()
 		GV* sleepgp = gv_fetchpv("CORE::GLOBAL::sleep", TRUE, SVt_PVCV);
 		GvCV_set(sleepgp, perl_get_cv("my_sleep", TRUE));    //dies on error
 		GvIMPORTED_CV_on(sleepgp);
+		GV* chowngp = gv_fetchpv("CORE::GLOBAL::chown", TRUE, SVt_PVCV);
+		GvCV_set(chowngp, perl_get_cv("my_chown", TRUE));    //dies on error
+		GvIMPORTED_CV_on(chowngp);
 	}
 	
 	//declare our file eval routine.


### PR DESCRIPTION
## Summary
- Automated Nexus Codex runner PR for a Webhook Inbox crash report.
- Nexus job: cmqop305z004njhdj1zfb5ero
- Nexus message: cmqlil0x500pbodkkr358fu43
- Execution mode: cloud-hybrid
- Codex Cloud task: https://chatgpt.com/codex/tasks/task_e_6a38b5181e308322992e1bea0ded9ca9
## Runner Safety
- Work was performed on an isolated runner branch.
- The base branch was not mutated directly.
- If this PR is rejected, closing the PR and deleting the branch removes the persistent code change.
## Codex Notes
Codex Cloud task completed and the VPS runner applied its final diff locally.

Task: https://chatgpt.com/codex/tasks/task_e_6a38b5181e308322992e1bea0ded9ca9
Environment: 68486d0ff1848191a9c267976d038d13
Final status: ready

## Cloud Status
[READY] Investigate and fix Nexus crash
Valorith/Server  •  3m ago
+5/-1 • 1 file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Neutralized the `chown` command in embedded Perl environments, consistent with existing restrictions on similar commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->