### PR TITLE
[Offline Trader] Handle RoF2 trader reconcile packets

### DIFF
--- a/common/eq_packet_structs.h
+++ b/common/eq_packet_structs.h
@@ -6462,6 +6462,7 @@ enum BazaarTraderBarterActions {
 	CustomerBrowsing             = 13,
 	BazaarInspect                = 18,
 	ItemMove                     = 19,
+	ReconcileItems               = 20,
 	TraderAck2                   = 22,
 	AddTraderToBazaarWindow      = 24,
 	RemoveTraderFromBazaarWindow = 25,

--- a/common/patches/rof2.cpp
+++ b/common/patches/rof2.cpp
@@ -6155,6 +6155,12 @@ namespace RoF2
 
 	DECODE(OP_Trader)
 	{
+		if (__packet->size < sizeof(uint32)) {
+			LogWarning("(RoF2) Short OP_Trader size [{}]", __packet->size);
+			__packet->SetOpcode(OP_Unknown);
+			return;
+		}
+
 		auto action = *(uint32 *)__packet->pBuffer;
 
 		LogTrading(
@@ -6213,6 +6219,10 @@ namespace RoF2
 				LogTrading("(RoF2) ListTraderItems action <green>[{}]", action);
 				break;
 			}
+			case structs::RoF2BazaarTraderBuyerActions::ReconcileItems: {
+				LogTrading("(RoF2) ReconcileItems action <green>[{}] size [{}]", action, __packet->size);
+				break;
+			}
 			case structs::RoF2BazaarTraderBuyerActions::PriceUpdate: {
 				DECODE_LENGTH_EXACT(structs::TraderPriceUpdate_Struct);
 				SETUP_DIRECT_DECODE(TraderPriceUpdate_Struct, structs::TraderPriceUpdate_Struct);
@@ -6259,6 +6269,12 @@ namespace RoF2
 
 	DECODE(OP_TraderShop)
 	{
+		if (__packet->size < sizeof(uint32)) {
+			LogWarning("(RoF2) Short OP_TraderShop size [{}]", __packet->size);
+			__packet->SetOpcode(OP_Unknown);
+			return;
+		}
+
 		uint32 action = *(uint32 *)__packet->pBuffer;
 
 		LogTrading(
@@ -6310,6 +6326,19 @@ namespace RoF2
 						   eq->unknown_008
 				);
 				FINISH_DIRECT_DECODE();
+				break;
+			}
+			case structs::RoF2BazaarTraderBuyerActions::EndTransaction: {
+				auto eq_buffer = __packet->pBuffer;
+				__packet->size = sizeof(TraderClick_Struct);
+				__packet->pBuffer = new unsigned char[__packet->size] {};
+
+				auto emu = (TraderClick_Struct *) __packet->pBuffer;
+				emu->Code = EndTransaction;
+
+				safe_delete_array(eq_buffer);
+
+				LogTrading("(RoF2) EndTransaction action <green>[{}]", action);
 				break;
 			}
 			case structs::RoF2BazaarTraderBuyerActions::BazaarInspect: {

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -15469,6 +15469,17 @@ void Client::Handle_OP_Trader(const EQApplicationPacket *app)
 	//
 	// SoF sends 1 or more unhandled OP_Trader packets of size 96 when a trade has completed.
 	// I don't know what they are for (yet), but it doesn't seem to matter that we ignore them.
+	if (app->size < sizeof(uint32)) {
+		LogWarning(
+			"Short OP_Trader packet for client [{}] account [{}] character [{}] size [{}]",
+			GetCleanName(),
+			AccountID(),
+			CharacterID(),
+			app->size
+		);
+		return;
+	}
+
 	auto action = *(uint32 *)app->pBuffer;
 
 	LogTrading(
@@ -15519,6 +15530,10 @@ void Client::Handle_OP_Trader(const EQApplicationPacket *app)
 		case ListTraderItems: {
 			TraderShowItems();
 			LogTrading("Show Trader Items");
+			break;
+		}
+		case ReconcileItems: {
+			LogTrading("Reconcile Trader Items");
 			break;
 		}
 		default: {


### PR DESCRIPTION
## Summary

This fixes RoF2 offline trader warning spam for normal trader packets observed from live use.

- Recognize RoF2 `OP_Trader` action `20` as `ReconcileItems` and keep it as a no-op, matching Titanium/UF behavior.
- Normalize compact RoF2 `OP_TraderShop` action `4` end-transaction packets into the existing server trader-shop struct.
- Add short-packet guards before reading trader packet action fields.

## Root Cause

RoF2 already defined action `20` as `ReconcileItems`, but its decoder did not handle that action. The packet then reached zone trader handling unchanged and produced a second unhandled-action warning.

RoF2 can also send `OP_TraderShop` end-transaction as a compact 4-byte packet. The decoder warned on it, and zone code could later treat it as the larger server `TraderClick_Struct`.

## Impact

This should not change trader gameplay behavior. The reconcile packet remains ignored as before, but is now explicitly recognized. End-transaction cleanup follows the existing zone handler path with a correctly sized zeroed server struct.

## Validation

- `git diff --check HEAD~1 HEAD`
- `cmake --build .\build-codex --target zone --config RelWithDebInfo`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an additional trader/bazaar action to better handle item reconciliation.

* **Bug Fixes**
  * Improved handling of malformed trader packets to prevent unexpected processing of very short requests.
  * Added safer validation for trader and trader shop actions, helping avoid client-side issues when packets are incomplete.
  * Enhanced handling of transaction-ending trader shop actions for more reliable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->