### PR TITLE
[Logging] Reduce RoF2 trader logging noise

### DIFF
--- a/common/patches/rof2.cpp
+++ b/common/patches/rof2.cpp
@@ -6163,7 +6163,7 @@ namespace RoF2
 
 		auto action = *(uint32 *)__packet->pBuffer;
 
-		LogTrading(
+		LogTradingDetail(
 			"(RoF2) DECODE(OP_Trader) action [{}] size [{}]",
 			action,
 			__packet->size
@@ -6220,7 +6220,7 @@ namespace RoF2
 				break;
 			}
 			case structs::RoF2BazaarTraderBuyerActions::ReconcileItems: {
-				LogTrading("(RoF2) ReconcileItems action <green>[{}] size [{}]", action, __packet->size);
+				LogTradingDetail("(RoF2) ReconcileItems action <green>[{}] size [{}]", action, __packet->size);
 				break;
 			}
 			case structs::RoF2BazaarTraderBuyerActions::PriceUpdate: {
@@ -6277,7 +6277,7 @@ namespace RoF2
 
 		uint32 action = *(uint32 *)__packet->pBuffer;
 
-		LogTrading(
+		LogTradingDetail(
 			"(RoF2) DECODE(OP_TraderShop) action [{}] size [{}]",
 			action,
 			__packet->size
@@ -6338,7 +6338,7 @@ namespace RoF2
 
 				safe_delete_array(eq_buffer);
 
-				LogTrading("(RoF2) EndTransaction action <green>[{}]", action);
+				LogTradingDetail("(RoF2) EndTransaction action <green>[{}]", action);
 				break;
 			}
 			case structs::RoF2BazaarTraderBuyerActions::BazaarInspect: {

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -15483,7 +15483,7 @@ void Client::Handle_OP_Trader(const EQApplicationPacket *app)
 
 	auto action = *(uint32 *)app->pBuffer;
 
-	LogTrading(
+	LogTradingDetail(
 		"Handle_OP_Trader client [{}] account [{}] character [{}] action [{}] size [{}] trader [{}] buyer [{}] zone [{}] instance [{}]",
 		GetCleanName(),
 		AccountID(),
@@ -15534,7 +15534,7 @@ void Client::Handle_OP_Trader(const EQApplicationPacket *app)
 			break;
 		}
 		case ReconcileItems: {
-			LogTrading("Reconcile Trader Items");
+			LogTradingDetail("Reconcile Trader Items");
 			break;
 		}
 		default: {
@@ -15740,7 +15740,7 @@ void Client::Handle_OP_TradeRequestAck(const EQApplicationPacket *app)
 void Client::Handle_OP_TraderShop(const EQApplicationPacket *app)
 {
 	auto in = (TraderClick_Struct *) app->pBuffer;
-	LogTrading(
+	LogTradingDetail(
 		"Handle_OP_TraderShop client [{}] account [{}] character [{}] code [{}] trader_id [{}] unknown008 [{}] approval [{}] size [{}] trader [{}] buyer [{}] zone [{}] instance [{}]",
 		GetCleanName(),
 		AccountID(),
@@ -15755,7 +15755,7 @@ void Client::Handle_OP_TraderShop(const EQApplicationPacket *app)
 		GetZoneID(),
 		GetInstanceID()
 	);
-	LogTrading("Handle_OP_TraderShop: TraderClick_Struct TraderID [{}], Code [{}], Unknown008 [{}], Approval [{}]",
+	LogTradingDetail("Handle_OP_TraderShop: TraderClick_Struct TraderID [{}], Code [{}], Unknown008 [{}], Approval [{}]",
 			   in->TraderID,
 			   in->Code,
 			   in->Unknown008,
@@ -15764,7 +15764,7 @@ void Client::Handle_OP_TraderShop(const EQApplicationPacket *app)
 
 	switch (in->Code) {
 		case ClickTrader: {
-			LogTrading("Handle_OP_TraderShop case ClickTrader [{}]", in->Code);
+			LogTradingDetail("Handle_OP_TraderShop case ClickTrader [{}]", in->Code);
 			auto outapp        = std::make_unique<EQApplicationPacket>(
 				OP_TraderShop,
 				static_cast<uint32>(sizeof(TraderClick_Struct))
@@ -15774,7 +15774,7 @@ void Client::Handle_OP_TraderShop(const EQApplicationPacket *app)
 
 			if (trader) {
 				data->Approval = trader->WithCustomer(GetID());
-				LogTrading("Client::Handle_OP_TraderShop: Shop Request ([{}]) to ([{}]) with Approval: [{}]",
+				LogTradingDetail("Client::Handle_OP_TraderShop: Shop Request ([{}]) to ([{}]) with Approval: [{}]",
 						   GetCleanName(),
 						   trader->GetCleanName(),
 						   data->Approval
@@ -15800,7 +15800,7 @@ void Client::Handle_OP_TraderShop(const EQApplicationPacket *app)
 				BulkSendTraderInventory(trader->CharacterID());
 				trader->Trader_CustomerBrowsing(this);
 				SetTraderID(in->TraderID);
-				LogTrading("Client::Handle_OP_TraderShop: Trader Inventory Sent to [{}] from [{}]",
+				LogTradingDetail("Client::Handle_OP_TraderShop: Trader Inventory Sent to [{}] from [{}]",
 						   GetID(),
 						   in->TraderID
 				);
@@ -15817,7 +15817,7 @@ void Client::Handle_OP_TraderShop(const EQApplicationPacket *app)
 			SetTraderID(0);
 			if (c) {
 				c->WithCustomer(0);
-				LogTrading("End Transaction - Code [{}]", in->Code);
+				LogTradingDetail("End Transaction - Code [{}]", in->Code);
 			}
 			else {
 				LogTrading("Null Client Pointer for Trader - Code [{}]", in->Code);


### PR DESCRIPTION
## Summary

- Move normal RoF2 trader packet trace logs from general Trading logging to Trading Detail.
- Keep malformed short packets and unhandled trader actions visible as warnings.
- Preserve bazaar/trader behavior; this is a logging-level-only fix.

## Root Cause

The RoF2 trader reconcile and trader-shop handling path logs normal client chatter at the general Trading level. When clients repeatedly send reconcile or transaction packets, the zone log can emit several lines per packet even though nothing abnormal happened.

## Impact

Servers with Trading logging enabled should no longer get flooded by normal RoF2 bazaar/offline trader polling, while detailed packet traces remain available by enabling Trading Detail.

## Validation

- `git diff --check`
- `cmake --build build-codex --target zone --config RelWithDebInfo -j 8`

The build completed successfully. It emitted existing MSVC conversion warnings in unrelated files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detailed logging for trader and trader-shop interactions, making it easier to trace actions like item reconciliation, shop requests, inventory updates, and transaction ավարտs.
  * Expanded the level of detail shown in packet handling logs without changing gameplay or decoding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->